### PR TITLE
Add admin-gated user and group management MVP

### DIFF
--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -5,6 +5,8 @@ import fileRoutes from './files';
 import conversationRoutes from './conversations';
 import settingsRoutes from './settings';
 import knowledgeRoutes from './knowledge';
+import usersRoutes from './users';
+import { requireSystemAdmin } from '../middleware/adminOnly';
 import { DatabaseService } from '../services/databaseService';
 import { WorkspaceService } from '../services/workspaceService';
 import { FileService } from '../services/fileService';
@@ -23,7 +25,8 @@ export default function(dbService: DatabaseService, userService: UserService) {
   const knowledgeService = new KnowledgeService(dbService, workspaceService);
 
   router.use('/agent', agentRoutes(workspaceService, fileService));
-  router.use('/settings', settingsRoutes());
+  router.use('/settings', requireSystemAdmin, settingsRoutes());
+  router.use('/users', requireSystemAdmin, usersRoutes(userService));
   router.use('/workspaces', workspaceRoutes(workspaceService, userService));
   router.use('/workspaces/:workspaceId/files', fileRoutes(fileService));
   router.use('/workspaces/:workspaceId/knowledge', knowledgeRoutes(knowledgeService));

--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -25,8 +25,8 @@ export default function(dbService: DatabaseService, userService: UserService) {
   const knowledgeService = new KnowledgeService(dbService, workspaceService);
 
   router.use('/agent', agentRoutes(workspaceService, fileService));
-  router.use('/settings', requireSystemAdmin, settingsRoutes());
-  router.use('/users', requireSystemAdmin, usersRoutes(userService));
+  router.use('/settings', requireSystemAdmin(userService), settingsRoutes());
+  router.use('/users', requireSystemAdmin(userService), usersRoutes(userService));
   router.use('/workspaces', workspaceRoutes(workspaceService, userService));
   router.use('/workspaces/:workspaceId/files', fileRoutes(fileService));
   router.use('/workspaces/:workspaceId/knowledge', knowledgeRoutes(knowledgeService));

--- a/backend/src/api/users.ts
+++ b/backend/src/api/users.ts
@@ -1,0 +1,119 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { UserService } from '../services/userService';
+
+const updateAdminSchema = z.object({
+  isAdmin: z.boolean(),
+});
+
+const createGroupSchema = z.object({
+  name: z.string().min(1).max(128),
+});
+
+const groupMemberSchema = z.object({
+  userId: z.string().uuid(),
+});
+
+export default function usersRoutes(userService: UserService) {
+  const router = Router();
+
+  router.get('/', async (_req, res) => {
+    try {
+      const users = await userService.listUsers();
+      res.json({ users });
+    } catch (error) {
+      console.error('Failed to list users', error);
+      res.status(500).json({ error: 'Failed to list users' });
+    }
+  });
+
+  router.put('/:userId/admin', async (req, res) => {
+    try {
+      const { isAdmin } = updateAdminSchema.parse(req.body);
+      const updated = await userService.setUserAdmin(req.params.userId, isAdmin);
+      if (!updated) {
+        return res.status(404).json({ error: 'User not found' });
+      }
+      res.json({ user: updated });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: error.issues[0]?.message || 'Invalid payload' });
+      }
+      console.error('Failed to update admin role', error);
+      res.status(500).json({ error: 'Failed to update admin role' });
+    }
+  });
+
+  router.get('/groups/list', async (_req, res) => {
+    try {
+      const groups = await userService.listGroups();
+      res.json({ groups });
+    } catch (error) {
+      console.error('Failed to list groups', error);
+      res.status(500).json({ error: 'Failed to list groups' });
+    }
+  });
+
+  router.post('/groups', async (req, res) => {
+    try {
+      const { name } = createGroupSchema.parse(req.body);
+      const group = await userService.createGroup(name);
+      res.status(201).json({ group });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: error.issues[0]?.message || 'Invalid payload' });
+      }
+      console.error('Failed to create group', error);
+      res.status(500).json({ error: 'Failed to create group' });
+    }
+  });
+
+  router.delete('/groups/:groupId', async (req, res) => {
+    try {
+      const removed = await userService.deleteGroup(req.params.groupId);
+      if (!removed) {
+        return res.status(404).json({ error: 'Group not found' });
+      }
+      res.status(204).send();
+    } catch (error) {
+      console.error('Failed to delete group', error);
+      res.status(500).json({ error: 'Failed to delete group' });
+    }
+  });
+
+  router.get('/groups/:groupId/members', async (req, res) => {
+    try {
+      const members = await userService.listGroupMembers(req.params.groupId);
+      res.json({ members });
+    } catch (error) {
+      console.error('Failed to list group members', error);
+      res.status(500).json({ error: 'Failed to list group members' });
+    }
+  });
+
+  router.post('/groups/:groupId/members', async (req, res) => {
+    try {
+      const { userId } = groupMemberSchema.parse(req.body);
+      await userService.addGroupMember(req.params.groupId, userId);
+      res.status(204).send();
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: error.issues[0]?.message || 'Invalid payload' });
+      }
+      console.error('Failed to add group member', error);
+      res.status(500).json({ error: 'Failed to add group member' });
+    }
+  });
+
+  router.delete('/groups/:groupId/members/:userId', async (req, res) => {
+    try {
+      await userService.removeGroupMember(req.params.groupId, req.params.userId);
+      res.status(204).send();
+    } catch (error) {
+      console.error('Failed to remove group member', error);
+      res.status(500).json({ error: 'Failed to remove group member' });
+    }
+  });
+
+  return router;
+}

