### PR TITLE
Add admin skill builder pane with actions apply and GitHub skill importer

### DIFF
--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -31,7 +31,7 @@ export default function(dbService: DatabaseService, userService: UserService) {
 
   router.use('/auth', authRoutes(userService, googleOAuthService));
   router.use('/agent', agentRoutes(workspaceService, fileService, googleOAuthService));
-  router.use('/settings', requireSystemAdmin(userService), settingsRoutes());
+  router.use('/settings', requireSystemAdmin(userService), settingsRoutes(workspaceService));
   router.use('/users', requireSystemAdmin(userService), usersRoutes(userService));
   router.use('/workspaces', workspaceRoutes(workspaceService, userService));
   router.use('/workspaces/:workspaceId/files', fileRoutes(fileService));

--- a/backend/src/api/settings.ts
+++ b/backend/src/api/settings.ts
@@ -1,16 +1,50 @@
-import { Router } from 'express';
+import { Router, Request, Response } from 'express';
+import multer from 'multer';
 import { z } from 'zod';
 import path from 'path';
 import { promises as fs } from 'fs';
+import crypto from 'crypto';
 import { parse as parseYaml } from 'yaml';
+import { existsSync } from 'fs';
+import type { WorkspaceService } from '../services/workspaceService';
+import { HttpError } from '../errors';
+import {
+  cancelAgentRun,
+  getRunMeta,
+  getRunStreamKey,
+  resumeAgentRun,
+  startAgentRun,
+} from '../services/agentRunService';
+import { blockingRedisClient } from '../services/redisService';
+import { signAgentContextToken } from '../services/agentToken';
 
 const repoRoot = path.resolve(__dirname, '../../..');
+const workspaceRoot = process.env.WORKSPACE_ROOT
+  ? path.resolve(process.env.WORKSPACE_ROOT)
+  : path.join(repoRoot, 'workspaces');
 
 // In production containers, the repo layout does not exist. Use explicit env vars.
-// Defaults are chosen to match our GKE volume mounts.
 const agentConfigPath = process.env.AGENT_CONFIG_PATH
   || path.join(process.env.AGENT_CONFIG_DIR || '/agent/config', 'runtime.yaml');
 const skillsRoot = process.env.SKILLS_ROOT || path.join(repoRoot, 'skills');
+
+const skillBuilderStorageRoot = path.join(repoRoot, '.local-run', 'skill-builder');
+const contextFilesRoot = path.join(skillBuilderStorageRoot, 'context-files');
+
+const ENABLE_SKILL_BUILDER_ASSISTANT = String(process.env.ENABLE_SKILL_BUILDER_ASSISTANT ?? 'true').toLowerCase() !== 'false';
+const ENABLE_GITHUB_SKILL_IMPORTER = String(process.env.ENABLE_GITHUB_SKILL_IMPORTER ?? 'true').toLowerCase() !== 'false';
+const ENABLE_SKILL_SCRIPT_RUNNER = String(process.env.ENABLE_SKILL_SCRIPT_RUNNER ?? 'false').toLowerCase() === 'true';
+
+const CONTEXT_ALLOWED_EXTENSIONS = [
+  '.py', '.md', '.txt', '.pdf', '.csv', '.json', '.yaml', '.yml', '.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg',
+];
+const CONTEXT_MAX_FILE_SIZE = 20 * 1024 * 1024;
+
+const ACTION_ALLOWED_PREFIXES = ['SKILL.md', 'scripts/', 'references/', 'assets/', 'templates/'];
+const IMPORT_ALLOWED_PREFIXES = ['SKILL.md', 'scripts/', 'references/', 'assets/', 'templates/', 'docs/', 'examples/'];
+const IMPORT_BLOCKED_EXTENSIONS = new Set(['.exe', '.dll', '.so', '.dylib', '.bat', '.cmd', '.com']);
+
+const SKILL_BUILDER_PERSONA = 'skill-builder';
 
 type SkillMetadata = {
   id: string;
@@ -20,6 +54,51 @@ type SkillMetadata = {
   error?: string;
   warning?: string;
 };
+
+type ContextFileMeta = {
+  fileId: string;
+  userId: string;
+  name: string;
+  relativePath: string;
+  absolutePath: string;
+  size: number;
+  mimeType: string;
+  uploadedAt: string;
+};
+
+type GithubImportFile = {
+  path: string;
+  size: number;
+  content: Buffer;
+};
+
+type GithubInspectSession = {
+  importSessionId: string;
+  userId: string;
+  source: {
+    owner: string;
+    repo: string;
+    ref: string;
+    path: string;
+    url: string;
+  };
+  detectedSkillId: string;
+  files: GithubImportFile[];
+  warnings: string[];
+  createdAt: string;
+};
+
+const skillBuilderWorkspaceByUser = new Map<string, string>();
+const contextFilesByUser = new Map<string, ContextFileMeta[]>();
+const githubImportSessions = new Map<string, GithubInspectSession>();
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: CONTEXT_MAX_FILE_SIZE,
+    files: 1,
+  },
+});
 
 const updateConfigSchema = z.object({
   content: z.string().min(1, 'Content is required'),
@@ -34,6 +113,85 @@ const createSkillSchema = z.object({
 const updateSkillContentSchema = z.object({
   path: z.string().min(1, 'Path is required'),
   content: z.string(),
+});
+
+const skillBuilderRunSchema = z.object({
+  prompt: z.string().min(1, 'Prompt is required'),
+  history: z.array(
+    z.object({
+      role: z.string().min(1),
+      content: z.string().min(1),
+    }),
+  ).optional(),
+  contextFileIds: z.array(z.string().min(1)).optional(),
+  selectedSkillId: z.string().optional(),
+  turnId: z.string().optional(),
+  forceReset: z.boolean().optional(),
+});
+
+const runDecisionSchema = z.object({
+  decision: z.enum(['approve', 'edit', 'reject']),
+  editedAction: z
+    .object({
+      name: z.string().min(1),
+      args: z.record(z.string(), z.unknown()).default({}),
+    })
+    .optional(),
+  message: z.string().optional(),
+});
+
+const createSkillActionSchema = z.object({
+  type: z.literal('create_skill'),
+  skillId: z.string().min(1),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  template: z.string().optional(),
+});
+
+const upsertTextActionSchema = z.object({
+  type: z.literal('upsert_text'),
+  skillId: z.string().min(1),
+  path: z.string().min(1),
+  content: z.string(),
+  encoding: z.literal('utf-8').default('utf-8'),
+});
+
+const uploadBinaryFromContextActionSchema = z.object({
+  type: z.literal('upload_binary_from_context'),
+  skillId: z.string().min(1),
+  contextFileId: z.string().min(1),
+  targetPath: z.string().min(1),
+});
+
+const deleteFileActionSchema = z.object({
+  type: z.literal('delete_file'),
+  skillId: z.string().min(1),
+  path: z.string().min(1),
+});
+
+const applyActionsSchema = z.object({
+  actions: z.array(z.discriminatedUnion('type', [
+    createSkillActionSchema,
+    upsertTextActionSchema,
+    uploadBinaryFromContextActionSchema,
+    deleteFileActionSchema,
+  ])).min(1),
+});
+
+const githubInspectSchema = z.object({
+  url: z.string().url(),
+  ref: z.string().optional(),
+  githubToken: z.string().optional(),
+});
+
+const githubApplySchema = z.object({
+  importSessionId: z.string().min(1),
+  destinationSkillId: z.string().optional(),
+  onCollision: z.literal('copy').default('copy'),
+});
+
+const parseActionsSchema = z.object({
+  text: z.string().min(1),
 });
 
 async function pathExists(targetPath: string) {
@@ -55,11 +213,20 @@ function resolveSkillDir(id: string) {
   return path.join(skillsRoot, normalizedId);
 }
 
-function resolveSkillFile(id: string, relativePath: string) {
+function isAllowedActionPath(relativePath: string, prefixes = ACTION_ALLOWED_PREFIXES): boolean {
+  const normalized = relativePath.replace(/\\/g, '/').replace(/^\/+/, '');
+  if (normalized === 'SKILL.md') return true;
+  return prefixes.some((prefix) => normalized.startsWith(prefix));
+}
+
+function resolveSkillFile(id: string, relativePath: string, prefixes = ACTION_ALLOWED_PREFIXES) {
   const skillDir = resolveSkillDir(id);
-  const normalized = relativePath.replace(/\\/g, '/');
-  if (normalized.includes('..') || normalized.startsWith('/')) {
+  const normalized = relativePath.replace(/\\/g, '/').replace(/^\/+/, '');
+  if (normalized.includes('..')) {
     throw new Error('Invalid path');
+  }
+  if (!isAllowedActionPath(normalized, prefixes)) {
+    throw new Error('Unsupported target path');
   }
   const resolved = path.resolve(skillDir, normalized);
   if (!resolved.startsWith(skillDir)) {
@@ -127,7 +294,233 @@ async function collectSkillFiles(dir: string, relativeDir = ''): Promise<string[
   return results.sort((a, b) => a.localeCompare(b));
 }
 
-export default function settingsRoutes() {
+function requireUserContext(req: Request) {
+  if (!req.userContext) {
+    throw new HttpError(401, 'Missing user context');
+  }
+  return req.userContext;
+}
+
+function handleError(res: Response, error: unknown, fallbackMessage: string) {
+  if (error instanceof HttpError) {
+    return res.status(error.statusCode).json({ error: error.message, details: error.details });
+  }
+  console.error(fallbackMessage, error);
+  return res.status(500).json({ error: fallbackMessage });
+}
+
+async function scaffoldSkill(skillId: string, name?: string, description?: string) {
+  const skillDir = resolveSkillDir(skillId);
+  if (await pathExists(skillDir)) {
+    throw new Error('Skill already exists');
+  }
+
+  await fs.mkdir(path.join(skillDir, 'scripts'), { recursive: true });
+  await fs.mkdir(path.join(skillDir, 'references'), { recursive: true });
+  await fs.mkdir(path.join(skillDir, 'assets'), { recursive: true });
+  await fs.mkdir(path.join(skillDir, 'templates'), { recursive: true });
+
+  const title = name || skillId;
+  const desc = (description || '').trim();
+
+  const skillContent = `---\nname: ${title}\ndescription: ${desc}\n---\n\n# ${title}\n\n## Overview\n\n${desc || '(Add skill overview)'}\n\n## Instructions\n\n1. Define the workflow\n2. Reference supporting files in this skill\n\n## Files\n\n- \`scripts/\` for executable helpers\n- \`references/\` for docs\n- \`assets/\` for images and static resources\n- \`templates/\` for reusable templates\n`;
+
+  await fs.writeFile(path.join(skillDir, 'SKILL.md'), skillContent, 'utf-8');
+  await fs.writeFile(path.join(skillDir, 'scripts', 'README.md'), '# Scripts\n\nPlace helper Python scripts here.\n', 'utf-8');
+  await fs.writeFile(path.join(skillDir, 'references', 'README.md'), '# References\n\nPlace reference docs here.\n', 'utf-8');
+  await fs.writeFile(path.join(skillDir, 'assets', 'README.md'), '# Assets\n\nPlace images/assets here.\n', 'utf-8');
+  await fs.writeFile(path.join(skillDir, 'templates', 'README.md'), '# Templates\n\nPlace templates here.\n', 'utf-8');
+}
+
+async function ensureSkillBuilderWorkspace(user: { userId: string; displayName: string }): Promise<string> {
+  const cached = skillBuilderWorkspaceByUser.get(user.userId);
+  if (cached) {
+    return cached;
+  }
+
+  const workspaceId = `skill-builder-${user.userId}`.replace(/[^a-zA-Z0-9_-]/g, '-');
+  const workspacePath = path.join(workspaceRoot, workspaceId);
+  await fs.mkdir(workspacePath, { recursive: true });
+  skillBuilderWorkspaceByUser.set(user.userId, workspaceId);
+  return workspaceId;
+}
+
+function getContextFilesForUser(userId: string): ContextFileMeta[] {
+  return contextFilesByUser.get(userId) || [];
+}
+
+function setContextFilesForUser(userId: string, files: ContextFileMeta[]) {
+  contextFilesByUser.set(userId, files);
+}
+
+function guessMimeType(fileName: string): string {
+  const ext = path.extname(fileName).toLowerCase();
+  if (['.md', '.txt', '.py', '.json', '.yaml', '.yml', '.csv'].includes(ext)) {
+    return 'text/plain';
+  }
+  if (ext === '.pdf') return 'application/pdf';
+  if (['.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg'].includes(ext)) {
+    return `image/${ext.replace('.', '').replace('jpg', 'jpeg')}`;
+  }
+  return 'application/octet-stream';
+}
+
+function parseGitHubSource(rawUrl: string, refOverride?: string) {
+  const parsed = new URL(rawUrl);
+  if (parsed.hostname !== 'github.com') {
+    throw new Error('Only github.com URLs are supported in v1');
+  }
+  const segments = parsed.pathname.split('/').filter(Boolean);
+  if (segments.length < 2) {
+    throw new Error('Invalid GitHub URL');
+  }
+  const owner = segments[0];
+  const repo = segments[1].replace(/\.git$/, '');
+
+  let ref = refOverride?.trim() || '';
+  let dirPath = '';
+
+  if (segments[2] === 'tree' && segments.length >= 4) {
+    ref = ref || segments[3];
+    dirPath = segments.slice(4).join('/');
+  } else if (segments[2] === 'blob' && segments.length >= 5) {
+    ref = ref || segments[3];
+    dirPath = segments.slice(4, -1).join('/');
+  } else {
+    dirPath = segments.slice(2).join('/');
+  }
+
+  if (!ref) {
+    ref = 'main';
+  }
+
+  return {
+    owner,
+    repo,
+    ref,
+    path: dirPath,
+    url: rawUrl,
+  };
+}
+
+async function githubApiJson(url: string, token?: string): Promise<any> {
+  const headers: Record<string, string> = {
+    'Accept': 'application/vnd.github+json',
+    'User-Agent': 'helpudoc-skill-importer',
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`GitHub API error (${response.status}): ${text || response.statusText}`);
+  }
+  return response.json();
+}
+
+async function githubDownloadFile(url: string, token?: string): Promise<Buffer> {
+  const headers: Record<string, string> = {
+    'User-Agent': 'helpudoc-skill-importer',
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`Failed downloading file (${response.status})`);
+  }
+  const arr = await response.arrayBuffer();
+  return Buffer.from(arr);
+}
+
+async function fetchGitHubDirectoryFiles(source: { owner: string; repo: string; ref: string; path: string }, token?: string) {
+  const collected: GithubImportFile[] = [];
+  const warnings: string[] = [];
+
+  const walk = async (dirPath: string) => {
+    const normalizedDirPath = dirPath
+      .split('/')
+      .filter(Boolean)
+      .map((segment) => encodeURIComponent(segment))
+      .join('/');
+    const endpoint = normalizedDirPath
+      ? `https://api.github.com/repos/${source.owner}/${source.repo}/contents/${normalizedDirPath}?ref=${encodeURIComponent(source.ref)}`
+      : `https://api.github.com/repos/${source.owner}/${source.repo}/contents?ref=${encodeURIComponent(source.ref)}`;
+    const payload = await githubApiJson(endpoint, token);
+    const entries = Array.isArray(payload) ? payload : [payload];
+
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') continue;
+      if (entry.type === 'dir') {
+        await walk(entry.path);
+        continue;
+      }
+      if (entry.type !== 'file') continue;
+      const ext = path.extname(String(entry.name || '')).toLowerCase();
+      if (IMPORT_BLOCKED_EXTENSIONS.has(ext)) {
+        warnings.push(`Skipped blocked file extension: ${entry.path}`);
+        continue;
+      }
+      const downloadUrl = typeof entry.download_url === 'string' ? entry.download_url : '';
+      if (!downloadUrl) {
+        warnings.push(`Skipped file without download URL: ${entry.path}`);
+        continue;
+      }
+      const content = await githubDownloadFile(downloadUrl, token);
+      collected.push({
+        path: String(entry.path || ''),
+        size: Number(entry.size || content.length),
+        content,
+      });
+    }
+  };
+
+  await walk(source.path || '');
+  return { files: collected, warnings };
+}
+
+function toSkillRelativePath(sourceRoot: string, filePath: string): string {
+  const normalizedRoot = sourceRoot.replace(/^\/+|\/+$/g, '');
+  const normalizedPath = filePath.replace(/^\/+/, '');
+  if (!normalizedRoot) return normalizedPath;
+  if (!normalizedPath.startsWith(normalizedRoot)) return normalizedPath;
+  return normalizedPath.slice(normalizedRoot.length).replace(/^\/+/, '');
+}
+
+function resolveCollisionSkillId(baseSkillId: string): string {
+  const candidateA = `${baseSkillId}-copy`;
+  if (!isValidSkillId(baseSkillId)) {
+    throw new Error('Invalid destination skill id');
+  }
+  const dirA = path.join(skillsRoot, candidateA);
+  if (!existsSync(dirA)) {
+    return candidateA;
+  }
+  let n = 2;
+  while (true) {
+    const candidate = `${baseSkillId}-v${n}`;
+    const dir = path.join(skillsRoot, candidate);
+    if (!existsSync(dir)) {
+      return candidate;
+    }
+    n += 1;
+  }
+}
+
+function extractActionsFromText(text: string): unknown[] {
+  const blockMatch = text.match(/```json\s*([\s\S]*?)```/i);
+  const candidate = (blockMatch ? blockMatch[1] : text).trim();
+  if (!candidate) return [];
+  const parsed = JSON.parse(candidate);
+  if (Array.isArray(parsed)) return parsed;
+  if (parsed && typeof parsed === 'object' && Array.isArray((parsed as any).actions)) {
+    return (parsed as any).actions;
+  }
+  throw new Error('No actions array found in input text');
+}
+
+export default function settingsRoutes(_workspaceService: WorkspaceService) {
   const router = Router();
 
   router.get('/agent-config', async (_req, res) => {
@@ -136,7 +529,6 @@ export default function settingsRoutes() {
       const content = await fs.readFile(agentConfigPath, 'utf-8');
       res.json({ content });
     } catch (error) {
-      // First-time boot: the PVC exists but runtime.yaml may not.
       if ((error as any)?.code === 'ENOENT') {
         return res.json({ content: '' });
       }
@@ -167,9 +559,7 @@ export default function settingsRoutes() {
       const skills: SkillMetadata[] = [];
 
       for (const entry of entries) {
-        if (!entry.isDirectory()) {
-          continue;
-        }
+        if (!entry.isDirectory()) continue;
         try {
           const metadata = await getSkillMetadata(entry.name);
           skills.push(metadata);
@@ -190,46 +580,15 @@ export default function settingsRoutes() {
     try {
       const { id, name, description } = createSkillSchema.parse(req.body);
       await fs.mkdir(skillsRoot, { recursive: true });
-      const skillDir = resolveSkillDir(id);
-
-      if (await pathExists(skillDir)) {
-        return res.status(409).json({ error: 'Skill already exists' });
-      }
-
-      await fs.mkdir(path.join(skillDir, 'scripts'), { recursive: true });
-      await fs.mkdir(path.join(skillDir, 'docs'), { recursive: true });
-      await fs.mkdir(path.join(skillDir, 'examples'), { recursive: true });
-      await fs.mkdir(path.join(skillDir, 'templates'), { recursive: true });
-
-      const skillContent = `---
-name: ${name || id}
-description: ${description || ''}
----
-
-# ${name || id}
-
-(Description of the skill)
-
-## Reference Files
-- [Docs](./docs/)
-- [Scripts](./scripts/)
-- [Examples](./examples/)
-- [Templates](./templates/)
-`;
-
-      await fs.writeFile(path.join(skillDir, 'SKILL.md'), skillContent, 'utf-8');
-      await fs.writeFile(path.join(skillDir, 'scripts', 'README.md'), '# Scripts\n\nPlace your helper scripts here.', 'utf-8');
-      await fs.writeFile(path.join(skillDir, 'docs', 'README.md'), '# Documentation\n\nPlace your documentation files here.', 'utf-8');
-      await fs.writeFile(path.join(skillDir, 'examples', 'README.md'), '# Examples\n\nPlace your example files here.', 'utf-8');
-      await fs.writeFile(path.join(skillDir, 'templates', 'README.md'), '# Templates\n\nPlace your code templates here.', 'utf-8');
-
+      await scaffoldSkill(id, name, description);
       res.json({ success: true, id });
     } catch (error: unknown) {
       if (error instanceof z.ZodError) {
         return res.status(400).json({ error: error.issues?.[0]?.message || 'Invalid input' });
       }
-      console.error('Failed to create skill', error);
-      res.status(500).json({ error: 'Failed to create skill' });
+      const message = error instanceof Error ? error.message : 'Failed to create skill';
+      const status = /already exists/i.test(message) ? 409 : 500;
+      res.status(status).json({ error: message });
     }
   });
 
@@ -258,7 +617,7 @@ description: ${description || ''}
     }
 
     try {
-      const fullPath = resolveSkillFile(req.params.id, filePath);
+      const fullPath = resolveSkillFile(req.params.id, filePath, IMPORT_ALLOWED_PREFIXES);
       if (!await pathExists(fullPath)) {
         return res.status(404).json({ error: 'File not found' });
       }
@@ -266,7 +625,7 @@ description: ${description || ''}
       res.json({ content });
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Failed to read skill file';
-      if (message === 'Invalid skill id' || message === 'Invalid path') {
+      if (['Invalid skill id', 'Invalid path', 'Unsupported target path'].includes(message)) {
         return res.status(400).json({ error: message });
       }
       console.error('Failed to read skill file', error);
@@ -277,7 +636,7 @@ description: ${description || ''}
   router.put('/skills/:id/content', async (req, res) => {
     try {
       const { path: filePath, content } = updateSkillContentSchema.parse(req.body);
-      const fullPath = resolveSkillFile(req.params.id, filePath);
+      const fullPath = resolveSkillFile(req.params.id, filePath, IMPORT_ALLOWED_PREFIXES);
       await fs.mkdir(path.dirname(fullPath), { recursive: true });
       await fs.writeFile(fullPath, content, 'utf-8');
       res.json({ success: true });
@@ -286,12 +645,517 @@ description: ${description || ''}
         return res.status(400).json({ error: error.issues?.[0]?.message || 'Invalid input' });
       }
       const message = error instanceof Error ? error.message : 'Failed to update skill file';
-      if (message === 'Invalid skill id' || message === 'Invalid path') {
+      if (['Invalid skill id', 'Invalid path', 'Unsupported target path'].includes(message)) {
         return res.status(400).json({ error: message });
       }
       console.error('Failed to update skill file', error);
       res.status(500).json({ error: 'Failed to update skill file' });
     }
+  });
+
+  router.post('/skills/parse-actions', async (req, res) => {
+    try {
+      const { text } = parseActionsSchema.parse(req.body);
+      const rawActions = extractActionsFromText(text);
+      const parsed = applyActionsSchema.parse({ actions: rawActions });
+      res.json({ actions: parsed.actions });
+    } catch (error: any) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: error.issues?.[0]?.message || 'Invalid action payload' });
+      }
+      return res.status(400).json({ error: error?.message || 'Failed to parse actions' });
+    }
+  });
+
+  router.post('/skills/apply-actions', async (req, res) => {
+    try {
+      const user = requireUserContext(req);
+      const { actions } = applyActionsSchema.parse(req.body);
+      await fs.mkdir(skillsRoot, { recursive: true });
+
+      const results: Array<{ index: number; type: string; status: 'ok' | 'error'; message?: string }> = [];
+      const contextFiles = getContextFilesForUser(user.userId);
+
+      for (let i = 0; i < actions.length; i += 1) {
+        const action = actions[i];
+        try {
+          if (action.type === 'create_skill') {
+            await scaffoldSkill(action.skillId, action.name, action.description);
+          } else if (action.type === 'upsert_text') {
+            const fullPath = resolveSkillFile(action.skillId, action.path);
+            await fs.mkdir(path.dirname(fullPath), { recursive: true });
+            await fs.writeFile(fullPath, action.content, 'utf-8');
+          } else if (action.type === 'upload_binary_from_context') {
+            const contextFile = contextFiles.find((item) => item.fileId === action.contextFileId);
+            if (!contextFile) {
+              throw new Error(`Context file not found: ${action.contextFileId}`);
+            }
+            const targetPath = resolveSkillFile(action.skillId, action.targetPath, IMPORT_ALLOWED_PREFIXES);
+            await fs.mkdir(path.dirname(targetPath), { recursive: true });
+            await fs.copyFile(contextFile.absolutePath, targetPath);
+          } else if (action.type === 'delete_file') {
+            const fullPath = resolveSkillFile(action.skillId, action.path, IMPORT_ALLOWED_PREFIXES);
+            if (await pathExists(fullPath)) {
+              await fs.rm(fullPath, { force: true });
+            }
+          }
+
+          results.push({ index: i, type: action.type, status: 'ok' });
+        } catch (error: any) {
+          const message = error?.message || 'Failed to apply action';
+          results.push({ index: i, type: action.type, status: 'error', message });
+          return res.status(400).json({ success: false, results, error: message });
+        }
+      }
+
+      return res.json({ success: true, results });
+    } catch (error: any) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: error.issues?.[0]?.message || 'Invalid payload' });
+      }
+      return handleError(res, error, 'Failed to apply actions');
+    }
+  });
+
+  router.post('/skills/import/github/inspect', async (req, res) => {
+    if (!ENABLE_GITHUB_SKILL_IMPORTER) {
+      return res.status(404).json({ error: 'GitHub skill importer is disabled' });
+    }
+    try {
+      const user = requireUserContext(req);
+      const { url, ref, githubToken } = githubInspectSchema.parse(req.body);
+      const source = parseGitHubSource(url, ref);
+      const { files, warnings } = await fetchGitHubDirectoryFiles(source, githubToken);
+      if (!files.length) {
+        return res.status(400).json({ error: 'No files found at source path' });
+      }
+
+      const relativeFiles = files.map((file) => ({
+        ...file,
+        skillPath: toSkillRelativePath(source.path, file.path),
+      }));
+
+      const hasSkill = relativeFiles.some((file) => file.skillPath === 'SKILL.md');
+      if (!hasSkill) {
+        return res.status(400).json({ error: 'Imported folder must include SKILL.md' });
+      }
+
+      const detectedSkillId = (source.path.split('/').filter(Boolean).pop() || source.repo)
+        .replace(/[^a-zA-Z0-9_-]/g, '-');
+
+      const importSessionId = crypto.randomUUID();
+      const session: GithubInspectSession = {
+        importSessionId,
+        userId: user.userId,
+        source,
+        detectedSkillId,
+        files: relativeFiles.map((file) => ({
+          path: file.skillPath,
+          size: file.size,
+          content: file.content,
+        })),
+        warnings,
+        createdAt: new Date().toISOString(),
+      };
+      githubImportSessions.set(importSessionId, session);
+
+      res.json({
+        importSessionId,
+        source,
+        detectedSkillId,
+        filesPreview: session.files.map((file) => ({ path: file.path, size: file.size })),
+        warnings,
+      });
+    } catch (error: any) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: error.issues?.[0]?.message || 'Invalid payload' });
+      }
+      return res.status(400).json({ error: error?.message || 'Failed to inspect GitHub import source' });
+    }
+  });
+
+  router.post('/skills/import/github/apply', async (req, res) => {
+    if (!ENABLE_GITHUB_SKILL_IMPORTER) {
+      return res.status(404).json({ error: 'GitHub skill importer is disabled' });
+    }
+    try {
+      const user = requireUserContext(req);
+      const { importSessionId, destinationSkillId, onCollision } = githubApplySchema.parse(req.body);
+      const session = githubImportSessions.get(importSessionId);
+      if (!session || session.userId !== user.userId) {
+        return res.status(404).json({ error: 'Import session not found' });
+      }
+
+      const requested = (destinationSkillId || session.detectedSkillId).trim();
+      if (!isValidSkillId(requested)) {
+        return res.status(400).json({ error: 'Invalid destination skill id' });
+      }
+
+      let targetSkillId = requested;
+      const targetDir = resolveSkillDir(targetSkillId);
+      if (await pathExists(targetDir)) {
+        if (onCollision !== 'copy') {
+          return res.status(400).json({ error: 'Only copy collision strategy is supported in v1' });
+        }
+        targetSkillId = resolveCollisionSkillId(requested);
+      }
+
+      await scaffoldSkill(targetSkillId, targetSkillId, `Imported from ${session.source.url}`);
+
+      const warnings = [...session.warnings];
+      let filesImported = 0;
+      for (const file of session.files) {
+        if (!isAllowedActionPath(file.path, IMPORT_ALLOWED_PREFIXES)) {
+          warnings.push(`Skipped unsupported path: ${file.path}`);
+          continue;
+        }
+        const fullPath = resolveSkillFile(targetSkillId, file.path, IMPORT_ALLOWED_PREFIXES);
+        await fs.mkdir(path.dirname(fullPath), { recursive: true });
+        await fs.writeFile(fullPath, file.content);
+        filesImported += 1;
+      }
+
+      githubImportSessions.delete(importSessionId);
+
+      res.json({ importedSkillId: targetSkillId, filesImported, warnings });
+    } catch (error: any) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: error.issues?.[0]?.message || 'Invalid payload' });
+      }
+      return handleError(res, error, 'Failed to apply GitHub import');
+    }
+  });
+
+  router.post('/skill-builder/session', async (req, res) => {
+    if (!ENABLE_SKILL_BUILDER_ASSISTANT) {
+      return res.status(404).json({ error: 'Skill Builder assistant is disabled' });
+    }
+    try {
+      const user = requireUserContext(req);
+      const workspaceId = await ensureSkillBuilderWorkspace(user);
+      res.json({
+        workspaceId,
+        limits: {
+          maxFileSize: CONTEXT_MAX_FILE_SIZE,
+          maxFiles: 50,
+        },
+        allowedExtensions: CONTEXT_ALLOWED_EXTENSIONS,
+      });
+    } catch (error) {
+      return handleError(res, error, 'Failed to create skill builder session');
+    }
+  });
+
+  router.get('/skill-builder/context-files', async (req, res) => {
+    try {
+      const user = requireUserContext(req);
+      res.json({ files: getContextFilesForUser(user.userId).map(({ absolutePath: _abs, userId: _uid, ...rest }) => rest) });
+    } catch (error) {
+      return handleError(res, error, 'Failed to load context files');
+    }
+  });
+
+  router.post('/skill-builder/context-files', upload.single('file'), async (req, res) => {
+    if (!ENABLE_SKILL_BUILDER_ASSISTANT) {
+      return res.status(404).json({ error: 'Skill Builder assistant is disabled' });
+    }
+    try {
+      const user = requireUserContext(req);
+      if (!req.file) {
+        return res.status(400).json({ error: 'No file uploaded' });
+      }
+
+      const originalName = req.file.originalname || 'upload.bin';
+      const ext = path.extname(originalName).toLowerCase();
+      if (!CONTEXT_ALLOWED_EXTENSIONS.includes(ext)) {
+        return res.status(400).json({ error: `Unsupported file extension: ${ext || '(none)'}` });
+      }
+
+      await fs.mkdir(path.join(contextFilesRoot, user.userId), { recursive: true });
+      const fileId = crypto.randomUUID();
+      const safeName = originalName.replace(/[^a-zA-Z0-9._-]/g, '_');
+      const relativePath = `${user.userId}/${fileId}-${safeName}`;
+      const absolutePath = path.join(contextFilesRoot, relativePath);
+      await fs.writeFile(absolutePath, req.file.buffer);
+
+      const meta: ContextFileMeta = {
+        fileId,
+        userId: user.userId,
+        name: safeName,
+        relativePath,
+        absolutePath,
+        size: req.file.size,
+        mimeType: req.file.mimetype || guessMimeType(safeName),
+        uploadedAt: new Date().toISOString(),
+      };
+
+      const existing = getContextFilesForUser(user.userId);
+      existing.push(meta);
+      setContextFilesForUser(user.userId, existing);
+
+      res.json({
+        fileId: meta.fileId,
+        name: meta.name,
+        relativePath: meta.relativePath,
+        size: meta.size,
+        mimeType: meta.mimeType,
+      });
+    } catch (error) {
+      return handleError(res, error, 'Failed to upload context file');
+    }
+  });
+
+  router.delete('/skill-builder/context-files/:fileId', async (req, res) => {
+    try {
+      const user = requireUserContext(req);
+      const files = getContextFilesForUser(user.userId);
+      const idx = files.findIndex((f) => f.fileId === req.params.fileId);
+      if (idx < 0) {
+        return res.status(404).json({ error: 'Context file not found' });
+      }
+      const [meta] = files.splice(idx, 1);
+      setContextFilesForUser(user.userId, files);
+      if (meta?.absolutePath && await pathExists(meta.absolutePath)) {
+        await fs.rm(meta.absolutePath, { force: true });
+      }
+      res.json({ success: true });
+    } catch (error) {
+      return handleError(res, error, 'Failed to delete context file');
+    }
+  });
+
+  router.post('/skill-builder/runs', async (req, res) => {
+    if (!ENABLE_SKILL_BUILDER_ASSISTANT) {
+      return res.status(404).json({ error: 'Skill Builder assistant is disabled' });
+    }
+    try {
+      const user = requireUserContext(req);
+      const payload = skillBuilderRunSchema.parse(req.body);
+      const workspaceId = await ensureSkillBuilderWorkspace(user);
+
+      const contextFiles = getContextFilesForUser(user.userId)
+        .filter((file) => !payload.contextFileIds?.length || payload.contextFileIds.includes(file.fileId));
+
+      if (contextFiles.length) {
+        const workspaceContextDir = path.join(workspaceRoot, workspaceId, 'context');
+        await fs.mkdir(workspaceContextDir, { recursive: true });
+        for (const file of contextFiles) {
+          const target = path.join(workspaceContextDir, file.name);
+          await fs.copyFile(file.absolutePath, target);
+        }
+      }
+
+      const contextLines: string[] = [];
+      if (payload.selectedSkillId) {
+        contextLines.push(`Selected skill target: ${payload.selectedSkillId}`);
+      }
+      if (contextFiles.length) {
+        contextLines.push('Attached context files (available in workspace /context):');
+        for (const file of contextFiles) {
+          contextLines.push(`- /context/${file.name}`);
+        }
+      }
+
+      const prompt = contextLines.length
+        ? `${payload.prompt}\n\n${contextLines.join('\n')}`
+        : payload.prompt;
+
+      let authToken: string | undefined;
+      if (ENABLE_SKILL_SCRIPT_RUNNER) {
+        const token = signAgentContextToken({
+          sub: user.userId,
+          userId: user.userId,
+          workspaceId,
+          isAdmin: true,
+          mcpServerAllowIds: [],
+          mcpServerDenyIds: [],
+          allowScriptRunner: true,
+        });
+        if (token) {
+          authToken = token;
+        }
+      }
+
+      const { runId, status } = await startAgentRun({
+        workspaceId,
+        persona: SKILL_BUILDER_PERSONA,
+        prompt,
+        history: payload.history,
+        forceReset: payload.forceReset,
+        turnId: payload.turnId,
+        authToken,
+      });
+
+      res.json({ runId, status, workspaceId, persona: SKILL_BUILDER_PERSONA });
+    } catch (error: any) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: error.issues?.[0]?.message || 'Invalid input' });
+      }
+      return handleError(res, error, 'Failed to start Skill Builder run');
+    }
+  });
+
+  router.get('/skill-builder/runs/:runId', async (req, res) => {
+    try {
+      requireUserContext(req);
+      const meta = await getRunMeta(req.params.runId);
+      if (!meta) {
+        return res.status(404).json({ error: 'Run not found' });
+      }
+      res.json(meta);
+    } catch (error) {
+      return handleError(res, error, 'Failed to fetch run status');
+    }
+  });
+
+  router.post('/skill-builder/runs/:runId/cancel', async (req, res) => {
+    try {
+      requireUserContext(req);
+      await cancelAgentRun(req.params.runId);
+      res.json({ status: 'cancelled' });
+    } catch (error) {
+      return handleError(res, error, 'Failed to cancel run');
+    }
+  });
+
+  router.post('/skill-builder/runs/:runId/decision', async (req, res) => {
+    try {
+      requireUserContext(req);
+      const payload = runDecisionSchema.parse(req.body);
+      const decisions = [
+        payload.decision === 'edit'
+          ? {
+              type: 'edit' as const,
+              edited_action: {
+                name: payload.editedAction?.name || 'request_plan_approval',
+                args: payload.editedAction?.args || {},
+              },
+              message: payload.message,
+            }
+          : payload.decision === 'reject'
+            ? { type: 'reject' as const, message: payload.message || 'Rejected by user' }
+            : { type: 'approve' as const },
+      ];
+      const result = await resumeAgentRun(req.params.runId, decisions);
+      res.json(result);
+    } catch (error: any) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: error.issues?.[0]?.message || 'Invalid input' });
+      }
+      return handleError(res, error, 'Failed to submit run decision');
+    }
+  });
+
+  router.get('/skill-builder/runs/:runId/stream', async (req, res) => {
+    const { runId } = req.params;
+    const after = typeof req.query.after === 'string' && req.query.after.trim() ? req.query.after : '0-0';
+    const abortController = new AbortController();
+
+    let streamKey: string | null = null;
+    let terminalStatus: 'completed' | 'failed' | 'cancelled' | 'awaiting_approval' | null = null;
+
+    try {
+      requireUserContext(req);
+      const meta = await getRunMeta(runId);
+      if (!meta) {
+        return res.status(404).json({ error: 'Run not found' });
+      }
+      streamKey = getRunStreamKey(runId);
+    } catch (error) {
+      if (error instanceof HttpError) {
+        return res.status(error.statusCode).json({ error: error.message });
+      }
+      return handleError(res, error, 'Failed to authorize run stream');
+    }
+
+    const cleanup = () => {
+      abortController.abort();
+    };
+
+    req.on('close', cleanup);
+    res.on('close', cleanup);
+
+    res.status(200);
+    res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Accel-Buffering', 'no');
+    (res as any).flushHeaders?.();
+
+    const readLoop = async () => {
+      if (!streamKey) return;
+      let lastId = after;
+      try {
+        while (!abortController.signal.aborted && !res.writableEnded) {
+          const streams = await blockingRedisClient.xRead(
+            { key: streamKey, id: lastId },
+            { BLOCK: 10000, COUNT: 50 },
+          );
+          if (streams && streams.length) {
+            for (const stream of streams) {
+              for (const message of stream.messages) {
+                const data = message.message.data;
+                if (data && !res.writableEnded) {
+                  let line = String(data);
+                  try {
+                    const parsed = JSON.parse(line);
+                    if (parsed && typeof parsed === 'object') {
+                      if (Array.isArray(parsed)) {
+                        line = JSON.stringify({ id: message.id, data: parsed });
+                      } else if (typeof (parsed as any).id !== 'string') {
+                        (parsed as any).id = message.id;
+                        line = JSON.stringify(parsed);
+                      }
+                    } else {
+                      line = JSON.stringify({ id: message.id, data: parsed });
+                    }
+                  } catch {
+                    // no-op
+                  }
+
+                  res.write(`${line}\n`);
+                }
+                lastId = message.id;
+              }
+            }
+          }
+
+          if (!streams || !streams.length) {
+            if (!res.writableEnded) {
+              res.write('{"type":"keepalive"}\n');
+            }
+          }
+
+          const meta = await getRunMeta(runId);
+          const status = meta?.status;
+          if (status && ['completed', 'failed', 'cancelled', 'awaiting_approval'].includes(status)) {
+            terminalStatus = status as typeof terminalStatus;
+          }
+
+          if (terminalStatus) {
+            if (terminalStatus !== 'awaiting_approval' && !res.writableEnded) {
+              res.write(JSON.stringify({ type: 'done', status: terminalStatus }) + '\n');
+            }
+            if (!res.writableEnded) {
+              res.end();
+            }
+            cleanup();
+            return;
+          }
+        }
+      } catch (error) {
+        if (!abortController.signal.aborted) {
+          console.error('Failed run stream loop', { runId, error });
+          if (!res.writableEnded) {
+            res.write(JSON.stringify({ type: 'error', message: 'Failed to read run stream' }) + '\n');
+            res.end();
+          }
+        }
+        cleanup();
+      }
+    };
+
+    void readLoop();
   });
 
   return router;

