### PR TITLE
refactor: split WorkspacePage helpers into utils/constants

### DIFF
--- a/frontend/src/constants/workspace.ts
+++ b/frontend/src/constants/workspace.ts
@@ -1,0 +1,22 @@
+export const PAPER2SLIDES_STAGE_ORDER = ['rag', 'analysis', 'plan', 'generate'] as const;
+export const PAPER2SLIDES_STYLE_PRESETS = ['academic', 'doraemon', 'custom'] as const;
+
+export const SLASH_COMMANDS = [
+  {
+    id: 'presentation',
+    command: '/presentation',
+    description: 'Generate slides/posters from @files.',
+  },
+  {
+    id: 'a2ui',
+    command: '/a2ui',
+    description: 'Render an A2UI canvas from your prompt.',
+  },
+] as const;
+
+export const SYSTEM_DIR_NAMES = new Set(['__macosx', 'skills']);
+export const SYSTEM_FILE_NAMES = new Set(['thumbs.db', 'desktop.ini']);
+
+export const MIN_CANVAS_ZOOM = 0.6;
+export const MAX_CANVAS_ZOOM = 2;
+export const CANVAS_ZOOM_STEP = 0.1;

--- a/frontend/src/utils/a2ui.ts
+++ b/frontend/src/utils/a2ui.ts
@@ -1,0 +1,187 @@
+const A2UI_ALLOWED_MESSAGE_KEYS = new Set([
+  'beginRendering',
+  'surfaceUpdate',
+  'dataModelUpdate',
+  'deleteSurface',
+]);
+
+export type A2uiPayloadResult = {
+  payload: unknown;
+  raw: string;
+};
+
+export const sanitizeJsonSource = (value: string) =>
+  Array.from(value)
+    .filter((char) => {
+      const code = char.charCodeAt(0);
+      if (code === 0xfeff) {
+        return false;
+      }
+      if (code <= 0x1f && code !== 0x09 && code !== 0x0a && code !== 0x0d) {
+        return false;
+      }
+      return true;
+    })
+    .join('');
+
+const parseJsonIfPossible = (value: string) => {
+  if (!value) return null;
+  try {
+    return JSON.parse(sanitizeJsonSource(value));
+  } catch {
+    return null;
+  }
+};
+
+export const normalizeA2uiPayload = (parsed: unknown): unknown => {
+  if (typeof parsed === 'string') {
+    const reparsed = parseJsonIfPossible(parsed);
+    if (reparsed != null) {
+      return normalizeA2uiPayload(reparsed);
+    }
+    return parsed;
+  }
+  if (Array.isArray(parsed)) {
+    return parsed;
+  }
+  if (parsed && typeof parsed === 'object') {
+    const record = parsed as Record<string, unknown>;
+    const nested = record.events ?? record.messages ?? record.a2ui;
+    if (Array.isArray(nested)) {
+      return nested;
+    }
+    const keys = Object.keys(record);
+    if (keys.length === 1 && A2UI_ALLOWED_MESSAGE_KEYS.has(keys[0])) {
+      return [record];
+    }
+  }
+  return parsed;
+};
+
+export const parseJsonLines = (value: string) => {
+  const lines = value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (!lines.length) return null;
+  const events: unknown[] = [];
+  for (const line of lines) {
+    const parsed = parseJsonIfPossible(line);
+    if (!parsed) {
+      return null;
+    }
+    events.push(parsed);
+  }
+  return events.length ? events : null;
+};
+
+const extractJsonSubstring = (value: string) => {
+  const start = value.search(/[[{]/);
+  if (start < 0) return null;
+  const pairs: Record<string, string> = { '{': '}', '[': ']' };
+  const openers = new Set(Object.keys(pairs));
+  const closers = new Set(Object.values(pairs));
+  const stack: string[] = [];
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < value.length; i += 1) {
+    const ch = value[i];
+    if (inString) {
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === '\\') {
+        escape = true;
+        continue;
+      }
+      if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (openers.has(ch)) {
+      stack.push(ch);
+      continue;
+    }
+    if (closers.has(ch)) {
+      const last = stack.pop();
+      if (!last || pairs[last] !== ch) {
+        return null;
+      }
+      if (stack.length === 0) {
+        return value.slice(start, i + 1);
+      }
+    }
+  }
+  return null;
+};
+
+const extractBracketedJson = (value: string) => {
+  const start = value.indexOf('[');
+  const end = value.lastIndexOf(']');
+  if (start < 0 || end < 0 || end <= start) return null;
+  return value.slice(start, end + 1);
+};
+
+export const extractA2uiPayload = (value: string): A2uiPayloadResult | null => {
+  const trimmed = sanitizeJsonSource(value).trim();
+  if (!trimmed) return null;
+
+  const fenceMatch = trimmed.match(/```(?:json|a2ui|a2ui-json)?\s*([\s\S]*?)```/i);
+  if (fenceMatch?.[1]) {
+    const candidate = fenceMatch[1].trim();
+    const parsed = parseJsonIfPossible(candidate);
+    if (parsed) {
+      return { payload: normalizeA2uiPayload(parsed), raw: candidate };
+    }
+    const jsonLines = parseJsonLines(candidate);
+    if (jsonLines) {
+      return { payload: normalizeA2uiPayload(jsonLines), raw: candidate };
+    }
+  }
+
+  const blockMatch = trimmed.match(/---BEGIN[^-]*---([\s\S]*?)---END[^-]*---/i);
+  if (blockMatch?.[1]) {
+    const candidate = blockMatch[1].trim();
+    const parsed = parseJsonIfPossible(candidate);
+    if (parsed) {
+      return { payload: normalizeA2uiPayload(parsed), raw: candidate };
+    }
+    const jsonLines = parseJsonLines(candidate);
+    if (jsonLines) {
+      return { payload: normalizeA2uiPayload(jsonLines), raw: candidate };
+    }
+  }
+
+  const directParsed = parseJsonIfPossible(trimmed);
+  if (directParsed) {
+    return { payload: normalizeA2uiPayload(directParsed), raw: trimmed };
+  }
+  const jsonLines = parseJsonLines(trimmed);
+  if (jsonLines) {
+    return { payload: normalizeA2uiPayload(jsonLines), raw: trimmed };
+  }
+
+  const substring = extractJsonSubstring(trimmed);
+  const parsed = substring ? parseJsonIfPossible(substring) : null;
+  if (parsed && substring) {
+    return { payload: normalizeA2uiPayload(parsed), raw: substring };
+  }
+  const subJsonLines = substring ? parseJsonLines(substring) : null;
+  if (subJsonLines && substring) {
+    return { payload: normalizeA2uiPayload(subJsonLines), raw: substring };
+  }
+
+  const bracketed = extractBracketedJson(trimmed);
+  const bracketParsed = bracketed ? parseJsonIfPossible(bracketed) : null;
+  if (bracketParsed && bracketed) {
+    return { payload: normalizeA2uiPayload(bracketParsed), raw: bracketed };
+  }
+
+  return null;
+};

--- a/frontend/src/utils/files.tsx
+++ b/frontend/src/utils/files.tsx
@@ -1,0 +1,101 @@
+import {
+  Description as MarkdownIcon,
+  Code as HtmlIcon,
+  PictureAsPdf as PdfIcon,
+  Image as ImageIcon,
+} from '@mui/icons-material';
+import { FileIcon } from 'lucide-react';
+
+import { SYSTEM_DIR_NAMES, SYSTEM_FILE_NAMES } from '../constants/workspace';
+import type { File as WorkspaceFile } from '../types';
+
+const TEXT_PREVIEW_EXTENSIONS = new Set([
+  '.md',
+  '.mermaid',
+  '.txt',
+  '.json',
+  '.html',
+  '.htm',
+  '.css',
+  '.js',
+  '.ts',
+  '.tsx',
+  '.jsx',
+  '.svg',
+  '.csv',
+]);
+
+export const normalizeFilePath = (value: string) => value.replace(/\\/g, '/');
+
+export const getFileDisplayName = (value: string) => {
+  if (!value) {
+    return '';
+  }
+  const normalized = normalizeFilePath(value);
+  const parts = normalized.split('/');
+  return parts[parts.length - 1] || normalized;
+};
+
+export const getFileTypeIcon = (value: string) => {
+  const normalized = getFileDisplayName(value).toLowerCase();
+  const sharedClass = 'text-slate-400 opacity-70';
+  if (normalized.endsWith('.md') || normalized.endsWith('.markdown')) {
+    return <MarkdownIcon className={sharedClass} fontSize="small" />;
+  }
+  if (normalized.endsWith('.html') || normalized.endsWith('.htm')) {
+    return <HtmlIcon className={sharedClass} fontSize="small" />;
+  }
+  if (normalized.endsWith('.pdf')) {
+    return <PdfIcon className={sharedClass} fontSize="small" />;
+  }
+  if (normalized.endsWith('.jpg') || normalized.endsWith('.jpeg')) {
+    return <ImageIcon className={sharedClass} fontSize="small" />;
+  }
+  if (['.png', '.gif', '.bmp', '.webp', '.svg'].some((ext) => normalized.endsWith(ext))) {
+    return <ImageIcon className={sharedClass} fontSize="small" />;
+  }
+  return <FileIcon size={16} className={sharedClass} />;
+};
+
+export const isSystemFile = (file: WorkspaceFile): boolean => {
+  const name = normalizeFilePath(file.name || '');
+  if (!name) {
+    return false;
+  }
+  const lowerName = name.toLowerCase();
+  const parts = lowerName.split('/');
+  const baseName = parts[parts.length - 1] || '';
+  if (SYSTEM_FILE_NAMES.has(baseName)) {
+    return true;
+  }
+  for (const part of parts) {
+    if (!part) {
+      continue;
+    }
+    if (SYSTEM_DIR_NAMES.has(part)) {
+      return true;
+    }
+    if (part.startsWith('.')) {
+      return true;
+    }
+  }
+  return false;
+};
+
+export const inferPreviewEncoding = (fileName: string, mimeType?: string | null): 'text' | 'base64' => {
+  const normalizedMime = (mimeType || '').toLowerCase();
+  if (
+    normalizedMime.startsWith('text/') ||
+    normalizedMime.includes('json') ||
+    normalizedMime.includes('javascript') ||
+    normalizedMime.includes('typescript') ||
+    normalizedMime.includes('markdown') ||
+    normalizedMime.includes('html') ||
+    normalizedMime.includes('xml')
+  ) {
+    return 'text';
+  }
+  const extIndex = fileName.lastIndexOf('.');
+  const ext = extIndex >= 0 ? fileName.slice(extIndex).toLowerCase() : '';
+  return TEXT_PREVIEW_EXTENSIONS.has(ext) ? 'text' : 'base64';
+};

--- a/frontend/src/utils/messages.ts
+++ b/frontend/src/utils/messages.ts
@@ -1,0 +1,50 @@
+import type { ConversationMessage, ConversationMessageMetadata } from '../types';
+
+export const mapMessagesToAgentHistory = (messages: ConversationMessage[]) => {
+  return messages
+    .filter((message) => typeof message.text === 'string' && message.text.trim().length > 0)
+    .map((message) => ({
+      role: message.sender === 'agent' ? 'assistant' : 'user',
+      content: message.text.trim(),
+    }));
+};
+
+export const mergeMessageMetadata = (message: ConversationMessage): ConversationMessage => {
+  const metadata = message.metadata as ConversationMessageMetadata | null | undefined;
+  if (!metadata) {
+    return message;
+  }
+  const thinkingText = message.thinkingText ?? metadata.thinkingText;
+  const toolEvents = message.toolEvents ?? metadata.toolEvents;
+  if (thinkingText === message.thinkingText && toolEvents === message.toolEvents) {
+    return message;
+  }
+  return {
+    ...message,
+    thinkingText,
+    toolEvents,
+  };
+};
+
+export const buildMessageMetadata = (
+  message?: ConversationMessage | null,
+): ConversationMessageMetadata | undefined => {
+  if (!message) {
+    return undefined;
+  }
+  const existingMetadata = (message.metadata as ConversationMessageMetadata | null | undefined) || undefined;
+  const metadata: ConversationMessageMetadata = {};
+  if (message.thinkingText) {
+    metadata.thinkingText = message.thinkingText;
+  }
+  if (message.toolEvents?.length) {
+    metadata.toolEvents = message.toolEvents;
+  }
+  if (existingMetadata?.runPolicy) {
+    metadata.runPolicy = existingMetadata.runPolicy;
+  }
+  if (existingMetadata?.pendingInterrupt) {
+    metadata.pendingInterrupt = existingMetadata.pendingInterrupt;
+  }
+  return Object.keys(metadata).length ? metadata : undefined;
+};

--- a/frontend/src/utils/personas.ts
+++ b/frontend/src/utils/personas.ts
@@ -1,0 +1,53 @@
+import type { AgentPersona } from '../types';
+
+export const DEFAULT_PERSONA_NAME = 'fast';
+export const DEFAULT_PERSONAS: AgentPersona[] = [
+  {
+    name: 'fast',
+    displayName: 'Fast',
+    description: 'Gemini 3 Flash (Preview)',
+  },
+  {
+    name: 'pro',
+    displayName: 'Pro',
+    description: 'Gemini 3 Pro (Preview)',
+  },
+];
+
+export const normalizePersonaName = (name: string): string => {
+  const normalized = name.trim().toLowerCase();
+  if (!normalized) {
+    return DEFAULT_PERSONA_NAME;
+  }
+  if (normalized === 'general-assistant') {
+    return 'fast';
+  }
+  return normalized;
+};
+
+export const normalizePersonas = (personas: AgentPersona[]): AgentPersona[] => {
+  const normalized = new Map<string, AgentPersona>();
+  const defaults = new Map(DEFAULT_PERSONAS.map((persona) => [persona.name, persona]));
+
+  personas.forEach((persona) => {
+    const name = normalizePersonaName(persona.name);
+    if (name !== 'fast' && name !== 'pro') {
+      return;
+    }
+    const fallback = defaults.get(name);
+    normalized.set(name, {
+      ...fallback,
+      ...persona,
+      name,
+      displayName: persona.displayName || fallback?.displayName || name,
+    });
+  });
+
+  DEFAULT_PERSONAS.forEach((persona) => {
+    if (!normalized.has(persona.name)) {
+      normalized.set(persona.name, persona);
+    }
+  });
+
+  return DEFAULT_PERSONAS.map((persona) => normalized.get(persona.name) || persona);
+};


### PR DESCRIPTION
## Summary
- extract workspace-level constants into `frontend/src/constants/workspace.ts`
- extract persona defaults/normalization into `frontend/src/utils/personas.ts`
- extract file/path helpers into `frontend/src/utils/files.tsx`
- extract A2UI parsing/sanitization helpers into `frontend/src/utils/a2ui.ts`
- extract message metadata/history helpers into `frontend/src/utils/messages.ts`
- update `frontend/src/pages/WorkspacePage.tsx` to consume new utility modules while keeping page-specific helpers local

## Why
This reduces `WorkspacePage` top-level complexity and isolates reusable logic into focused modules without changing intended behavior.

## Validation
- `npm exec eslint src/utils/a2ui.ts src/utils/files.tsx src/utils/messages.ts src/utils/personas.ts src/constants/workspace.ts`
- `npm exec -- tsc -b`
- `npm --prefix frontend run lint` reports pre-existing issues outside this extraction scope

## Notes
The PR was originally created with a placeholder message due a Codex generation error; this body replaces that placeholder.
