### PR TITLE
ci: fix Secret Scan workflow for PR events

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -13,5 +13,5 @@ jobs:
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2
-        with:
-          config-path: .gitleaks.toml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- fix `Secret Scan` workflow for PR events by passing required `GITHUB_TOKEN` to `gitleaks/gitleaks-action@v2`
- remove unsupported `config-path` input that now emits warnings in v2

## Why
PR checks currently show a failing `gitleaks` run with:
`GITHUB_TOKEN is now required to scan pull requests`

This causes otherwise valid PRs (including #5) to remain unstable.

## Impact
No app/runtime changes. CI-only workflow fix.