--- a/backend/src/middleware/adminOnly.ts
+++ b/backend/src/middleware/adminOnly.ts
@@ -1,13 +1,36 @@
 import { Request, Response, NextFunction } from 'express';
+import { UserService } from '../services/userService';
 
-export function requireSystemAdmin(req: Request, res: Response, next: NextFunction) {
-  if (!req.userContext) {
-    return res.status(401).json({ error: 'Missing user context' });
-  }
+export function requireSystemAdmin(userService: UserService) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (!req.userContext) {
+        return res.status(401).json({ error: 'Missing user context' });
+      }
 
-  if (!req.userContext.isAdmin) {
-    return res.status(403).json({ error: 'Admin access required' });
-  }
+      const latestUser = await userService.getUserById(req.userContext.userId);
+      if (!latestUser) {
+        return res.status(401).json({ error: 'User not found' });
+      }
 
-  return next();
+      const refreshedContext = {
+        ...req.userContext,
+        isAdmin: latestUser.isAdmin,
+      };
+
+      req.userContext = refreshedContext;
+      res.locals.userContext = refreshedContext;
+      if (req.session?.userContext) {
+        req.session.userContext = refreshedContext;
+      }
+
+      if (!latestUser.isAdmin) {
+        return res.status(403).json({ error: 'Admin access required' });
+      }
+
+      return next();
+    } catch (error) {
+      return next(error);
+    }
+  };
 }

--- a/backend/src/middleware/adminOnly.ts
+++ b/backend/src/middleware/adminOnly.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function requireSystemAdmin(req: Request, res: Response, next: NextFunction) {
+  if (!req.userContext) {
+    return res.status(401).json({ error: 'Missing user context' });
+  }
+
+  if (!req.userContext.isAdmin) {
+    return res.status(403).json({ error: 'Admin access required' });
+  }
+
+  return next();
+}