--- a/frontend/src/components/settings/SkillsRegistryTab.tsx
+++ b/frontend/src/components/settings/SkillsRegistryTab.tsx
@@ -1,14 +1,65 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Plus, RefreshCw, Loader2, Save, FolderOpen, AlertCircle, Search, ChevronRight } from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Plus,
+  RefreshCw,
+  Loader2,
+  Save,
+  FolderOpen,
+  AlertCircle,
+  Search,
+  ChevronRight,
+  MessageSquare,
+  Paperclip,
+  Upload,
+  X,
+  Wand2,
+  Github,
+  Play,
+  CheckCircle2,
+  Minimize2,
+  Maximize2,
+} from 'lucide-react';
 import Editor from '@monaco-editor/react';
 import {
+  applyGithubSkillImport,
+  applySkillBuilderActions,
+  cancelSkillBuilderRun,
   createSkill,
+  createSkillBuilderSession,
+  deleteSkillBuilderContextFile,
   fetchSkillContent,
   fetchSkillFiles,
   fetchSkills,
+  inspectGithubSkillImport,
+  listSkillBuilderContextFiles,
+  parseSkillBuilderActions,
   saveSkillContent,
+  startSkillBuilderRun,
+  streamSkillBuilderRun,
+  submitSkillBuilderDecision,
+  uploadSkillBuilderContextFile,
+  type GithubImportInspectResult,
+  type SkillBuilderAction,
+  type SkillBuilderContextFile,
 } from '../../services/settingsApi';
 import type { SkillDefinition } from '../../types';