--- a/backend/src/middleware/userContext.ts
+++ b/backend/src/middleware/userContext.ts
@@ -30,6 +30,7 @@ export function userContextMiddleware(userService: UserService) {
         externalId: userRecord.externalId,
         displayName: userRecord.displayName,
         email: userRecord.email,
+        isAdmin: userRecord.isAdmin,
       };
 
       if (req.session) {

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -7,6 +7,14 @@ export interface UserRecord {
   externalId: string;
   email?: string | null;
   displayName: string;
+  isAdmin: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GroupRecord {
+  id: string;
+  name: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -16,6 +24,15 @@ interface UserProfileInput {
   displayName?: string | null;
   email?: string | null;
 }
+
+const normalizeEmail = (email?: string | null) => email?.trim().toLowerCase() || null;
+
+const parseAdminEmails = () => new Set(
+  (process.env.ADMIN_EMAILS || '')
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean),
+);
 
 export class UserService {
   private db: Knex;
@@ -27,16 +44,19 @@ export class UserService {
   async ensureUser(profile: UserProfileInput): Promise<UserRecord> {
     const normalizedExternalId = profile.externalId.trim().toLowerCase();
     const displayName = (profile.displayName || profile.externalId).trim();
-    const email = profile.email?.trim() || null;
+    const email = normalizeEmail(profile.email);
+    const adminEmails = parseAdminEmails();
 
     const existing = await this.db<UserRecord>('users').where({ externalId: normalizedExternalId }).first();
     if (!existing) {
+      const isAdmin = !!(email && adminEmails.has(email));
       const [created] = await this.db<UserRecord>('users')
         .insert({
           id: uuidv4(),
           externalId: normalizedExternalId,
           displayName,
           email,
+          isAdmin,
         })
         .returning('*');
       return created;
@@ -48,6 +68,10 @@ export class UserService {
     }
     if (email !== existing.email) {
       updates.email = email;
+    }
+
+    if (!existing.isAdmin && email && adminEmails.has(email)) {
+      updates.isAdmin = true;
     }
 
     if (Object.keys(updates).length) {
@@ -62,5 +86,65 @@ export class UserService {
     }
 
     return existing;
+  }
+
+  async listUsers(): Promise<UserRecord[]> {
+    return this.db<UserRecord>('users')
+      .select('*')
+      .orderBy('createdAt', 'asc');
+  }
+
+  async setUserAdmin(userId: string, isAdmin: boolean): Promise<UserRecord | null> {
+    const [updated] = await this.db<UserRecord>('users')
+      .where({ id: userId })
+      .update({
+        isAdmin,
+        updatedAt: this.db.fn.now(),
+      })
+      .returning('*');
+
+    return updated || null;
+  }
+
+  async listGroups(): Promise<GroupRecord[]> {
+    return this.db<GroupRecord>('groups')
+      .select('*')
+      .orderBy('name', 'asc');
+  }
+
+  async createGroup(name: string): Promise<GroupRecord> {
+    const [group] = await this.db<GroupRecord>('groups')
+      .insert({
+        id: uuidv4(),
+        name: name.trim(),
+      })
+      .returning('*');
+    return group;
+  }
+
+  async deleteGroup(groupId: string): Promise<number> {
+    return this.db<GroupRecord>('groups').where({ id: groupId }).del();
+  }
+
+  async listGroupMembers(groupId: string): Promise<UserRecord[]> {
+    return this.db<UserRecord>('users as u')
+      .join('group_members as gm', 'u.id', 'gm.userId')
+      .where('gm.groupId', groupId)
+      .select('u.*')
+      .orderBy('u.displayName', 'asc');
+  }
+
+  async addGroupMember(groupId: string, userId: string): Promise<void> {
+    await this.db('group_members')
+      .insert({
+        groupId,
+        userId,
+      })
+      .onConflict(['groupId', 'userId'])
+      .ignore();
+  }
+
+  async removeGroupMember(groupId: string, userId: string): Promise<number> {
+    return this.db('group_members').where({ groupId, userId }).del();
   }
 }

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -94,6 +94,10 @@ export class UserService {
       .orderBy('createdAt', 'asc');
   }
 
+  async getUserById(userId: string): Promise<UserRecord | null> {
+    const user = await this.db<UserRecord>('users').where({ id: userId }).first();
+    return user || null;
+  }
   async setUserAdmin(userId: string, isAdmin: boolean): Promise<UserRecord | null> {
     const [updated] = await this.db<UserRecord>('users')
       .where({ id: userId })

--- a/backend/src/types/session.d.ts
+++ b/backend/src/types/session.d.ts
@@ -5,5 +5,6 @@ declare module 'express-session' {
   interface SessionData {
     userContext?: UserContext;
     externalId?: string;
+    isAdmin?: boolean;
   }
 }

--- a/backend/src/types/session/index.d.ts
+++ b/backend/src/types/session/index.d.ts
@@ -5,5 +5,6 @@ declare module 'express-session' {
   interface SessionData {
     userContext?: UserContext;
     externalId?: string;
+    isAdmin?: boolean;
   }
 }

--- a/backend/src/types/user.ts
+++ b/backend/src/types/user.ts
@@ -3,4 +3,5 @@ export interface UserContext {
   externalId: string;
   displayName: string;
   email?: string | null;
+  isAdmin: boolean;
 }

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,23 +1,271 @@
-import { Users2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Plus, ShieldCheck, ShieldOff, Trash2, Users2 } from 'lucide-react';
 import SettingsShell from '../components/settings/SettingsShell';
+import {
+  addGroupMember,
+  createGroup,
+  deleteGroup,
+  fetchGroupMembers,
+  fetchGroups,
+  fetchUsers,
+  removeGroupMember,
+  setUserAdmin,
+  type ManagedGroup,
+  type ManagedUser,
+} from '../services/settingsApi';
 
 const UsersPage = () => {
+  const [users, setUsers] = useState<ManagedUser[]>([]);
+  const [groups, setGroups] = useState<ManagedGroup[]>([]);
+  const [selectedGroupId, setSelectedGroupId] = useState<string>('');
+  const [groupMembers, setGroupMembers] = useState<ManagedUser[]>([]);
+  const [newGroupName, setNewGroupName] = useState('');
+  const [selectedUserId, setSelectedUserId] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const selectedGroup = useMemo(
+    () => groups.find((group) => group.id === selectedGroupId),
+    [groups, selectedGroupId],
+  );
+
+  const loadBaseData = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [loadedUsers, loadedGroups] = await Promise.all([fetchUsers(), fetchGroups()]);
+      setUsers(loadedUsers);
+      setGroups(loadedGroups);
+      if (loadedGroups.length) {
+        const nextGroupId = selectedGroupId && loadedGroups.some((group) => group.id === selectedGroupId)
+          ? selectedGroupId
+          : loadedGroups[0].id;
+        setSelectedGroupId(nextGroupId);
+      } else {
+        setSelectedGroupId('');
+        setGroupMembers([]);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load user management data');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadGroupMembers = async (groupId: string) => {
+    if (!groupId) {
+      setGroupMembers([]);
+      return;
+    }
+    try {
+      const members = await fetchGroupMembers(groupId);
+      setGroupMembers(members);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load members');
+    }
+  };
+
+  useEffect(() => {
+    void loadBaseData();
+  }, []);
+
+  useEffect(() => {
+    void loadGroupMembers(selectedGroupId);
+  }, [selectedGroupId]);
+
+  const handleToggleAdmin = async (user: ManagedUser) => {
+    try {
+      const updated = await setUserAdmin(user.id, !user.isAdmin);
+      setUsers((prev) => prev.map((entry) => (entry.id === updated.id ? updated : entry)));
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update admin role');
+    }
+  };
+
+  const handleCreateGroup = async () => {
+    if (!newGroupName.trim()) {
+      return;
+    }
+    try {
+      const created = await createGroup(newGroupName.trim());
+      setGroups((prev) => [...prev, created].sort((a, b) => a.name.localeCompare(b.name)));
+      setSelectedGroupId(created.id);
+      setNewGroupName('');
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create group');
+    }
+  };
+
+  const handleDeleteGroup = async (groupId: string) => {
+    try {
+      await deleteGroup(groupId);
+      const remaining = groups.filter((group) => group.id !== groupId);
+      setGroups(remaining);
+      setSelectedGroupId(remaining[0]?.id || '');
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete group');
+    }
+  };
+
+  const handleAddMember = async () => {
+    if (!selectedGroupId || !selectedUserId) {
+      return;
+    }
+    try {
+      await addGroupMember(selectedGroupId, selectedUserId);
+      setSelectedUserId('');
+      await loadGroupMembers(selectedGroupId);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add member');
+    }
+  };
+
+  const handleRemoveMember = async (userId: string) => {
+    if (!selectedGroupId) {
+      return;
+    }
+    try {
+      await removeGroupMember(selectedGroupId, userId);
+      await loadGroupMembers(selectedGroupId);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to remove member');
+    }
+  };
+
+  const selectableUsers = users.filter((user) => !groupMembers.some((member) => member.id === user.id));
+
   return (
     <SettingsShell
       eyebrow="Users"
-      title="Users"
-      description="Manage workspace members and permissions."
+      title="User & Group Management"
+      description="Manage system administrators and in-app user groups for RBAC rollout."
     >
-      <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
-        <div className="flex flex-col items-center gap-4 text-center text-slate-600">
-          <span className="flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-100 text-slate-700">
-            <Users2 size={28} />
-          </span>
-          <div>
-            <p className="font-semibold text-slate-900">User management is coming soon.</p>
-            <p className="mt-2">Invite teammates, manage access, and control permissions from a single place.</p>
-          </div>
+      {error && (
+        <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+          {error}
         </div>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="mb-4 flex items-center gap-3">
+            <Users2 size={20} className="text-slate-700" />
+            <h3 className="text-lg font-semibold text-slate-900">Users</h3>
+          </div>
+
+          {loading ? (
+            <p className="text-sm text-slate-600">Loading users…</p>
+          ) : (
+            <div className="space-y-3">
+              {users.map((user) => (
+                <div key={user.id} className="flex items-center justify-between rounded-xl border border-slate-200 px-3 py-2">
+                  <div>
+                    <p className="text-sm font-medium text-slate-900">{user.displayName}</p>
+                    <p className="text-xs text-slate-500">{user.email || user.externalId}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleToggleAdmin(user)}
+                    className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs font-semibold ${user.isAdmin
+                      ? 'bg-emerald-100 text-emerald-800 hover:bg-emerald-200'
+                      : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+                      }`}
+                  >
+                    {user.isAdmin ? <ShieldCheck size={14} /> : <ShieldOff size={14} />}
+                    {user.isAdmin ? 'Admin' : 'Member'}
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 className="text-lg font-semibold text-slate-900">Groups</h3>
+
+          <div className="mt-4 flex gap-2">
+            <input
+              value={newGroupName}
+              onChange={(event) => setNewGroupName(event.target.value)}
+              placeholder="Create group (e.g. analysts)"
+              className="flex-1 rounded-xl border border-slate-300 px-3 py-2 text-sm"
+            />
+            <button
+              type="button"
+              onClick={handleCreateGroup}
+              className="inline-flex items-center gap-1 rounded-xl bg-slate-900 px-3 py-2 text-sm font-semibold text-white"
+            >
+              <Plus size={14} />
+              Add
+            </button>
+          </div>
+
+          <div className="mt-4 space-y-2">
+            {groups.map((group) => (
+              <div key={group.id} className={`flex items-center justify-between rounded-xl border px-3 py-2 ${group.id === selectedGroupId ? 'border-slate-700 bg-slate-50' : 'border-slate-200'}`}>
+                <button
+                  type="button"
+                  className="text-sm font-medium text-slate-900"
+                  onClick={() => setSelectedGroupId(group.id)}
+                >
+                  {group.name}
+                </button>
+                <button
+                  type="button"
+                  className="rounded-md p-1 text-rose-600 hover:bg-rose-50"
+                  onClick={() => handleDeleteGroup(group.id)}
+                >
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            ))}
+          </div>
+
+          {selectedGroup && (
+            <div className="mt-6 rounded-2xl border border-slate-200 p-4">
+              <p className="text-sm font-semibold text-slate-900">Members: {selectedGroup.name}</p>
+              <div className="mt-3 flex gap-2">
+                <select
+                  className="flex-1 rounded-xl border border-slate-300 px-3 py-2 text-sm"
+                  value={selectedUserId}
+                  onChange={(event) => setSelectedUserId(event.target.value)}
+                >
+                  <option value="">Select user</option>
+                  {selectableUsers.map((user) => (
+                    <option key={user.id} value={user.id}>{user.displayName}</option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={handleAddMember}
+                  className="rounded-xl bg-slate-900 px-3 py-2 text-sm font-semibold text-white"
+                >
+                  Add member
+                </button>
+              </div>
+
+              <div className="mt-3 space-y-2">
+                {groupMembers.map((member) => (
+                  <div key={member.id} className="flex items-center justify-between rounded-lg border border-slate-200 px-3 py-2">
+                    <span className="text-sm text-slate-800">{member.displayName}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveMember(member.id)}
+                      className="text-xs font-semibold text-rose-600"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </section>
       </div>
     </SettingsShell>
   );

--- a/frontend/src/services/settingsApi.ts
+++ b/frontend/src/services/settingsApi.ts
@@ -1,6 +1,19 @@
 import type { SkillDefinition } from '../types';
 import { API_URL, apiFetch } from './apiClient';
 
+export type ManagedUser = {
+  id: string;
+  externalId: string;
+  displayName: string;
+  email?: string | null;
+  isAdmin: boolean;
+};
+
+export type ManagedGroup = {
+  id: string;
+  name: string;
+};
+
 export const fetchAgentConfig = async (): Promise<string> => {
   const response = await apiFetch(`${API_URL}/settings/agent-config`);
   if (!response.ok) {
@@ -78,5 +91,101 @@ export const saveSkillContent = async (id: string, filePath: string, content: st
   if (!response.ok) {
     const data = await response.json().catch(() => ({}));
     throw new Error(data.error || 'Failed to save skill content');
+  }
+};
+
+export const fetchUsers = async (): Promise<ManagedUser[]> => {
+  const response = await apiFetch(`${API_URL}/users`);
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || 'Failed to load users');
+  }
+  const data = await response.json();
+  return data.users;
+};
+
+export const setUserAdmin = async (userId: string, isAdmin: boolean): Promise<ManagedUser> => {
+  const response = await apiFetch(`${API_URL}/users/${userId}/admin`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ isAdmin }),
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || 'Failed to update user admin role');
+  }
+  const data = await response.json();
+  return data.user;
+};
+
+export const fetchGroups = async (): Promise<ManagedGroup[]> => {
+  const response = await apiFetch(`${API_URL}/users/groups/list`);
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || 'Failed to load groups');
+  }
+  const data = await response.json();
+  return data.groups;
+};
+
+export const createGroup = async (name: string): Promise<ManagedGroup> => {
+  const response = await apiFetch(`${API_URL}/users/groups`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name }),
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || 'Failed to create group');
+  }
+  const data = await response.json();
+  return data.group;
+};
+
+export const deleteGroup = async (groupId: string): Promise<void> => {
+  const response = await apiFetch(`${API_URL}/users/groups/${groupId}`, {
+    method: 'DELETE',
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || 'Failed to delete group');
+  }
+};
+
+export const fetchGroupMembers = async (groupId: string): Promise<ManagedUser[]> => {
+  const response = await apiFetch(`${API_URL}/users/groups/${groupId}/members`);
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || 'Failed to load group members');
+  }
+  const data = await response.json();
+  return data.members;
+};
+
+export const addGroupMember = async (groupId: string, userId: string): Promise<void> => {
+  const response = await apiFetch(`${API_URL}/users/groups/${groupId}/members`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ userId }),
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || 'Failed to add member');
+  }
+};
+
+export const removeGroupMember = async (groupId: string, userId: string): Promise<void> => {
+  const response = await apiFetch(`${API_URL}/users/groups/${groupId}/members/${userId}`, {
+    method: 'DELETE',
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || 'Failed to remove member');
   }
 };


### PR DESCRIPTION
### Motivation
- Provide a minimal RBAC foundation so system administrators can manage users and in-app groups from the UI.  
- Seed admin users from an environment list and gate sensitive settings behind an admin check to protect runtime configuration.  
- Add DB schema and service APIs to support groups, group membership, and future skill/connection grants.  

### Description
- Add an admin-only users API in `backend/src/api/users.ts` with endpoints to list users, toggle `isAdmin`, manage `groups`, and manage `group_members`.  
- Add `requireSystemAdmin` middleware in `backend/src/middleware/adminOnly.ts` and gate the `/settings` and new `/users` routes in `backend/src/api/routes.ts`.  
- Extend `UserContext` and session typings with `isAdmin` and propagate `isAdmin` from `userContextMiddleware` in `backend/src/middleware/userContext.ts` and `backend/src/types/*`.  
- Implement `isAdmin` support and group APIs in `UserService` (`backend/src/services/userService.ts`) and extend `DatabaseService` (`backend/src/services/databaseService.ts`) to create/update columns and new tables: `users.isAdmin`, `groups`, `group_members`, `skill_grants`, `mcp_connections`, and `mcp_connection_grants`.  
- Add a frontend Users settings page at `frontend/src/pages/UsersPage.tsx` and API client methods in `frontend/src/services/settingsApi.ts` to list users, toggle admin, and manage groups/members.  

### Testing
- Ran frontend type-check: `cd frontend && npx tsc -b` — succeeded.  
- Started frontend dev server for manual validation: `cd frontend && npm run dev -- --host 0.0.0.0 --port 4173` and captured a screenshot of `/settings/users` (artifact: `artifacts/users-page.png`).  
- Attempted frontend production build and backend type-check/install: `cd frontend && npm run build` and `cd backend && npx tsc -p tsconfig.json` — these did not complete in this environment (frontend build was terminated and backend type-check failed due to missing/unaligned dependencies).  
- Backend install: `cd backend && npm ci` failed in this environment due to a `403 Forbidden` from the npm registry, so full backend compilation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69965a934fd0832b812d924b90f5efad)