+
+const BUILDER_COLLAPSED_KEY = 'settings.skillBuilder.collapsed';
+
+type ChatMessage = {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  text: string;
+  runId?: string;
+  createdAt: string;
+};
+
+const ACCEPT_UPLOADS = '.py,.md,.txt,.pdf,.csv,.json,.yaml,.yml,.png,.jpg,.jpeg,.webp,.gif,.svg';
+
+const makeId = () =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `id-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 
 const SkillsRegistryTab: React.FC = () => {
   const [skills, setSkills] = useState<SkillDefinition[]>([]);
@@ -33,6 +84,53 @@ const SkillsRegistryTab: React.FC = () => {
 
   const [searchTerm, setSearchTerm] = useState('');
 
+  const [builderCollapsed, setBuilderCollapsed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem(BUILDER_COLLAPSED_KEY) === '1';
+  });
+  const [builderReady, setBuilderReady] = useState(false);
+  const [builderWorkspaceId, setBuilderWorkspaceId] = useState<string>('');
+  const [builderMessages, setBuilderMessages] = useState<ChatMessage[]>([]);
+  const [builderPrompt, setBuilderPrompt] = useState('');
+  const [builderRunning, setBuilderRunning] = useState(false);
+  const [builderRunId, setBuilderRunId] = useState<string | null>(null);
+  const [builderError, setBuilderError] = useState<string | null>(null);
+  const [contextFiles, setContextFiles] = useState<SkillBuilderContextFile[]>([]);
+  const [contextUploading, setContextUploading] = useState(false);
+  const [selectedContextIds, setSelectedContextIds] = useState<string[]>([]);
+  const [proposedActions, setProposedActions] = useState<SkillBuilderAction[]>([]);
+  const [actionsError, setActionsError] = useState<string | null>(null);
+  const [applyingActionIndex, setApplyingActionIndex] = useState<number | null>(null);
+  const [applyingAll, setApplyingAll] = useState(false);
+
+  const [githubModalOpen, setGithubModalOpen] = useState(false);
+  const [githubUrl, setGithubUrl] = useState('');
+  const [githubRef, setGithubRef] = useState('');
+  const [githubToken, setGithubToken] = useState('');
+  const [githubInspectLoading, setGithubInspectLoading] = useState(false);
+  const [githubApplyLoading, setGithubApplyLoading] = useState(false);
+  const [githubInspectResult, setGithubInspectResult] = useState<GithubImportInspectResult | null>(null);
+  const [githubImportError, setGithubImportError] = useState<string | null>(null);
+
+  const attachmentInputRef = useRef<HTMLInputElement | null>(null);
+  const streamAbortRef = useRef<AbortController | null>(null);
+
+  const selectedSkill = useMemo(
+    () => skills.find((skill) => skill.id === selectedSkillId) || null,
+    [skills, selectedSkillId],
+  );
+
+  const filteredSkills = useMemo(() => {
+    if (!searchTerm) return skills;
+    const lower = searchTerm.toLowerCase();
+    return skills.filter(
+      (s) =>
+        s.id.toLowerCase().includes(lower)
+        || (s.name && s.name.toLowerCase().includes(lower))
+        || (s.description && s.description.toLowerCase().includes(lower)),
+    );
+  }, [skills, searchTerm]);
+
   const loadSkills = useCallback(async () => {
     try {
       setLoading(true);
@@ -47,9 +145,33 @@ const SkillsRegistryTab: React.FC = () => {
     }
   }, []);
 
+  const loadContextFiles = useCallback(async () => {
+    try {
+      const filesList = await listSkillBuilderContextFiles();
+      setContextFiles(filesList);
+      setSelectedContextIds((prev) => prev.filter((id) => filesList.some((f) => f.fileId === id)));
+    } catch (err) {
+      console.error('Failed to load context files', err);
+    }
+  }, []);
+
+  const setupBuilderSession = useCallback(async () => {
+    try {
+      const session = await createSkillBuilderSession();
+      setBuilderWorkspaceId(session.workspaceId);
+      setBuilderReady(true);
+      setBuilderError(null);
+      await loadContextFiles();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to initialize Skill Builder';
+      setBuilderError(message);
+    }
+  }, [loadContextFiles]);
+
   useEffect(() => {
     loadSkills();
-  }, [loadSkills]);
+    setupBuilderSession();
+  }, [loadSkills, setupBuilderSession]);
 
   useEffect(() => {
     if (!selectedSkillId && skills.length > 0) {
@@ -68,9 +190,8 @@ const SkillsRegistryTab: React.FC = () => {
         setFilesLoading(true);
         const data = await fetchSkillFiles(selectedSkillId);
         setFiles(data);
-        // Auto-select the main file (SKILL.md preferred, then README.md, then first file)
         if (data.length > 0) {
-          const preferred = data.find(f => f === 'SKILL.md') || data.find(f => f === 'README.md') || data[0];
+          const preferred = data.find((f) => f === 'SKILL.md') || data[0];
           setSelectedFile(preferred);
         } else {
           setSelectedFile(null);
@@ -82,8 +203,7 @@ const SkillsRegistryTab: React.FC = () => {
         setFilesLoading(false);
       }
     };
-
-    loadFiles();
+    void loadFiles();
   }, [selectedSkillId]);
 
   useEffect(() => {
@@ -103,24 +223,17 @@ const SkillsRegistryTab: React.FC = () => {
         setFileLoading(false);
       }
     };
-
-    loadContent();
+    void loadContent();
   }, [selectedSkillId, selectedFile]);
 
-  const selectedSkill = useMemo(
-    () => skills.find((skill) => skill.id === selectedSkillId) || null,
-    [skills, selectedSkillId]
-  );
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(BUILDER_COLLAPSED_KEY, builderCollapsed ? '1' : '0');
+  }, [builderCollapsed]);
 
-  const filteredSkills = useMemo(() => {
-    if (!searchTerm) return skills;
-    const lower = searchTerm.toLowerCase();
-    return skills.filter(s =>
-      s.id.toLowerCase().includes(lower) ||
-      (s.name && s.name.toLowerCase().includes(lower)) ||
-      (s.description && s.description.toLowerCase().includes(lower))
-    );
-  }, [skills, searchTerm]);
+  useEffect(() => () => {
+    streamAbortRef.current?.abort();
+  }, []);
 
   const handleCreateSkill = async () => {
     if (!newId) {
@@ -139,7 +252,6 @@ const SkillsRegistryTab: React.FC = () => {
       setNewName('');
       setNewDesc('');
     } catch (err) {
-      console.error('Failed to create skill', err);
       const message = err instanceof Error ? err.message : 'Failed to create skill';
       setCreateError(message);
     } finally {
@@ -148,14 +260,11 @@ const SkillsRegistryTab: React.FC = () => {
   };
 
   const handleSaveFile = async () => {
-    if (!selectedSkillId || !selectedFile) {
-      return;
-    }
+    if (!selectedSkillId || !selectedFile) return;
     try {
       setFileSaving(true);
       await saveSkillContent(selectedSkillId, selectedFile, fileContent);
     } catch (err) {
-      console.error('Failed to save skill file', err);
       const message = err instanceof Error ? err.message : 'Failed to save skill file';
       alert(message);
     } finally {
@@ -173,6 +282,288 @@ const SkillsRegistryTab: React.FC = () => {
     if (fileName.endsWith('.css')) return 'css';
     if (fileName.endsWith('.html')) return 'html';
     return 'plaintext';
+  };
+
+  const appendMessage = (message: ChatMessage) => {
+    setBuilderMessages((prev) => [...prev, message]);
+  };
+
+  const updateAssistantMessage = (runId: string, content: string) => {
+    setBuilderMessages((prev) => {
+      const idx = prev.findIndex((m) => m.runId === runId && m.role === 'assistant');
+      if (idx < 0) {
+        return [...prev, { id: makeId(), role: 'assistant', text: content, runId, createdAt: new Date().toISOString() }];
+      }
+      const updated = [...prev];
+      updated[idx] = { ...updated[idx], text: content };
+      return updated;
+    });
+  };
+
+  const parseActionsFromMessages = useCallback(async () => {
+    const assistantText = [...builderMessages]
+      .reverse()
+      .find((msg) => msg.role === 'assistant' && msg.text.trim())
+      ?.text;
+
+    if (!assistantText) {
+      setActionsError('No assistant output to parse actions from.');
+      return;
+    }
+
+    try {
+      setActionsError(null);
+      const actions = await parseSkillBuilderActions(assistantText);
+      setProposedActions(actions);
+      if (!actions.length) {
+        setActionsError('No actions found in assistant output.');
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to parse actions';
+      setActionsError(message);
+    }
+  }, [builderMessages]);
+
+  const handleSendPrompt = async () => {
+    if (!builderPrompt.trim() || !builderReady || builderRunning) return;
+
+    const prompt = builderPrompt.trim();
+    setBuilderPrompt('');
+    setBuilderError(null);
+    setActionsError(null);
+
+    appendMessage({ id: makeId(), role: 'user', text: prompt, createdAt: new Date().toISOString() });
+
+    try {
+      setBuilderRunning(true);
+      const run = await startSkillBuilderRun({
+        prompt,
+        selectedSkillId: selectedSkillId || undefined,
+        contextFileIds: selectedContextIds,
+        history: builderMessages.map((msg) => ({
+          role: msg.role === 'assistant' ? 'assistant' : 'user',
+          content: msg.text,
+        })),
+      });
+
+      setBuilderRunId(run.runId);
+
+      const controller = new AbortController();
+      streamAbortRef.current = controller;
+      let assistantBuffer = '';
+
+      await streamSkillBuilderRun(
+        run.runId,
+        async (chunk) => {
+          if (chunk.type === 'token' || chunk.type === 'chunk' || chunk.type === 'thought' || chunk.type === 'tool_end' || chunk.type === 'tool_start' || chunk.type === 'tool_error') {
+            const text = (chunk as { content?: string }).content || '';
+            if (text) {
+              assistantBuffer += text;
+              updateAssistantMessage(run.runId, assistantBuffer);
+            }
+          } else if (chunk.type === 'interrupt') {
+            appendMessage({
+              id: makeId(),
+              role: 'system',
+              runId: run.runId,
+              text: 'Approval required. Use Approve / Reject below to continue.',
+              createdAt: new Date().toISOString(),
+            });
+          } else if (chunk.type === 'error') {
+            appendMessage({
+              id: makeId(),
+              role: 'system',
+              runId: run.runId,
+              text: chunk.message || 'Run failed',
+              createdAt: new Date().toISOString(),
+            });
+          } else if (chunk.type === 'done') {
+            if (!assistantBuffer.trim()) {
+              appendMessage({
+                id: makeId(),
+                role: 'assistant',
+                runId: run.runId,
+                text: '(Done)',
+                createdAt: new Date().toISOString(),
+              });
+            } else {
+              try {
+                setActionsError(null);
+                const actions = await parseSkillBuilderActions(assistantBuffer);
+                setProposedActions(actions);
+              } catch {
+                // Best-effort parse from current stream payload; fallback to full message parse below.
+              }
+            }
+            await parseActionsFromMessages();
+          }
+        },
+        controller.signal,
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to run Skill Builder';
+      setBuilderError(message);
+      appendMessage({ id: makeId(), role: 'system', text: message, createdAt: new Date().toISOString() });
+    } finally {
+      setBuilderRunning(false);
+      setBuilderRunId(null);
+      streamAbortRef.current = null;
+    }
+  };
+
+  const handleRunDecision = async (decision: 'approve' | 'reject') => {
+    if (!builderRunId) return;
+    try {
+      await submitSkillBuilderDecision(builderRunId, decision);
+      appendMessage({
+        id: makeId(),
+        role: 'system',
+        text: decision === 'approve' ? 'Approval submitted.' : 'Rejection submitted.',
+        createdAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to submit decision';
+      setBuilderError(message);
+    }
+  };
+
+  const handleCancelRun = async () => {
+    if (!builderRunId) return;
+    try {
+      await cancelSkillBuilderRun(builderRunId);
+      streamAbortRef.current?.abort();
+      setBuilderRunning(false);
+      setBuilderRunId(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to cancel run';
+      setBuilderError(message);
+    }
+  };
+
+  const handleContextUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const filesList = event.target.files;
+    if (!filesList || filesList.length === 0) return;
+
+    const file = filesList[0];
+    try {
+      setContextUploading(true);
+      const uploaded = await uploadSkillBuilderContextFile(file);
+      setContextFiles((prev) => [...prev, uploaded]);
+      setSelectedContextIds((prev) => [...prev, uploaded.fileId]);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to upload context file';
+      setBuilderError(message);
+    } finally {
+      setContextUploading(false);
+      event.target.value = '';
+    }
+  };
+
+  const handleDeleteContextFile = async (fileId: string) => {
+    try {
+      await deleteSkillBuilderContextFile(fileId);
+      setContextFiles((prev) => prev.filter((f) => f.fileId !== fileId));
+      setSelectedContextIds((prev) => prev.filter((id) => id !== fileId));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to delete context file';
+      setBuilderError(message);
+    }
+  };
+
+  const toggleContextSelection = (fileId: string) => {
+    setSelectedContextIds((prev) => (prev.includes(fileId)
+      ? prev.filter((id) => id !== fileId)
+      : [...prev, fileId]));
+  };
+
+  const applyAction = async (action: SkillBuilderAction, index: number) => {
+    setApplyingActionIndex(index);
+    setActionsError(null);
+    try {
+      const result = await applySkillBuilderActions([action]);
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to apply action');
+      }
+      await loadSkills();
+      if (action.skillId) {
+        setSelectedSkillId(action.skillId);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to apply action';
+      setActionsError(message);
+    } finally {
+      setApplyingActionIndex(null);
+    }
+  };
+
+  const applyAllActions = async () => {
+    if (!proposedActions.length) return;
+    setApplyingAll(true);
+    setActionsError(null);
+    try {
+      const result = await applySkillBuilderActions(proposedActions);
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to apply actions');
+      }
+      await loadSkills();
+      const createAction = proposedActions.find((a) => a.type === 'create_skill');
+      if (createAction?.skillId) {
+        setSelectedSkillId(createAction.skillId);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to apply actions';
+      setActionsError(message);
+    } finally {
+      setApplyingAll(false);
+    }
+  };
+
+  const handleGithubInspect = async () => {
+    if (!githubUrl.trim()) {
+      setGithubImportError('GitHub URL is required');
+      return;
+    }
+
+    try {
+      setGithubInspectLoading(true);
+      setGithubImportError(null);
+      const result = await inspectGithubSkillImport({
+        url: githubUrl.trim(),
+        ref: githubRef.trim() || undefined,
+        githubToken: githubToken.trim() || undefined,
+      });
+      setGithubInspectResult(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to inspect GitHub source';
+      setGithubImportError(message);
+      setGithubInspectResult(null);
+    } finally {
+      setGithubInspectLoading(false);
+    }
+  };
+
+  const handleGithubApply = async () => {
+    if (!githubInspectResult) return;
+    try {
+      setGithubApplyLoading(true);
+      setGithubImportError(null);
+      const result = await applyGithubSkillImport({
+        importSessionId: githubInspectResult.importSessionId,
+        onCollision: 'copy',
+      });
+      await loadSkills();
+      setSelectedSkillId(result.importedSkillId);
+      setGithubModalOpen(false);
+      setGithubInspectResult(null);
+      setGithubUrl('');
+      setGithubRef('');
+      setGithubToken('');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to import skill';
+      setGithubImportError(message);
+    } finally {
+      setGithubApplyLoading(false);
+    }
   };
 
   if (loading) {
@@ -201,145 +592,330 @@ const SkillsRegistryTab: React.FC = () => {
   }
 
   return (
-    <div style={{ height: 'calc(100vh - 280px)', minHeight: '550px' }} className="flex gap-5">
-      {/* Left Sidebar - Skills List */}
-      <div className="w-72 flex-shrink-0 flex flex-col bg-white border border-slate-200 rounded-xl overflow-hidden">
-        {/* Sidebar Header */}
-        <div className="p-3 border-b border-slate-200 bg-slate-50">
-          <div className="flex items-center justify-between mb-3">
-            <span className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Skills</span>
-            <div className="flex items-center gap-1">
+    <div style={{ height: 'calc(100vh - 260px)', minHeight: '620px' }} className="flex gap-4">
+      <div className={`${builderCollapsed ? 'w-12' : 'w-[390px]'} flex-shrink-0 border border-slate-200 rounded-xl bg-white flex flex-col overflow-hidden`}>
+        <div className="px-3 py-2 border-b border-slate-200 bg-slate-50 flex items-center justify-between">
+          {!builderCollapsed && (
+            <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+              <MessageSquare size={16} />
+              Skill Builder
+            </div>
+          )}
+          <button
+            onClick={() => setBuilderCollapsed((prev) => !prev)}
+            className="p-1.5 text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded"
+            title={builderCollapsed ? 'Expand Skill Builder' : 'Collapse Skill Builder'}
+          >
+            {builderCollapsed ? <Maximize2 size={14} /> : <Minimize2 size={14} />}
+          </button>
+        </div>
+
+        {!builderCollapsed && (
+          <>
+            <div className="px-3 py-2 border-b border-slate-200 bg-slate-50 flex items-center justify-between gap-2">
+              <div className="text-xs text-slate-500 truncate">
+                {builderReady ? `Workspace: ${builderWorkspaceId}` : 'Initializing session...'}
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => setGithubModalOpen(true)}
+                  className="inline-flex items-center gap-1 px-2 py-1 text-xs border border-slate-300 rounded hover:bg-slate-100"
+                >
+                  <Github size={13} />
+                  Import
+                </button>
+                <button
+                  type="button"
+                  onClick={parseActionsFromMessages}
+                  className="inline-flex items-center gap-1 px-2 py-1 text-xs border border-slate-300 rounded hover:bg-slate-100"
+                >
+                  <Wand2 size={13} />
+                  Parse Actions
+                </button>
+              </div>
+            </div>
+
+            <div className="px-3 py-2 border-b border-slate-200">
+              <div className="flex items-center gap-2 mb-2 text-xs text-slate-600">
+                <Paperclip size={13} />
+                Context Files
+              </div>
+              <div className="flex items-center gap-2 mb-2">
+                <button
+                  type="button"
+                  disabled={contextUploading}
+                  onClick={() => attachmentInputRef.current?.click()}
+                  className="inline-flex items-center gap-1 px-2 py-1 text-xs bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-60"
+                >
+                  {contextUploading ? <Loader2 size={12} className="animate-spin" /> : <Upload size={12} />}
+                  Upload
+                </button>
+                <input
+                  ref={attachmentInputRef}
+                  type="file"
+                  className="hidden"
+                  accept={ACCEPT_UPLOADS}
+                  onChange={handleContextUpload}
+                />
+              </div>
+              <div className="space-y-1 max-h-24 overflow-y-auto">
+                {contextFiles.map((file) => (
+                  <div key={file.fileId} className="flex items-center justify-between gap-2 text-xs border border-slate-200 rounded px-2 py-1">
+                    <label className="flex items-center gap-2 min-w-0 flex-1 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={selectedContextIds.includes(file.fileId)}
+                        onChange={() => toggleContextSelection(file.fileId)}
+                      />
+                      <span className="truncate" title={file.name}>{file.name}</span>
+                    </label>
+                    <button
+                      type="button"
+                      onClick={() => void handleDeleteContextFile(file.fileId)}
+                      className="text-slate-400 hover:text-rose-600"
+                      title="Remove"
+                    >
+                      <X size={12} />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex-1 overflow-y-auto p-3 space-y-2 bg-slate-50">
+              {builderMessages.map((msg) => (
+                <div
+                  key={msg.id}
+                  className={`rounded-lg px-3 py-2 text-sm whitespace-pre-wrap ${msg.role === 'user'
+                    ? 'bg-blue-600 text-white ml-6'
+                    : msg.role === 'assistant'
+                      ? 'bg-white border border-slate-200 mr-2'
+                      : 'bg-amber-50 border border-amber-200 text-amber-800'
+                    }`}
+                >
+                  {msg.text}
+                </div>
+              ))}
+              {builderRunning && (
+                <div className="rounded-lg px-3 py-2 text-sm bg-white border border-slate-200 text-slate-500 flex items-center gap-2">
+                  <Loader2 size={14} className="animate-spin" />
+                  Running...
+                </div>
+              )}
+            </div>
+
+            <div className="border-t border-slate-200 p-3 bg-white space-y-2">
+              {builderError && <p className="text-xs text-rose-600">{builderError}</p>}
+              {builderRunId && (
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void handleRunDecision('approve')}
+                    className="px-2 py-1 text-xs bg-emerald-600 text-white rounded hover:bg-emerald-700"
+                  >
+                    Approve
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleRunDecision('reject')}
+                    className="px-2 py-1 text-xs bg-rose-600 text-white rounded hover:bg-rose-700"
+                  >
+                    Reject
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleCancelRun()}
+                    className="px-2 py-1 text-xs border border-slate-300 rounded hover:bg-slate-100"
+                  >
+                    Cancel Run
+                  </button>
+                </div>
+              )}
+              <textarea
+                value={builderPrompt}
+                onChange={(e) => setBuilderPrompt(e.target.value)}
+                placeholder="Ask Skill Builder to create/update skills. It can propose actions for Apply."
+                rows={3}
+                className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-slate-500"
+              />
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  disabled={!builderReady || builderRunning || !builderPrompt.trim()}
+                  onClick={() => void handleSendPrompt()}
+                  className="inline-flex items-center gap-1 px-3 py-1.5 text-sm bg-slate-900 text-white rounded-lg hover:bg-slate-800 disabled:opacity-60"
+                >
+                  <Play size={14} />
+                  Send
+                </button>
+              </div>
+            </div>
+
+            <div className="border-t border-slate-200 p-3 bg-white">
+              <div className="flex items-center justify-between mb-2">
+                <div className="text-xs font-semibold text-slate-600 uppercase tracking-wide">Proposed Actions</div>
+                <button
+                  type="button"
+                  disabled={!proposedActions.length || applyingAll}
+                  onClick={() => void applyAllActions()}
+                  className="inline-flex items-center gap-1 px-2 py-1 text-xs bg-emerald-600 text-white rounded hover:bg-emerald-700 disabled:opacity-60"
+                >
+                  {applyingAll ? <Loader2 size={12} className="animate-spin" /> : <CheckCircle2 size={12} />}
+                  Apply All
+                </button>
+              </div>
+              {actionsError && <p className="text-xs text-rose-600 mb-2">{actionsError}</p>}
+              <div className="space-y-2 max-h-40 overflow-y-auto">
+                {proposedActions.map((action, index) => (
+                  <div key={`${action.type}-${index}`} className="border border-slate-200 rounded p-2 bg-slate-50">
+                    <div className="text-xs font-medium text-slate-700 mb-1">{action.type}</div>
+                    <pre className="text-[11px] text-slate-600 whitespace-pre-wrap max-h-20 overflow-y-auto">{JSON.stringify(action, null, 2)}</pre>
+                    <div className="mt-2 flex justify-end">
+                      <button
+                        type="button"
+                        disabled={applyingActionIndex === index}
+                        onClick={() => void applyAction(action, index)}
+                        className="px-2 py-1 text-xs border border-slate-300 rounded hover:bg-white disabled:opacity-60"
+                      >
+                        {applyingActionIndex === index ? 'Applying...' : 'Apply'}
+                      </button>
+                    </div>
+                  </div>
+                ))}
+                {!proposedActions.length && (
+                  <p className="text-xs text-slate-500">No actions parsed yet.</p>
+                )}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      <div className="flex-1 min-w-0 flex gap-4">
+        <div className="w-72 flex-shrink-0 flex flex-col bg-white border border-slate-200 rounded-xl overflow-hidden">
+          <div className="p-3 border-b border-slate-200 bg-slate-50">
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Skills</span>
               <button
-                onClick={loadSkills}
+                onClick={() => void loadSkills()}
                 className="p-1.5 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-md transition-colors"
                 title="Refresh"
               >
                 <RefreshCw size={14} />
               </button>
             </div>
-          </div>
-          {/* Search */}
-          <div className="relative mb-2">
-            <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-400" />
-            <input
-              type="text"
-              placeholder="Search..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-8 pr-3 py-1.5 bg-white border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-slate-400 transition-all"
-            />
-          </div>
-          {/* Add Skill Button */}
-          <button
-            onClick={() => {
-              setIsAdding(true);
-              setCreateError(null);
-              setNewId('');
-              setNewName('');
-              setNewDesc('');
-            }}
-            className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-slate-900 text-white rounded-lg text-sm font-medium hover:bg-slate-800 transition-colors"
-          >
-            <Plus size={16} />
-            Add Skill
-          </button>
-        </div>
-
-        {/* Add Skill Form (inline) */}
-        {isAdding && (
-          <div className="p-3 border-b border-slate-200 bg-amber-50">
-            <div className="space-y-2">
+            <div className="relative mb-2">
+              <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-400" />
               <input
                 type="text"
-                value={newId}
-                onChange={(e) => setNewId(e.target.value)}
-                placeholder="skill-id *"
-                className="w-full px-2.5 py-1.5 rounded-md border border-slate-300 text-sm font-mono bg-white focus:outline-none focus:ring-1 focus:ring-amber-500"
+                placeholder="Search..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="w-full pl-8 pr-3 py-1.5 bg-white border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-slate-400 transition-all"
               />
-              <input
-                type="text"
-                value={newName}
-                onChange={(e) => setNewName(e.target.value)}
-                placeholder="Display Name"
-                className="w-full px-2.5 py-1.5 rounded-md border border-slate-300 text-sm bg-white focus:outline-none focus:ring-1 focus:ring-amber-500"
-              />
-              <input
-                type="text"
-                value={newDesc}
-                onChange={(e) => setNewDesc(e.target.value)}
-                placeholder="Description"
-                className="w-full px-2.5 py-1.5 rounded-md border border-slate-300 text-sm bg-white focus:outline-none focus:ring-1 focus:ring-amber-500"
-              />
-              {createError && <p className="text-xs text-rose-600">{createError}</p>}
-              <div className="flex gap-2">
-                <button
-                  onClick={() => setIsAdding(false)}
-                  className="flex-1 px-2 py-1.5 text-slate-600 text-sm hover:bg-slate-100 rounded-md transition-colors"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleCreateSkill}
-                  disabled={createLoading}
-                  className="flex-1 flex items-center justify-center gap-1 px-2 py-1.5 bg-emerald-600 text-white text-sm rounded-md hover:bg-emerald-700 transition-colors disabled:opacity-50"
-                >
-                  {createLoading ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
-                  Create
-                </button>
-              </div>
             </div>
-          </div>
-        )}
-
-        {/* Skills List */}
-        <div className="flex-1 overflow-y-auto p-2 space-y-1">
-          {filteredSkills.map((skill) => (
             <button
-              key={skill.id}
-              onClick={() => setSelectedSkillId(skill.id)}
-              className={`w-full text-left p-2.5 rounded-lg border transition-all ${selectedSkillId === skill.id
-                ? 'border-slate-400 bg-slate-100'
-                : 'border-transparent hover:bg-slate-50'
-                }`}
+              onClick={() => {
+                setIsAdding(true);
+                setCreateError(null);
+                setNewId('');
+                setNewName('');
+                setNewDesc('');
+              }}
+              className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-slate-900 text-white rounded-lg text-sm font-medium hover:bg-slate-800 transition-colors"
             >
-              <div className="flex items-center gap-2">
-                {/* Status Dot */}
-                <span className={`w-2 h-2 rounded-full flex-shrink-0 ${skill.valid ? 'bg-emerald-500' : 'bg-amber-500'}`} />
-                <span className="font-medium text-slate-900 truncate text-sm">{skill.name || skill.id}</span>
-              </div>
-              <p className="text-xs font-mono text-slate-400 mt-0.5 ml-4">{skill.id}</p>
-              {skill.description && (
-                <p className="text-xs text-slate-500 mt-1 ml-4 line-clamp-2">{skill.description}</p>
-              )}
+              <Plus size={16} />
+              Add Skill
             </button>
-          ))}
-          {filteredSkills.length === 0 && (
-            <div className="text-center py-8 text-slate-400 text-sm">
-              {searchTerm ? 'No skills match your search.' : 'No skills yet.'}
+          </div>
+
+          {isAdding && (
+            <div className="p-3 border-b border-slate-200 bg-amber-50">
+              <div className="space-y-2">
+                <input
+                  type="text"
+                  value={newId}
+                  onChange={(e) => setNewId(e.target.value)}
+                  placeholder="skill-id *"
+                  className="w-full px-2.5 py-1.5 rounded-md border border-slate-300 text-sm font-mono bg-white focus:outline-none focus:ring-1 focus:ring-amber-500"
+                />
+                <input
+                  type="text"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="Display Name"
+                  className="w-full px-2.5 py-1.5 rounded-md border border-slate-300 text-sm bg-white focus:outline-none focus:ring-1 focus:ring-amber-500"
+                />
+                <input
+                  type="text"
+                  value={newDesc}
+                  onChange={(e) => setNewDesc(e.target.value)}
+                  placeholder="Description"
+                  className="w-full px-2.5 py-1.5 rounded-md border border-slate-300 text-sm bg-white focus:outline-none focus:ring-1 focus:ring-amber-500"
+                />
+                {createError && <p className="text-xs text-rose-600">{createError}</p>}
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setIsAdding(false)}
+                    className="flex-1 px-2 py-1.5 text-slate-600 text-sm hover:bg-slate-100 rounded-md transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={() => void handleCreateSkill()}
+                    disabled={createLoading}
+                    className="flex-1 flex items-center justify-center gap-1 px-2 py-1.5 bg-emerald-600 text-white text-sm rounded-md hover:bg-emerald-700 transition-colors disabled:opacity-50"
+                  >
+                    {createLoading ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+                    Create
+                  </button>
+                </div>
+              </div>
             </div>
           )}
-        </div>
-      </div>
 
-      {/* Right Panel - Editor Area */}
-      <div className="flex-1 flex flex-col bg-white border border-slate-200 rounded-xl overflow-hidden">
-        {selectedSkill ? (
-          <>
-            {/* Editor Header / Toolbar */}
-            <div className="flex items-center justify-between px-4 py-2.5 border-b border-slate-200 bg-slate-50">
-              <div className="flex items-center gap-2 min-w-0">
-                {/* Breadcrumb */}
-                <span className="font-medium text-slate-700 truncate">{selectedSkill.name || selectedSkill.id}</span>
-                {selectedFile && (
-                  <>
-                    <ChevronRight size={14} className="text-slate-400 flex-shrink-0" />
-                    <span className="text-sm font-mono text-slate-500 truncate">{selectedFile}</span>
-                  </>
-                )}
+          <div className="flex-1 overflow-y-auto p-2 space-y-1">
+            {filteredSkills.map((skill) => (
+              <button
+                key={skill.id}
+                onClick={() => setSelectedSkillId(skill.id)}
+                className={`w-full text-left p-2.5 rounded-lg border transition-all ${selectedSkillId === skill.id
+                  ? 'border-slate-400 bg-slate-100'
+                  : 'border-transparent hover:bg-slate-50'
+                  }`}
+              >
+                <div className="flex items-center gap-2">
+                  <span className={`w-2 h-2 rounded-full flex-shrink-0 ${skill.valid ? 'bg-emerald-500' : 'bg-amber-500'}`} />
+                  <span className="font-medium text-slate-900 truncate text-sm">{skill.name || skill.id}</span>
+                </div>
+                <p className="text-xs font-mono text-slate-400 mt-0.5 ml-4">{skill.id}</p>
+                {skill.description && <p className="text-xs text-slate-500 mt-1 ml-4 line-clamp-2">{skill.description}</p>}
+              </button>
+            ))}
+            {filteredSkills.length === 0 && (
+              <div className="text-center py-8 text-slate-400 text-sm">
+                {searchTerm ? 'No skills match your search.' : 'No skills yet.'}
               </div>
-              <div className="flex items-center gap-2 flex-shrink-0">
+            )}
+          </div>
+        </div>
+
+        <div className="flex-1 flex flex-col bg-white border border-slate-200 rounded-xl overflow-hidden">
+          {selectedSkill ? (
+            <>
+              <div className="flex items-center justify-between px-4 py-2.5 border-b border-slate-200 bg-slate-50">
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="font-medium text-slate-700 truncate">{selectedSkill.name || selectedSkill.id}</span>
+                  {selectedFile && (
+                    <>
+                      <ChevronRight size={14} className="text-slate-400 flex-shrink-0" />
+                      <span className="text-sm font-mono text-slate-500 truncate">{selectedFile}</span>
+                    </>
+                  )}
+                </div>
                 <button
-                  onClick={handleSaveFile}
+                  onClick={() => void handleSaveFile()}
                   disabled={!selectedFile || fileSaving}
                   className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-emerald-600 text-white rounded-md hover:bg-emerald-700 disabled:opacity-50 transition-colors font-medium"
                 >
@@ -347,87 +923,145 @@ const SkillsRegistryTab: React.FC = () => {
                   Save
                 </button>
               </div>
-            </div>
 
-            {/* Main Content Area */}
-            <div className="flex-1 flex min-h-0">
-              {/* Files Sidebar (thin) */}
-              <div className="w-40 flex-shrink-0 border-r border-slate-200 bg-slate-50 flex flex-col">
-                <div className="p-2 border-b border-slate-100">
-                  <div className="flex items-center gap-1.5 text-[10px] font-semibold text-slate-400 uppercase tracking-wider">
-                    <FolderOpen size={12} />
-                    Files
+              <div className="flex-1 flex min-h-0">
+                <div className="w-40 flex-shrink-0 border-r border-slate-200 bg-slate-50 flex flex-col">
+                  <div className="p-2 border-b border-slate-100">
+                    <div className="flex items-center gap-1.5 text-[10px] font-semibold text-slate-400 uppercase tracking-wider">
+                      <FolderOpen size={12} />
+                      Files
+                    </div>
                   </div>
+                  {filesLoading ? (
+                    <div className="flex-1 flex items-center justify-center">
+                      <Loader2 size={16} className="animate-spin text-slate-400" />
+                    </div>
+                  ) : (
+                    <div className="flex-1 overflow-y-auto py-1">
+                      {files.map((file) => (
+                        <button
+                          key={file}
+                          onClick={() => setSelectedFile(file)}
+                          className={`w-full text-left px-3 py-1.5 text-xs transition-colors truncate ${selectedFile === file
+                            ? 'bg-white text-emerald-700 font-medium border-l-2 border-emerald-500'
+                            : 'text-slate-600 hover:bg-slate-100 border-l-2 border-transparent'
+                            }`}
+                          title={file}
+                        >
+                          {file}
+                        </button>
+                      ))}
+                    </div>
+                  )}
                 </div>
-                {filesLoading ? (
-                  <div className="flex-1 flex items-center justify-center">
-                    <Loader2 size={16} className="animate-spin text-slate-400" />
-                  </div>
-                ) : (
-                  <div className="flex-1 overflow-y-auto py-1">
-                    {files.map((file) => (
-                      <button
-                        key={file}
-                        onClick={() => setSelectedFile(file)}
-                        className={`w-full text-left px-3 py-1.5 text-xs transition-colors truncate ${selectedFile === file
-                          ? 'bg-white text-emerald-700 font-medium border-l-2 border-emerald-500'
-                          : 'text-slate-600 hover:bg-slate-100 border-l-2 border-transparent'
-                          }`}
-                        title={file}
-                      >
-                        {file}
-                      </button>
-                    ))}
-                    {files.length === 0 && (
-                      <p className="text-xs text-slate-400 p-3 text-center italic">No files</p>
-                    )}
-                  </div>
-                )}
-              </div>
 
-              {/* Code Editor */}
-              <div className="flex-1 relative bg-[#1e1e1e]">
-                {fileLoading ? (
-                  <div className="absolute inset-0 flex items-center justify-center bg-[#1e1e1e]">
-                    <Loader2 size={24} className="animate-spin text-slate-500" />
-                  </div>
-                ) : selectedFile ? (
-                  <Editor
-                    height="100%"
-                    theme="vs-dark"
-                    language={getLanguage(selectedFile)}
-                    value={fileContent}
-                    onChange={(value) => setFileContent(value || '')}
-                    options={{
-                      minimap: { enabled: false },
-                      fontSize: 13,
-                      lineHeight: 20,
-                      wordWrap: 'on',
-                      scrollBeyondLastLine: false,
-                      automaticLayout: true,
-                      padding: { top: 12, bottom: 12 },
-                      lineNumbers: 'on',
-                      renderLineHighlight: 'line',
-                      cursorBlinking: 'smooth',
-                      smoothScrolling: true,
-                    }}
-                  />
-                ) : (
-                  <div className="flex flex-col items-center justify-center h-full text-slate-500 bg-slate-100">
-                    <p className="text-sm">Select a file to edit</p>
-                  </div>
-                )}
+                <div className="flex-1 relative bg-[#1e1e1e]">
+                  {fileLoading ? (
+                    <div className="absolute inset-0 flex items-center justify-center bg-[#1e1e1e]">
+                      <Loader2 size={24} className="animate-spin text-slate-500" />
+                    </div>
+                  ) : selectedFile ? (
+                    <Editor
+                      height="100%"
+                      theme="vs-dark"
+                      language={getLanguage(selectedFile)}
+                      value={fileContent}
+                      onChange={(value) => setFileContent(value || '')}
+                      options={{
+                        minimap: { enabled: false },
+                        fontSize: 13,
+                        lineHeight: 20,
+                        wordWrap: 'on',
+                        scrollBeyondLastLine: false,
+                        automaticLayout: true,
+                        padding: { top: 12, bottom: 12 },
+                      }}
+                    />
+                  ) : (
+                    <div className="flex flex-col items-center justify-center h-full text-slate-500 bg-slate-100">
+                      <p className="text-sm">Select a file to edit</p>
+                    </div>
+                  )}
+                </div>
               </div>
+            </>
+          ) : (
+            <div className="flex-1 flex flex-col items-center justify-center text-slate-400 bg-slate-50">
+              <FolderOpen size={40} className="mb-3 opacity-20" />
+              <p className="font-medium text-slate-500">No skill selected</p>
             </div>
-          </>
-        ) : (
-          <div className="flex-1 flex flex-col items-center justify-center text-slate-400 bg-slate-50">
-            <FolderOpen size={40} className="mb-3 opacity-20" />
-            <p className="font-medium text-slate-500">No skill selected</p>
-            <p className="text-sm mt-1">Select a skill from the list to view and edit its files.</p>
-          </div>
-        )}
+          )}
+        </div>
       </div>
+
+      {githubModalOpen && (
+        <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center p-4">
+          <div className="w-full max-w-2xl bg-white rounded-xl border border-slate-200 shadow-xl">
+            <div className="px-4 py-3 border-b border-slate-200 flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-slate-800">Import Skill From GitHub</h3>
+              <button onClick={() => setGithubModalOpen(false)} className="text-slate-400 hover:text-slate-600">
+                <X size={16} />
+              </button>
+            </div>
+            <div className="p-4 space-y-3">
+              <input
+                value={githubUrl}
+                onChange={(e) => setGithubUrl(e.target.value)}
+                placeholder="https://github.com/<owner>/<repo>/tree/<ref>/<skill-path>"
+                className="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+              />
+              <div className="grid grid-cols-2 gap-2">
+                <input
+                  value={githubRef}
+                  onChange={(e) => setGithubRef(e.target.value)}
+                  placeholder="ref (optional)"
+                  className="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+                />
+                <input
+                  value={githubToken}
+                  onChange={(e) => setGithubToken(e.target.value)}
+                  placeholder="GitHub token (optional/private repos)"
+                  className="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+                />
+              </div>
+              {githubImportError && <p className="text-xs text-rose-600">{githubImportError}</p>}
+
+              {githubInspectResult && (
+                <div className="border border-slate-200 rounded p-3 bg-slate-50">
+                  <p className="text-sm text-slate-700 mb-1">Detected skill id: <span className="font-mono">{githubInspectResult.detectedSkillId}</span></p>
+                  <p className="text-xs text-slate-500 mb-2">{githubInspectResult.filesPreview.length} files</p>
+                  <div className="max-h-32 overflow-y-auto border border-slate-200 rounded bg-white p-2 text-xs font-mono text-slate-600">
+                    {githubInspectResult.filesPreview.map((file) => (
+                      <div key={file.path}>{file.path} ({file.size} bytes)</div>
+                    ))}
+                  </div>
+                  {githubInspectResult.warnings.length > 0 && (
+                    <div className="mt-2 text-xs text-amber-700">
+                      {githubInspectResult.warnings.map((w) => <div key={w}>- {w}</div>)}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+            <div className="px-4 py-3 border-t border-slate-200 flex justify-between">
+              <button
+                onClick={() => void handleGithubInspect()}
+                disabled={githubInspectLoading}
+                className="px-3 py-1.5 text-sm border border-slate-300 rounded hover:bg-slate-50 disabled:opacity-60"
+              >
+                {githubInspectLoading ? 'Inspecting...' : 'Inspect'}
+              </button>
+              <button
+                onClick={() => void handleGithubApply()}
+                disabled={!githubInspectResult || githubApplyLoading}
+                className="px-3 py-1.5 text-sm bg-emerald-600 text-white rounded hover:bg-emerald-700 disabled:opacity-60"
+              >
+                {githubApplyLoading ? 'Importing...' : 'Import (Copy on Collision)'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/services/settingsApi.ts
+++ b/frontend/src/services/settingsApi.ts
@@ -1,4 +1,5 @@
 import type { SkillDefinition } from '../types';
+import type { AgentStreamChunk } from '../../../packages/shared/src/services/agentStream';
 import { API_URL, apiFetch } from './apiClient';
 
 export type ManagedUser = {
@@ -12,6 +13,89 @@ export type ManagedUser = {
 export type ManagedGroup = {
   id: string;
   name: string;
+};
+
+export type SkillBuilderAction =
+  | {
+      type: 'create_skill';
+      skillId: string;
+      name?: string;
+      description?: string;
+      template?: string;
+    }
+  | {
+      type: 'upsert_text';
+      skillId: string;
+      path: string;
+      content: string;
+      encoding: 'utf-8';
+    }
+  | {
+      type: 'upload_binary_from_context';
+      skillId: string;
+      contextFileId: string;
+      targetPath: string;
+    }
+  | {
+      type: 'delete_file';
+      skillId: string;
+      path: string;
+    };
+
+export type ApplyActionsResult = {
+  success: boolean;
+  results: Array<{
+    index: number;
+    type: string;
+    status: 'ok' | 'error';
+    message?: string;
+  }>;
+  error?: string;
+};
+
+export type SkillBuilderSession = {
+  workspaceId: string;
+  limits: {
+    maxFileSize: number;
+    maxFiles: number;
+  };
+  allowedExtensions: string[];
+};
+
+export type SkillBuilderContextFile = {
+  fileId: string;
+  name: string;
+  relativePath: string;
+  size: number;
+  mimeType: string;
+  uploadedAt?: string;
+};
+
+export type SkillBuilderRun = {
+  runId: string;
+  status: 'queued' | 'running' | 'awaiting_approval' | 'completed' | 'failed' | 'cancelled';
+  workspaceId: string;
+  persona: string;
+};
+
+export type GithubImportInspectResult = {
+  importSessionId: string;
+  source: {
+    owner: string;
+    repo: string;
+    ref: string;
+    path: string;
+    url: string;
+  };
+  detectedSkillId: string;
+  filesPreview: Array<{ path: string; size: number }>;
+  warnings: string[];
+};
+
+const unwrapError = async (response: Response, fallback: string) => {
+  const data = await response.json().catch(() => ({}));
+  const message = typeof data.error === 'string' ? data.error : fallback;
+  throw new Error(message);
 };
 
 export const fetchAgentConfig = async (): Promise<string> => {
@@ -102,6 +186,224 @@ export const saveSkillContent = async (id: string, filePath: string, content: st
     const data = await response.json().catch(() => ({}));
     throw new Error(data.error || 'Failed to save skill content');
   }
+};
+
+export const parseSkillBuilderActions = async (text: string): Promise<SkillBuilderAction[]> => {
+  const response = await apiFetch(`${API_URL}/settings/skills/parse-actions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  });
+  if (!response.ok) {
+    await unwrapError(response, 'Failed to parse actions');
+  }
+  const data = await response.json();
+  return data.actions;
+};
+
+export const applySkillBuilderActions = async (actions: SkillBuilderAction[]): Promise<ApplyActionsResult> => {
+  const response = await apiFetch(`${API_URL}/settings/skills/apply-actions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ actions }),
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    return {
+      success: false,
+      results: data.results || [],
+      error: data.error || 'Failed to apply actions',
+    };
+  }
+  return data;
+};
+
+export const createSkillBuilderSession = async (): Promise<SkillBuilderSession> => {
+  const response = await apiFetch(`${API_URL}/settings/skill-builder/session`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{}',
+  });
+  if (!response.ok) {
+    await unwrapError(response, 'Failed to create Skill Builder session');
+  }
+  return response.json();
+};
+
+export const uploadSkillBuilderContextFile = async (file: File): Promise<SkillBuilderContextFile> => {
+  const form = new FormData();
+  form.append('file', file);
+  const response = await apiFetch(`${API_URL}/settings/skill-builder/context-files`, {
+    method: 'POST',
+    body: form,
+  });
+  if (!response.ok) {
+    await unwrapError(response, 'Failed to upload context file');
+  }
+  return response.json();
+};
+
+export const listSkillBuilderContextFiles = async (): Promise<SkillBuilderContextFile[]> => {
+  const response = await apiFetch(`${API_URL}/settings/skill-builder/context-files`);
+  if (!response.ok) {
+    await unwrapError(response, 'Failed to list context files');
+  }
+  const data = await response.json();
+  return data.files || [];
+};
+
+export const deleteSkillBuilderContextFile = async (fileId: string) => {
+  const response = await apiFetch(`${API_URL}/settings/skill-builder/context-files/${encodeURIComponent(fileId)}`, {
+    method: 'DELETE',
+  });
+  if (!response.ok) {
+    await unwrapError(response, 'Failed to delete context file');
+  }
+};
+
+export const startSkillBuilderRun = async (payload: {
+  prompt: string;
+  history?: Array<{ role: string; content: string }>;
+  contextFileIds?: string[];
+  selectedSkillId?: string;
+  turnId?: string;
+  forceReset?: boolean;
+}): Promise<SkillBuilderRun> => {
+  const response = await apiFetch(`${API_URL}/settings/skill-builder/runs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    await unwrapError(response, 'Failed to start Skill Builder run');
+  }
+  return response.json();
+};
+
+export const getSkillBuilderRun = async (runId: string) => {
+  const response = await apiFetch(`${API_URL}/settings/skill-builder/runs/${encodeURIComponent(runId)}`);
+  if (!response.ok) {
+    await unwrapError(response, 'Failed to fetch Skill Builder run');
+  }
+  return response.json();
+};
+
+export const cancelSkillBuilderRun = async (runId: string) => {
+  const response = await apiFetch(`${API_URL}/settings/skill-builder/runs/${encodeURIComponent(runId)}/cancel`, {
+    method: 'POST',
+  });
+  if (!response.ok) {
+    await unwrapError(response, 'Failed to cancel Skill Builder run');
+  }
+  return response.json();
+};
+
+export const submitSkillBuilderDecision = async (
+  runId: string,
+  decision: 'approve' | 'edit' | 'reject',
+  options?: {
+    editedAction?: { name: string; args: Record<string, unknown> };
+    message?: string;
+  },
+) => {
+  const response = await apiFetch(`${API_URL}/settings/skill-builder/runs/${encodeURIComponent(runId)}/decision`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      decision,
+      editedAction: options?.editedAction,
+      message: options?.message,
+    }),
+  });
+  if (!response.ok) {
+    await unwrapError(response, 'Failed to submit decision');
+  }
+  return response.json();
+};
+
+export const streamSkillBuilderRun = async (
+  runId: string,
+  onChunk: (chunk: AgentStreamChunk) => void,
+  signal?: AbortSignal,
+  afterId?: string,
+) => {
+  const url = afterId
+    ? `${API_URL}/settings/skill-builder/runs/${encodeURIComponent(runId)}/stream?after=${encodeURIComponent(afterId)}`
+    : `${API_URL}/settings/skill-builder/runs/${encodeURIComponent(runId)}/stream`;
+
+  const response = await apiFetch(url, { method: 'GET', signal });
+  if (!response.ok) {
+    await unwrapError(response, 'Failed to stream Skill Builder run');
+  }
+  if (!response.body) {
+    throw new Error('Streaming not supported by this browser');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    let newlineIndex = buffer.indexOf('\n');
+    while (newlineIndex >= 0) {
+      const line = buffer.slice(0, newlineIndex).trim();
+      buffer = buffer.slice(newlineIndex + 1);
+      if (line) {
+        try {
+          const chunk = JSON.parse(line);
+          onChunk(chunk);
+        } catch (error) {
+          console.error('Failed to parse Skill Builder stream chunk', error, line);
+        }
+      }
+      newlineIndex = buffer.indexOf('\n');
+    }
+  }
+
+  if (buffer.trim()) {
+    try {
+      const chunk = JSON.parse(buffer.trim());
+      onChunk(chunk);
+    } catch (error) {
+      console.error('Failed to parse trailing Skill Builder stream chunk', error, buffer);
+    }
+  }
+};
+
+export const inspectGithubSkillImport = async (payload: {
+  url: string;
+  ref?: string;
+  githubToken?: string;
+}): Promise<GithubImportInspectResult> => {
+  const response = await apiFetch(`${API_URL}/settings/skills/import/github/inspect`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    await unwrapError(response, 'Failed to inspect GitHub import');
+  }
+  return response.json();
+};
+
+export const applyGithubSkillImport = async (payload: {
+  importSessionId: string;
+  destinationSkillId?: string;
+  onCollision: 'copy';
+}): Promise<{ importedSkillId: string; filesImported: number; warnings: string[] }> => {
+  const response = await apiFetch(`${API_URL}/settings/skills/import/github/apply`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    await unwrapError(response, 'Failed to import skill from GitHub');
+  }
+  return response.json();
 };
 
 export const fetchUsers = async (): Promise<ManagedUser[]> => {


### PR DESCRIPTION
## Summary
Implements the unified Skill Builder plan in admin `SkillsRegistryTab` with:
- Collapsible left Skill Builder pane (chat + attachments + action apply)
- Direct skill creation/update/deletion via structured action batches
- GitHub skill installer (inspect + apply, copy-on-collision)
- Skill builder run orchestration endpoints (session/files/runs/stream/decision/cancel)

## Plan Checklist

### 1) Product Behavior
- [x] Add collapsible left pane in `SkillsRegistryTab` named Skill Builder
- [x] Keep existing skill list + Monaco editor intact
- [x] Fixed persona for builder runs: `skill-builder`
- [x] Attachment support for `.py,.md,.txt,.pdf,.csv,.json,.yaml,.yml,.png,.jpg,.jpeg,.webp,.gif,.svg`
- [x] Structured actions surfaced in UI with `Apply` and `Apply All`

### 2) Builder Must Create Skills
- [x] `create_skill` action implemented in backend apply-actions
- [x] Follow-up file actions supported: `upsert_text`, `upload_binary_from_context`, `delete_file`
- [x] Transaction-like batch semantics with per-action status and explicit failure response
- [x] Per-action apply and batch apply in UI

### 3) GitHub Skill Installer (v1)
- [x] Added inspect endpoint
- [x] Added apply endpoint
- [x] Added modal UX in `SkillsRegistryTab` (URL/ref/token, inspect preview, import)
- [x] Validates `SKILL.md` existence before apply
- [x] Default collision policy is copy (`-copy`, `-v2`, `-v3`, ...)

### 4) API Surface (Admin-only under `/settings`)
Implemented:
- [x] `POST /settings/skill-builder/session`
- [x] `POST /settings/skill-builder/context-files`
- [x] `GET /settings/skill-builder/context-files`
- [x] `DELETE /settings/skill-builder/context-files/:fileId`
- [x] `POST /settings/skill-builder/runs`
- [x] `GET /settings/skill-builder/runs/:runId`
- [x] `GET /settings/skill-builder/runs/:runId/stream`
- [x] `POST /settings/skill-builder/runs/:runId/cancel`
- [x] `POST /settings/skill-builder/runs/:runId/decision`
- [x] `POST /settings/skills/apply-actions`
- [x] `POST /settings/skills/import/github/inspect`
- [x] `POST /settings/skills/import/github/apply`
- [x] `POST /settings/skills/parse-actions` (helper for assistant output parsing)

### 5) Runtime/Execution Constraints
- [x] No generic shell execution added
- [x] Script-runner token gate wiring kept behind `ENABLE_SKILL_SCRIPT_RUNNER` in builder run path
- [ ] Explicit `run_skill_python_script` tool implementation itself is not in this PR (only config/wiring existed already)

### 6) Security / Governance
- [x] All endpoints remain behind existing `requireSystemAdmin`
- [x] Skill/file path restrictions + traversal protections
- [x] Upload extension + file size limits enforced server-side
- [x] GitHub token is request-scoped (not persisted)
- [ ] Dedicated audit-log persistence not added in this PR (can be follow-up)

## Files Changed
- `backend/src/api/settings.ts`
- `backend/src/api/routes.ts`
- `frontend/src/services/settingsApi.ts`
- `frontend/src/components/settings/SkillsRegistryTab.tsx`

## Validation
- [x] Frontend TypeScript build passed: `npx --no-install tsc -b`
- [x] Backend TypeScript check passed with lib skip: `npx --no-install tsc -p tsconfig.json --noEmit --skipLibCheck`
- [!] Full backend typecheck still reports existing external typing gap (`@types/ws` for hocuspocus), pre-existing and unrelated to this PR.

## Notes
- Fixed two implementation bugs during validation:
  - NDJSON stream parsing delimiter in frontend run stream parser
  - GitHub nested path encoding in backend inspect traversal
