### PR TITLE
Add dynamic HITL clarification flow

### DIFF
--- a/agent/config/runtime.yaml
+++ b/agent/config/runtime.yaml
@@ -59,6 +59,9 @@ tools:
   - name: request_plan_approval
     kind: builtin
     description: Request human approval for a generated execution plan
+  - name: request_clarification
+    kind: builtin
+    description: Pause the run and ask the human for clarification with optional choices
 
 mcp_servers:
   - name: toolbox-bq-demo

--- a/agent/helpudoc_agent/app.py
+++ b/agent/helpudoc_agent/app.py
@@ -67,6 +67,12 @@ class ResumeChatRequest(BaseModel):
     decisions: List[Decision]
 
 
+class InterruptResponseRequest(BaseModel):
+    message: Optional[str] = None
+    selectedChoiceIds: List[str] = Field(default_factory=list)
+    selectedValues: List[str] = Field(default_factory=list)
+
+
 class RagQueryRequest(BaseModel):
     query: str
     mode: str = "local"
@@ -799,9 +805,20 @@ def create_app() -> FastAPI:
         review_configs = interrupt_value.get("review_configs")
         payload = {
             "type": "interrupt",
+            "kind": interrupt_value.get("kind"),
+            "title": interrupt_value.get("title"),
+            "description": interrupt_value.get("description"),
+            "stepIndex": interrupt_value.get("step_index"),
+            "stepCount": interrupt_value.get("step_count"),
             "actionRequests": action_requests if isinstance(action_requests, list) else [],
             "reviewConfigs": review_configs if isinstance(review_configs, list) else [],
         }
+        response_spec = interrupt_value.get("response_spec")
+        if isinstance(response_spec, dict):
+            payload["responseSpec"] = response_spec
+        display_payload = interrupt_value.get("display_payload")
+        if isinstance(display_payload, dict):
+            payload["displayPayload"] = display_payload
         if isinstance(interrupt_id, str) and interrupt_id:
             payload["interruptId"] = interrupt_id
         return payload
@@ -886,6 +903,7 @@ def create_app() -> FastAPI:
         message: ChatRequest,
         *,
         resume_decisions: Optional[List[Dict[str, Any]]] = None,
+        resume_value: Any = None,
     ) -> AsyncGenerator[bytes, None]:
         agent = getattr(runtime, "agent", None)
         if agent is None:
@@ -897,7 +915,7 @@ def create_app() -> FastAPI:
             manager.reset_session()
 
         payload = _prepare_payload(message)
-        if not resume_decisions:
+        if resume_decisions is None and resume_value is None:
             tagged_files = _extract_tagged_files(message.message)
             runtime.workspace_state.context["tagged_files"] = tagged_files
             # Historical behavior forced "RAG-only" when any tagged files were present, which breaks
@@ -933,8 +951,10 @@ def create_app() -> FastAPI:
                 nonlocal saw_interrupt
                 stream_config = _build_agent_config(runtime, message, callbacks=[handler])
                 stream_input: Any = {"messages": payload}
-                if resume_decisions:
+                if resume_decisions is not None:
                     stream_input = Command(resume={"decisions": resume_decisions})
+                elif resume_value is not None:
+                    stream_input = Command(resume=resume_value)
                 final_result = await agent.ainvoke(stream_input, config=stream_config)
 
                 emitted = False
@@ -1077,6 +1097,27 @@ def create_app() -> FastAPI:
                 decisions_payload.append(item.dict(exclude_none=True))  # type: ignore[attr-defined]
         placeholder = ChatRequest(message="", history=None, forceReset=False)
         stream = _stream_agent_response(runtime, placeholder, resume_decisions=decisions_payload)
+        return StreamingResponse(stream, media_type="application/jsonl")
+
+    @app.post("/agents/{agent_name}/workspace/{workspace_id}/chat/stream/respond")
+    async def chat_stream_respond(
+        agent_name: str,
+        workspace_id: str,
+        response_request: InterruptResponseRequest,
+        request: Request,
+    ):
+        try:
+            initial_context = _extract_request_context(request)
+            runtime = await registry.get_or_create(agent_name, workspace_id, initial_context=initial_context)
+        except ValueError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        if hasattr(response_request, "model_dump"):
+            response_payload = response_request.model_dump(exclude_none=True)  # type: ignore[attr-defined]
+        else:
+            response_payload = response_request.dict(exclude_none=True)  # type: ignore[attr-defined]
+        placeholder = ChatRequest(message="", history=None, forceReset=False)
+        stream = _stream_agent_response(runtime, placeholder, resume_value=response_payload)
         return StreamingResponse(stream, media_type="application/jsonl")
 
     return app

--- a/agent/helpudoc_agent/graph.py
+++ b/agent/helpudoc_agent/graph.py
@@ -29,6 +29,7 @@ GENERAL_SYSTEM_PROMPT = (
     "For proposal/SOW/RFP requests, always load the proposal-writing skill and write "
     "the proposal to workspace markdown files using write_file (and append_to_report if needed). "
     "Before executing a multi-step skill-driven plan, first call request_plan_approval with a concise plan and checklist. "
+    "If execution is blocked on missing user intent or an unresolved choice, call request_clarification instead of guessing. "
     "Only proceed with side-effecting tools after approval (or after applying user edits). "
     "Reply in chat with brief status updates, not full sections. "
     "If no skill applies, proceed with best-effort behavior."

--- a/agent/helpudoc_agent/tools_and_schemas.py
+++ b/agent/helpudoc_agent/tools_and_schemas.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 from langchain_core.tools import tool
 from langchain_core.tools import Tool
+from langgraph.types import interrupt
 
 try:
     import vertexai
@@ -219,6 +220,7 @@ class ToolFactory:
             "list_skills": self._build_list_skills_tool,
             "load_skill": self._build_load_skill_tool,
             "request_plan_approval": self._build_request_plan_approval_tool,
+            "request_clarification": self._build_request_clarification_tool,
         }
 
     def build_tools(self, tool_names: List[str], workspace_state: WorkspaceState) -> List[Tool]:
@@ -404,6 +406,106 @@ class ToolFactory:
             "Ask human to approve, edit, or reject a proposed plan before execution."
         )
         return request_plan_approval
+
+    def _build_request_clarification_tool(self, workspace_state: WorkspaceState) -> Tool:
+        """Pause execution and ask the human a clarification question."""
+
+        @tool
+        def request_clarification(
+            title: str,
+            description: str = "",
+            options_json: str = "[]",
+            allow_freeform: bool = True,
+            multi_select: bool = False,
+            placeholder: str = "",
+            submit_label: str = "Continue",
+            step_index: int = 0,
+            step_count: int = 1,
+            context_json: str = "{}",
+        ) -> str:
+            """Ask the human for clarification with optional selectable choices and typed feedback."""
+            if workspace_state.context.get("tagged_files_only"):
+                return "Tool disabled: tagged files were provided, use rag_query only."
+
+            prompt_title = (title or "").strip()
+            prompt_description = (description or "").strip()
+            if not prompt_title:
+                return "Clarification request blocked: title is required."
+
+            parsed_choices: List[Dict[str, str]] = []
+            try:
+                raw_options = json.loads(options_json or "[]")
+            except json.JSONDecodeError:
+                raw_options = []
+            if isinstance(raw_options, list):
+                for index, item in enumerate(raw_options):
+                    if isinstance(item, str) and item.strip():
+                        parsed_choices.append(
+                            {
+                                "id": f"choice-{index + 1}",
+                                "label": item.strip(),
+                                "value": item.strip(),
+                            }
+                        )
+                    elif isinstance(item, dict):
+                        label = str(item.get("label") or item.get("value") or "").strip()
+                        value = str(item.get("value") or label).strip()
+                        if not label or not value:
+                            continue
+                        parsed_choices.append(
+                            {
+                                "id": str(item.get("id") or f"choice-{index + 1}").strip(),
+                                "label": label,
+                                "value": value,
+                                **(
+                                    {"description": str(item.get("description")).strip()}
+                                    if str(item.get("description") or "").strip()
+                                    else {}
+                                ),
+                            }
+                        )
+
+            input_mode = "text"
+            if parsed_choices and allow_freeform:
+                input_mode = "text_or_choice"
+            elif parsed_choices:
+                input_mode = "choice"
+
+            display_payload: Dict[str, Any] = {}
+            try:
+                parsed_context = json.loads(context_json or "{}")
+                if isinstance(parsed_context, dict):
+                    display_payload = parsed_context
+            except json.JSONDecodeError:
+                display_payload = {}
+
+            response = interrupt(
+                {
+                    "kind": "clarification",
+                    "title": prompt_title,
+                    "description": prompt_description,
+                    "step_index": max(0, int(step_index or 0)),
+                    "step_count": max(1, int(step_count or 1)),
+                    "response_spec": {
+                        "inputMode": input_mode,
+                        "multiple": bool(multi_select),
+                        "submitLabel": (submit_label or "Continue").strip() or "Continue",
+                        "placeholder": (placeholder or "").strip(),
+                        "choices": parsed_choices,
+                    },
+                    "display_payload": display_payload,
+                }
+            )
+            if isinstance(response, dict):
+                return json.dumps(response, ensure_ascii=False)
+            return str(response)
+
+        request_clarification.name = "request_clarification"
+        request_clarification.description = (
+            "Pause execution to ask the human a clarification question. "
+            "Use options_json for clickable choices and allow_freeform for typed input."
+        )
+        return request_clarification
 
     def _build_append_to_report_tool(self, workspace_state: WorkspaceState) -> Tool:
         """Append a section file to the stitched proposal inside the workspace."""

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -40,6 +40,7 @@
         "@types/multer": "^2.0.0",
         "@types/node": "^24.7.2",
         "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.18.1",
         "nodemon": "^3.0.0",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
@@ -1981,6 +1982,16 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/accepts": {
       "version": "2.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -45,6 +45,7 @@
     "@types/multer": "^2.0.0",
     "@types/node": "^24.7.2",
     "@types/uuid": "^10.0.0",
+    "@types/ws": "^8.18.1",
     "nodemon": "^3.0.0",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",

--- a/backend/src/api/agent.ts
+++ b/backend/src/api/agent.ts
@@ -18,6 +18,7 @@ import {
   getRunMeta,
   getRunStreamKey,
   resumeAgentRun,
+  resumeAgentRunWithResponse,
   startAgentRun,
 } from '../services/agentRunService';
 import { blockingRedisClient } from '../services/redisService';
@@ -112,6 +113,11 @@ export default function(
       })
       .optional(),
     message: z.string().optional(),
+  });
+  const runResponseSchema = z.object({
+    message: z.string().optional(),
+    selectedChoiceIds: z.array(z.string().min(1)).optional(),
+    selectedValues: z.array(z.string()).optional(),
   });
 
   const requireUserContext = (req: Request) => {
@@ -489,6 +495,9 @@ export default function(
       if (meta.status !== 'awaiting_approval') {
         return res.status(409).json({ error: 'Run is not awaiting approval' });
       }
+      if (meta.pendingInterrupt?.kind === 'clarification') {
+        return res.status(409).json({ error: 'Run is awaiting a clarification response, not an approval decision' });
+      }
       const payload = runDecisionSchema.parse(req.body);
       console.info('[AgentDecision]', {
         runId,
@@ -517,6 +526,40 @@ export default function(
         return res.status(400).json({ error: 'Invalid input' });
       }
       handleError(res, error, 'Failed to submit run decision');
+    }
+  });
+
+  router.post('/runs/:runId/respond', async (req, res) => {
+    try {
+      const user = requireUserContext(req);
+      const { runId } = req.params;
+      const meta = await getRunMeta(runId);
+      if (!meta) {
+        return res.status(404).json({ error: 'Run not found' });
+      }
+      await workspaceService.ensureMembership(meta.workspaceId, user.userId, { requireEdit: true });
+      if (meta.status !== 'awaiting_approval') {
+        return res.status(409).json({ error: 'Run is not awaiting input' });
+      }
+      const interruptKind = meta.pendingInterrupt?.kind ?? 'approval';
+      if (interruptKind !== 'clarification') {
+        return res.status(409).json({ error: 'Run is awaiting an approval decision, not a clarification response' });
+      }
+      const payload = runResponseSchema.parse(req.body);
+      if (!payload.message && !payload.selectedChoiceIds?.length && !payload.selectedValues?.length) {
+        return res.status(400).json({ error: 'Clarification response requires a message or a selected choice' });
+      }
+      const result = await resumeAgentRunWithResponse(runId, {
+        message: payload.message,
+        selectedChoiceIds: payload.selectedChoiceIds,
+        selectedValues: payload.selectedValues,
+      });
+      res.json(result);
+    } catch (error: any) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: 'Invalid input' });
+      }
+      handleError(res, error, 'Failed to submit clarification response');
     }
   });
 

--- a/backend/src/api/conversations.ts
+++ b/backend/src/api/conversations.ts
@@ -90,6 +90,12 @@ export default function conversationRoutes(conversationService: ConversationServ
       runId: z.string().optional(),
       status: z.enum(['queued', 'running', 'awaiting_approval', 'completed', 'failed', 'cancelled']).optional(),
       pendingInterrupt: z.object({
+        kind: z.enum(['approval', 'clarification']).optional(),
+        interruptId: z.string().optional(),
+        title: z.string().optional(),
+        description: z.string().optional(),
+        stepIndex: z.number().int().nonnegative().optional(),
+        stepCount: z.number().int().positive().optional(),
         actionRequests: z.array(z.object({
           name: z.string().optional(),
           args: z.record(z.string(), z.unknown()).optional(),
@@ -98,6 +104,21 @@ export default function conversationRoutes(conversationService: ConversationServ
           action_name: z.string().optional(),
           allowed_decisions: z.array(z.string()).optional(),
         }).passthrough()).optional(),
+        responseSpec: z.object({
+          inputMode: z.enum(['none', 'text', 'choice', 'text_or_choice']).optional(),
+          multiple: z.boolean().optional(),
+          submitLabel: z.string().optional(),
+          placeholder: z.string().optional(),
+          allowDismiss: z.boolean().optional(),
+          dismissLabel: z.string().optional(),
+          choices: z.array(z.object({
+            id: z.string(),
+            label: z.string(),
+            description: z.string().optional(),
+            value: z.string(),
+          }).passthrough()).optional(),
+        }).passthrough().optional(),
+        displayPayload: z.record(z.string(), z.unknown()).optional(),
       }).passthrough().optional(),
       runPolicy: z.object({
         skill: z.string().optional(),

--- a/backend/src/services/agentRunService.ts
+++ b/backend/src/services/agentRunService.ts
@@ -4,7 +4,9 @@ import { redisClient } from './redisService';
 import {
   runAgentStream,
   resumeAgentStream,
+  resumeAgentResponseStream,
   type AgentDecision,
+  type AgentInterruptResponse,
   type AgentHistoryEntry,
 } from './agentService';
 
@@ -26,6 +28,27 @@ type StartRunParams = {
   authToken?: string;
 };
 
+type RunPendingInterrupt = {
+  kind?: 'approval' | 'clarification';
+  interruptId?: string;
+  title?: string;
+  description?: string;
+  stepIndex?: number;
+  stepCount?: number;
+  actionRequests?: Array<{ name?: string; args?: Record<string, unknown> }>;
+  reviewConfigs?: Array<{ action_name?: string; allowed_decisions?: string[] }>;
+  responseSpec?: {
+    inputMode?: 'none' | 'text' | 'choice' | 'text_or_choice';
+    multiple?: boolean;
+    submitLabel?: string;
+    placeholder?: string;
+    allowDismiss?: boolean;
+    dismissLabel?: string;
+    choices?: Array<{ id?: string; label?: string; description?: string; value?: string }>;
+  };
+  displayPayload?: Record<string, unknown>;
+};
+
 type RunMeta = {
   workspaceId: string;
   persona: string;
@@ -35,11 +58,19 @@ type RunMeta = {
   completedAt?: string;
   error?: string;
   turnId?: string;
-  pendingInterrupt?: string;
+  pendingInterrupt?: RunPendingInterrupt;
 };
 
 type RunContext = {
   params: StartRunParams;
+};
+
+type ResumePayload =
+  | { decisions: AgentDecision[]; response?: never }
+  | { response: AgentInterruptResponse; decisions?: never };
+
+type PersistedRunMeta = Omit<RunMeta, 'pendingInterrupt'> & {
+  pendingInterrupt?: string;
 };
 
 const STREAM_TTL_SECONDS = 60 * 60 * 24; // 24h
@@ -52,7 +83,7 @@ const runContexts = new Map<string, RunContext>();
 const buildStreamKey = (runId: string) => `agent:run:${runId}`;
 const buildMetaKey = (runId: string) => `agent:run:${runId}:meta`;
 
-const persistMeta = async (runId: string, meta: Partial<RunMeta>) => {
+const persistMeta = async (runId: string, meta: Partial<PersistedRunMeta>) => {
   const metaKey = buildMetaKey(runId);
   const stringified: Record<string, string> = {};
   Object.entries(meta).forEach(([key, value]) => {
@@ -98,6 +129,52 @@ const buildAgentErrorPayload = (error: any, persona: string): string => {
     return error.message;
   }
   return 'Agent run failed.';
+};
+
+const parsePendingInterrupt = (raw: string | undefined): RunPendingInterrupt | undefined => {
+  if (!raw || !raw.trim()) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const payload = parsed as Record<string, unknown>;
+    return {
+      kind:
+        payload.kind === 'clarification' || payload.kind === 'approval'
+          ? payload.kind
+          : undefined,
+      interruptId: typeof payload.interruptId === 'string' ? payload.interruptId : undefined,
+      title: typeof payload.title === 'string' ? payload.title : undefined,
+      description: typeof payload.description === 'string' ? payload.description : undefined,
+      stepIndex: typeof payload.stepIndex === 'number' ? payload.stepIndex : undefined,
+      stepCount: typeof payload.stepCount === 'number' ? payload.stepCount : undefined,
+      actionRequests: Array.isArray(payload.actionRequests)
+        ? payload.actionRequests.filter(
+            (item): item is { name?: string; args?: Record<string, unknown> } =>
+              Boolean(item) && typeof item === 'object' && !Array.isArray(item),
+          )
+        : undefined,
+      reviewConfigs: Array.isArray(payload.reviewConfigs)
+        ? payload.reviewConfigs.filter(
+            (item): item is { action_name?: string; allowed_decisions?: string[] } =>
+              Boolean(item) && typeof item === 'object' && !Array.isArray(item),
+          )
+        : undefined,
+      responseSpec:
+        payload.responseSpec && typeof payload.responseSpec === 'object' && !Array.isArray(payload.responseSpec)
+          ? (payload.responseSpec as RunPendingInterrupt['responseSpec'])
+          : undefined,
+      displayPayload:
+        payload.displayPayload && typeof payload.displayPayload === 'object' && !Array.isArray(payload.displayPayload)
+          ? (payload.displayPayload as Record<string, unknown>)
+          : undefined,
+    };
+  } catch {
+    return undefined;
+  }
 };
 
 const cleanupRun = (runId: string, upstream?: IncomingMessage) => {
@@ -163,7 +240,7 @@ const parseLine = (line: string): Record<string, unknown> | null => {
   }
 };
 
-async function runAgentRunWorker(runId: string, params: StartRunParams, resumeDecisions?: AgentDecision[]) {
+async function runAgentRunWorker(runId: string, params: StartRunParams, resumePayload?: ResumePayload) {
   const controller = new AbortController();
   runAbortControllers.set(runId, controller);
 
@@ -173,7 +250,8 @@ async function runAgentRunWorker(runId: string, params: StartRunParams, resumeDe
       workspaceId: params.workspaceId,
       persona: params.persona,
       hasHistory: Boolean(params.history?.length),
-      resumeDecisions: Boolean(resumeDecisions?.length),
+      resumeDecisions: Boolean(resumePayload && 'decisions' in resumePayload && resumePayload.decisions?.length),
+      resumeResponse: Boolean(resumePayload && 'response' in resumePayload),
     });
   }
 
@@ -243,8 +321,14 @@ async function runAgentRunWorker(runId: string, params: StartRunParams, resumeDe
   };
 
   try {
-    const response = resumeDecisions?.length
-      ? await resumeAgentStream(params.persona, params.workspaceId, resumeDecisions, {
+    const response =
+      resumePayload && 'decisions' in resumePayload && resumePayload.decisions
+      ? await resumeAgentStream(params.persona, params.workspaceId, resumePayload.decisions, {
+          signal: controller.signal,
+          authToken: params.authToken,
+        })
+      : resumePayload && 'response' in resumePayload && resumePayload.response
+      ? await resumeAgentResponseStream(params.persona, params.workspaceId, resumePayload.response, {
           signal: controller.signal,
           authToken: params.authToken,
         })
@@ -326,7 +410,25 @@ export async function resumeAgentRun(
     error: '',
     pendingInterrupt: '',
   });
-  void runAgentRunWorker(runId, context.params, decisions);
+  void runAgentRunWorker(runId, context.params, { decisions });
+  return { runId, status: 'queued' };
+}
+
+export async function resumeAgentRunWithResponse(
+  runId: string,
+  response: AgentInterruptResponse,
+): Promise<{ runId: string; status: AgentRunStatus }> {
+  const context = runContexts.get(runId);
+  if (!context) {
+    throw new Error('Run context not found. Start a new run.');
+  }
+  await persistMeta(runId, {
+    status: 'queued',
+    startedAt: new Date().toISOString(),
+    error: '',
+    pendingInterrupt: '',
+  });
+  void runAgentRunWorker(runId, context.params, { response });
   return { runId, status: 'queued' };
 }
 
@@ -353,7 +455,7 @@ export async function getRunMeta(runId: string): Promise<RunMeta | null> {
     completedAt: meta.completedAt,
     error: meta.error,
     turnId: meta.turnId,
-    pendingInterrupt: meta.pendingInterrupt,
+    pendingInterrupt: parsePendingInterrupt(meta.pendingInterrupt),
   };
 }
 

--- a/backend/src/services/agentService.ts
+++ b/backend/src/services/agentService.ts
@@ -29,6 +29,12 @@ export type AgentDecision = {
   message?: string;
 };
 
+export type AgentInterruptResponse = {
+  message?: string;
+  selectedChoiceIds?: string[];
+  selectedValues?: string[];
+};
+
 type RunAgentOptions = {
   forceReset?: boolean;
   signal?: AbortSignal;
@@ -101,6 +107,27 @@ export async function resumeAgentStream(
   return client.post(
     `/agents/${persona}/workspace/${workspaceId}/chat/stream/resume`,
     { decisions },
+    {
+      responseType: "stream",
+      signal: options?.signal,
+      headers,
+    }
+  );
+}
+
+export async function resumeAgentResponseStream(
+  persona: string,
+  workspaceId: string,
+  response: AgentInterruptResponse,
+  options?: RunAgentOptions
+): Promise<AxiosResponse<IncomingMessage>> {
+  const headers: Record<string, string> = {};
+  if (options?.authToken) {
+    headers.Authorization = `Bearer ${options.authToken}`;
+  }
+  return client.post(
+    `/agents/${persona}/workspace/${workspaceId}/chat/stream/respond`,
+    response,
     {
       responseType: "stream",
       signal: options?.signal,

--- a/frontend/src/components/chat/AgentChatPane.tsx
+++ b/frontend/src/components/chat/AgentChatPane.tsx
@@ -47,8 +47,9 @@ export default function AgentChatPane({
   expandedToolMessages,
   expandedThinkingMessages,
   copiedMessageId,
-  approvalFeedbackByMessageId,
-  approvalSubmittingByMessageId,
+  interruptInputByMessageId,
+  interruptSelectedChoicesByMessageId,
+  interruptSubmittingByMessageId,
   chatMessage,
   chatAttachments,
   showPaper2SlidesControls,
@@ -64,11 +65,13 @@ export default function AgentChatPane({
   attachmentInputRef,
   workspaceId,
   formatMessageTimestamp,
-  approvalFieldKey,
+  interruptFieldKey,
+  getInterruptKind,
   getAllowedDecisions,
   getPrimaryInterruptAction,
   isPlanApprovalInterrupt,
-  setApprovalFeedbackByMessageId,
+  setInterruptInputByMessageId,
+  setInterruptSelectedChoicesByMessageId,
   onToggleAgentPaneVisibility,
   onModeChange,
   onToggleHistory,
@@ -82,6 +85,7 @@ export default function AgentChatPane({
   onCopyMessageText,
   onRerunMessage,
   onInterruptDecision,
+  onClarificationResponse,
   onChatInputChange,
   onChatInputKeyDown,
   onChatInputKeyUp,
@@ -114,8 +118,9 @@ export default function AgentChatPane({
   expandedToolMessages: Set<ConversationMessage['id']>;
   expandedThinkingMessages: Set<ConversationMessage['id']>;
   copiedMessageId: ConversationMessage['id'] | null;
-  approvalFeedbackByMessageId: Record<string, string>;
-  approvalSubmittingByMessageId: Record<string, boolean>;
+  interruptInputByMessageId: Record<string, string>;
+  interruptSelectedChoicesByMessageId: Record<string, string[]>;
+  interruptSubmittingByMessageId: Record<string, boolean>;
   chatMessage: string;
   chatAttachments: File[];
   showPaper2SlidesControls: boolean;
@@ -131,7 +136,13 @@ export default function AgentChatPane({
   attachmentInputRef: RefObject<HTMLInputElement | null>;
   workspaceId?: string;
   formatMessageTimestamp: (value?: string) => string;
-  approvalFieldKey: (messageKey: string, field: 'feedback' | 'edit-json' | 'reject-note') => string;
+  interruptFieldKey: (
+    messageKey: string,
+    field: 'feedback' | 'edit-json' | 'reject-note' | 'clarification-text',
+  ) => string;
+  getInterruptKind: (
+    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  ) => 'approval' | 'clarification';
   getAllowedDecisions: (
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => Array<'approve' | 'edit' | 'reject'>;
@@ -139,7 +150,8 @@ export default function AgentChatPane({
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => { name?: string; args?: Record<string, unknown> } | undefined;
   isPlanApprovalInterrupt: (pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt']) => boolean;
-  setApprovalFeedbackByMessageId: Dispatch<SetStateAction<Record<string, string>>>;
+  setInterruptInputByMessageId: Dispatch<SetStateAction<Record<string, string>>>;
+  setInterruptSelectedChoicesByMessageId: Dispatch<SetStateAction<Record<string, string[]>>>;
   onToggleAgentPaneVisibility: () => void;
   onModeChange: (event: ChangeEvent<HTMLSelectElement>) => void;
   onToggleHistory: () => void;
@@ -155,6 +167,10 @@ export default function AgentChatPane({
   onInterruptDecision: (
     message: ConversationMessage,
     decision: 'approve' | 'edit' | 'reject',
+    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  ) => void;
+  onClarificationResponse: (
+    message: ConversationMessage,
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => void;
   onChatInputChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
@@ -211,19 +227,23 @@ export default function AgentChatPane({
           expandedToolMessages={expandedToolMessages}
           expandedThinkingMessages={expandedThinkingMessages}
           copiedMessageId={copiedMessageId}
-          approvalFeedbackByMessageId={approvalFeedbackByMessageId}
-          approvalSubmittingByMessageId={approvalSubmittingByMessageId}
-          approvalFieldKey={approvalFieldKey}
+          interruptInputByMessageId={interruptInputByMessageId}
+          interruptSelectedChoicesByMessageId={interruptSelectedChoicesByMessageId}
+          interruptSubmittingByMessageId={interruptSubmittingByMessageId}
+          interruptFieldKey={interruptFieldKey}
+          getInterruptKind={getInterruptKind}
           formatMessageTimestamp={formatMessageTimestamp}
           getAllowedDecisions={getAllowedDecisions}
           getPrimaryInterruptAction={getPrimaryInterruptAction}
           isPlanApprovalInterrupt={isPlanApprovalInterrupt}
-          setApprovalFeedbackByMessageId={setApprovalFeedbackByMessageId}
+          setInterruptInputByMessageId={setInterruptInputByMessageId}
+          setInterruptSelectedChoicesByMessageId={setInterruptSelectedChoicesByMessageId}
           toggleThinkingVisibility={onToggleThinkingVisibility}
           toggleToolActivityVisibility={onToggleToolActivityVisibility}
           handleCopyMessageText={onCopyMessageText}
           handleRerunMessage={onRerunMessage}
           handleInterruptDecision={onInterruptDecision}
+          handleClarificationResponse={onClarificationResponse}
           workspaceId={workspaceId}
         />
         <ChatInputArea

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -1,13 +1,66 @@
-import { Copy, RotateCcw } from 'lucide-react';
-import ReactMarkdown from 'react-markdown';
+import { Copy, Loader2, RotateCcw } from 'lucide-react';
+import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
+import { useEffect, useMemo, useState, type Dispatch, type KeyboardEvent, type SetStateAction } from 'react';
 
-import type { ConversationMessage, ConversationMessageMetadata } from '../../types';
+import type { ConversationMessage, ConversationMessageMetadata, PendingInterrupt } from '../../types';
 import ToolOutputFilePreview from './ToolOutputFilePreview';
 
 const THOUGHT_PREVIEW_LIMIT = 320;
 const THINKING_PLACEHOLDER = 'Formulating a research plan based on your prompt and available context.';
+
+const formatInterruptValue = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+};
+
+const renderDisplayPayload = (
+  payload?: Record<string, unknown>,
+  heading = 'Details',
+  tone: 'dark' | 'light' = 'dark',
+) => {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload) || !Object.keys(payload).length) {
+    return null;
+  }
+  const containerClass =
+    tone === 'dark'
+      ? 'rounded-2xl border border-white/10 bg-white/5 p-4 text-left'
+      : 'rounded-2xl border border-slate-200/70 bg-white/65 p-4 text-left';
+  const headingClass =
+    tone === 'dark'
+      ? 'text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55'
+      : 'text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400';
+  const keyClass =
+    tone === 'dark'
+      ? 'text-[11px] font-semibold uppercase tracking-[0.14em] text-white/45'
+      : 'text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500';
+  const valueClass =
+    tone === 'dark'
+      ? 'mt-1 whitespace-pre-wrap text-sm leading-relaxed text-white/88'
+      : 'mt-1 whitespace-pre-wrap text-sm leading-relaxed text-slate-700';
+  return (
+    <div className={containerClass}>
+      <p className={headingClass}>{heading}</p>
+      <div className="mt-3 space-y-3">
+        {Object.entries(payload).map(([key, value]) => (
+          <div key={key}>
+            <p className={keyClass}>{key}</p>
+            <p className={valueClass}>{formatInterruptValue(value)}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const getClarificationInputMode = (pendingInterrupt?: PendingInterrupt): 'none' | 'text' | 'choice' | 'text_or_choice' =>
+  pendingInterrupt?.responseSpec?.inputMode || 'text';
 
 export default function ChatMessageBubble({
   message,
@@ -17,33 +70,44 @@ export default function ChatMessageBubble({
   expandedToolMessages,
   expandedThinkingMessages,
   copiedMessageId,
-  approvalFeedbackByMessageId,
-  approvalSubmittingByMessageId,
-  approvalFieldKey,
+  interruptInputByMessageId,
+  interruptSelectedChoicesByMessageId,
+  interruptSubmittingByMessageId,
+  interruptFieldKey,
   formatMessageTimestamp,
+  getInterruptKind,
   getAllowedDecisions,
   getPrimaryInterruptAction,
   isPlanApprovalInterrupt,
-  setApprovalFeedbackByMessageId,
+  setInterruptInputByMessageId,
+  setInterruptSelectedChoicesByMessageId,
   toggleThinkingVisibility,
   toggleToolActivityVisibility,
   handleCopyMessageText,
   handleRerunMessage,
   handleInterruptDecision,
+  handleClarificationResponse,
   isStreaming,
   workspaceId,
 }: {
   message: ConversationMessage;
   personaDisplayName: string;
   messageBubbleMaxWidth: string;
-  markdownComponents: Record<string, any>;
+  markdownComponents: Components;
   expandedToolMessages: Set<ConversationMessage['id']>;
   expandedThinkingMessages: Set<ConversationMessage['id']>;
   copiedMessageId: ConversationMessage['id'] | null;
-  approvalFeedbackByMessageId: Record<string, string>;
-  approvalSubmittingByMessageId: Record<string, boolean>;
-  approvalFieldKey: (messageKey: string, field: 'feedback' | 'edit-json' | 'reject-note') => string;
+  interruptInputByMessageId: Record<string, string>;
+  interruptSelectedChoicesByMessageId: Record<string, string[]>;
+  interruptSubmittingByMessageId: Record<string, boolean>;
+  interruptFieldKey: (
+    messageKey: string,
+    field: 'feedback' | 'edit-json' | 'reject-note' | 'clarification-text',
+  ) => string;
   formatMessageTimestamp: (value?: string) => string;
+  getInterruptKind: (
+    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  ) => 'approval' | 'clarification';
   getAllowedDecisions: (
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => Array<'approve' | 'edit' | 'reject'>;
@@ -51,7 +115,8 @@ export default function ChatMessageBubble({
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => { name?: string; args?: Record<string, unknown> } | undefined;
   isPlanApprovalInterrupt: (pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt']) => boolean;
-  setApprovalFeedbackByMessageId: Dispatch<SetStateAction<Record<string, string>>>;
+  setInterruptInputByMessageId: Dispatch<SetStateAction<Record<string, string>>>;
+  setInterruptSelectedChoicesByMessageId: Dispatch<SetStateAction<Record<string, string[]>>>;
   toggleThinkingVisibility: (messageId: ConversationMessage['id']) => void;
   toggleToolActivityVisibility: (messageId: ConversationMessage['id']) => void;
   handleCopyMessageText: (message: ConversationMessage) => void;
@@ -59,6 +124,10 @@ export default function ChatMessageBubble({
   handleInterruptDecision: (
     message: ConversationMessage,
     decision: 'approve' | 'edit' | 'reject',
+    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  ) => void;
+  handleClarificationResponse: (
+    message: ConversationMessage,
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => void;
   isStreaming: boolean;
@@ -70,12 +139,15 @@ export default function ChatMessageBubble({
   const toolEvents = message.toolEvents || [];
   const hasToolEvents = toolEvents.length > 0;
   const pendingInterrupt = messageMetadata?.pendingInterrupt;
+  const interruptKind = getInterruptKind(pendingInterrupt);
+  const isClarificationInterrupt = Boolean(pendingInterrupt && interruptKind === 'clarification');
   const allowedInterruptDecisions = getAllowedDecisions(pendingInterrupt);
   const primaryInterruptAction = getPrimaryInterruptAction(pendingInterrupt);
   const isPlanApprovalRequest = isPlanApprovalInterrupt(pendingInterrupt);
   const messageKey = String(message.id);
-  const decisionBusy = Boolean(approvalSubmittingByMessageId[messageKey]);
+  const interruptBusy = Boolean(interruptSubmittingByMessageId[messageKey]);
   const [interruptMode, setInterruptMode] = useState<'review' | 'editing' | 'rejecting'>('review');
+  const [clarificationDismissed, setClarificationDismissed] = useState(false);
   const isToolActivityExpanded = expandedToolMessages.has(message.id);
   const isThinkingExpanded = expandedThinkingMessages.has(message.id);
   const rawThinkingText = message.thinkingText?.trim() || '';
@@ -85,7 +157,7 @@ export default function ChatMessageBubble({
   const isThinkingCollapsed = showThinkingToggle && !isThinkingExpanded;
   const sanitizedAgentText = (() => {
     const raw = message.text || '';
-    if (!pendingInterrupt || !raw) {
+    if (!pendingInterrupt || !raw || interruptKind !== 'approval') {
       return raw;
     }
     return raw
@@ -104,11 +176,20 @@ export default function ChatMessageBubble({
   })();
   const canCopyMessage =
     Boolean((message.text && message.text.trim()) || (message.thinkingText && message.thinkingText.trim()));
+  const shouldShowFallbackStatus = !sanitizedAgentText && !displayThinkingText && !hasToolEvents;
   const copyTitle = copiedMessageId === message.id ? 'Copied!' : 'Copy message';
   const copyButtonPositionClass = message.sender === 'user' ? 'right-10' : 'right-2';
-  const planFeedbackKey = approvalFieldKey(messageKey, 'feedback');
-  const genericEditKey = approvalFieldKey(messageKey, 'edit-json');
-  const rejectNoteKey = approvalFieldKey(messageKey, 'reject-note');
+  const planFeedbackKey = interruptFieldKey(messageKey, 'feedback');
+  const genericEditKey = interruptFieldKey(messageKey, 'edit-json');
+  const rejectNoteKey = interruptFieldKey(messageKey, 'reject-note');
+  const clarificationTextKey = interruptFieldKey(messageKey, 'clarification-text');
+  const clarificationInputMode = getClarificationInputMode(pendingInterrupt);
+  const clarificationAllowsChoices = clarificationInputMode === 'choice' || clarificationInputMode === 'text_or_choice';
+  const clarificationAllowsText = clarificationInputMode === 'text' || clarificationInputMode === 'text_or_choice';
+  const clarificationChoices = pendingInterrupt?.responseSpec?.choices || [];
+  const selectedChoiceIds = interruptSelectedChoicesByMessageId[messageKey] || [];
+  const clarificationValue = interruptInputByMessageId[clarificationTextKey] || '';
+  const allowDismiss = Boolean(pendingInterrupt?.responseSpec?.allowDismiss);
 
   const planText = useMemo(() => {
     const args = primaryInterruptAction?.args;
@@ -133,21 +214,82 @@ export default function ChatMessageBubble({
   useEffect(() => {
     if (!pendingInterrupt) {
       setInterruptMode('review');
+      setClarificationDismissed(false);
+      return;
     }
+    setClarificationDismissed(false);
   }, [pendingInterrupt, messageKey]);
 
-  const setApprovalValue = (fieldKey: string, value: string) => {
-    setApprovalFeedbackByMessageId((prev) => ({
+  const setInterruptValue = (fieldKey: string, value: string) => {
+    setInterruptInputByMessageId((prev) => ({
       ...prev,
       [fieldKey]: value,
     }));
   };
 
+  const setSelectedChoices = (nextChoices: string[]) => {
+    setInterruptSelectedChoicesByMessageId((prev) => ({
+      ...prev,
+      [messageKey]: nextChoices,
+    }));
+  };
+
+  const handleClarificationChoiceToggle = (choiceId: string, choiceValue: string) => {
+    const isMultiple = Boolean(pendingInterrupt?.responseSpec?.multiple);
+    const nextChoices = isMultiple
+      ? selectedChoiceIds.includes(choiceId)
+        ? selectedChoiceIds.filter((value) => value !== choiceId)
+        : [...selectedChoiceIds, choiceId]
+      : [choiceId];
+    setSelectedChoices(nextChoices);
+    if (clarificationInputMode === 'text_or_choice') {
+      setInterruptValue(clarificationTextKey, choiceValue);
+    }
+  };
+
+  const handleClarificationKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!pendingInterrupt || clarificationDismissed) {
+      return;
+    }
+    const target = event.target as HTMLElement | null;
+    const isTextEntryTarget = target?.tagName === 'TEXTAREA' || target?.tagName === 'INPUT';
+    if (clarificationAllowsChoices && clarificationChoices.length) {
+      if (isTextEntryTarget) {
+        return;
+      }
+      const currentIndex = selectedChoiceIds.length
+        ? clarificationChoices.findIndex((choice) => choice.id === selectedChoiceIds[0])
+        : -1;
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        const nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % clarificationChoices.length;
+        const nextChoice = clarificationChoices[nextIndex];
+        handleClarificationChoiceToggle(nextChoice.id, nextChoice.value);
+        return;
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        const nextIndex = currentIndex <= 0 ? clarificationChoices.length - 1 : currentIndex - 1;
+        const nextChoice = clarificationChoices[nextIndex];
+        handleClarificationChoiceToggle(nextChoice.id, nextChoice.value);
+        return;
+      }
+    }
+    const hasValidResponse =
+      clarificationValue.trim().length > 0 ||
+      selectedChoiceIds.length > 0 ||
+      clarificationInputMode === 'none';
+    if (event.key === 'Enter' && !event.shiftKey && hasValidResponse && !interruptBusy) {
+      event.preventDefault();
+      handleClarificationResponse(message, pendingInterrupt);
+    }
+  };
+
+  const clarificationDisplayPayload = renderDisplayPayload(pendingInterrupt?.displayPayload, 'Context', 'dark');
+  const approvalDisplayPayload = renderDisplayPayload(pendingInterrupt?.displayPayload, 'Plan details', 'light');
+
   return (
-    <div
-      className={`group flex items-start gap-3 motion-safe:animate-[chat-pane-message-in_220ms_ease-out] ${isAgentMessage ? '' : 'justify-end'
-        }`}
-    >
+    <div className={`group flex items-start gap-3 motion-safe:animate-[chat-pane-message-in_220ms_ease-out] ${isAgentMessage ? '' : 'justify-end'}`}>
       <div style={{ width: '100%', maxWidth: messageBubbleMaxWidth }} className="relative flex-1 md:flex-initial">
         {isAgentMessage ? (
           <div className="w-full rounded-2xl border border-slate-200 bg-gradient-to-br from-white via-slate-50 to-blue-50/40 px-4 py-4 text-slate-800 shadow-[0_22px_40px_-28px_rgba(15,23,42,0.8)] ring-1 ring-slate-100">
@@ -159,28 +301,28 @@ export default function ChatMessageBubble({
               <div className="relative mt-3 pl-4 before:absolute before:bottom-2 before:left-1 before:top-2 before:w-px before:bg-sky-200">
                 <span className="absolute left-0 top-3 h-2.5 w-2.5 rounded-full border border-sky-300 bg-sky-100" />
                 <div className="rounded-2xl border border-sky-100 bg-sky-50/60 px-3 py-3 text-[13px] text-slate-600 shadow-inner transition-all duration-200 ease-in-out">
-                <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-wide text-sky-700">
-                  <span>Thinking</span>
-                  {showThinkingToggle ? (
-                    <button
-                      type="button"
-                      onClick={() => toggleThinkingVisibility(message.id)}
-                      className="text-sky-700 transition-all duration-200 hover:text-sky-600"
-                    >
-                      {isThinkingExpanded ? 'Show less' : 'Expand'}
-                    </button>
-                  ) : null}
-                </div>
+                  <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-wide text-sky-700">
+                    <span>Thinking</span>
+                    {showThinkingToggle ? (
+                      <button
+                        type="button"
+                        onClick={() => toggleThinkingVisibility(message.id)}
+                        className="text-sky-700 transition-all duration-200 hover:text-sky-600"
+                      >
+                        {isThinkingExpanded ? 'Show less' : 'Expand'}
+                      </button>
+                    ) : null}
+                  </div>
                   <div
-                  className="relative mt-2 overflow-hidden whitespace-pre-line leading-relaxed transition-[max-height] duration-300 ease-in-out"
-                  style={{ maxHeight: isThinkingCollapsed ? '7.5rem' : '28rem' }}
-                >
-                  {displayThinkingText}
-                  {isThinkingCollapsed ? (
-                    <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-sky-50/95 to-transparent" />
-                  ) : null}
+                    className="relative mt-2 overflow-hidden whitespace-pre-line leading-relaxed transition-[max-height] duration-300 ease-in-out"
+                    style={{ maxHeight: isThinkingCollapsed ? '7.5rem' : '28rem' }}
+                  >
+                    {displayThinkingText}
+                    {isThinkingCollapsed ? (
+                      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-sky-50/95 to-transparent" />
+                    ) : null}
+                  </div>
                 </div>
-              </div>
               </div>
             ) : null}
             {sanitizedAgentText ? (
@@ -189,166 +331,70 @@ export default function ChatMessageBubble({
                   {sanitizedAgentText}
                 </ReactMarkdown>
               </div>
-            ) : (
+            ) : shouldShowFallbackStatus ? (
               <span className="mt-3 block text-sm text-slate-500">
                 {displayThinkingText ? 'Finalizing response...' : 'Thinking...'}
               </span>
-            )}
-            {pendingInterrupt ? (
+            ) : null}
+            {pendingInterrupt && !isClarificationInterrupt ? (
               <div className="relative mt-4 pl-4 before:absolute before:-bottom-2 before:left-1 before:top-2 before:w-px before:bg-slate-200">
                 <span className="absolute left-0 top-3 h-2.5 w-2.5 rounded-full border border-indigo-300 bg-indigo-100" />
                 <div className="rounded-2xl border border-sky-200/70 bg-gradient-to-br from-white/75 via-sky-50/70 to-indigo-100/60 p-4 shadow-[0_18px_40px_-28px_rgba(30,64,175,0.75)] backdrop-blur-md">
-                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-700">Approval Required</p>
-                <p className="mt-1 text-sm text-slate-700">
-                  Please review the proposed plan below before continuing.
-                </p>
-                {isPlanApprovalRequest ? (
-                  <div className="mt-3 grid gap-2">
-                    {interruptMode === 'editing' ? (
-                      <textarea
-                        value={approvalFeedbackByMessageId[planFeedbackKey] || ''}
-                        onChange={(event) => setApprovalValue(planFeedbackKey, event.target.value)}
-                        className="w-full rounded-xl border border-slate-200/80 bg-white/85 p-3 text-sm text-slate-700 backdrop-blur-sm focus:border-sky-400 focus:outline-none"
-                        rows={6}
-                        placeholder="Edit this plan before saving changes"
-                      />
-                    ) : (
-                      <div className="max-h-48 overflow-y-auto rounded-xl border border-slate-200/70 bg-white/60 p-3 text-sm text-slate-700 whitespace-pre-wrap">
-                        {planText || 'No plan details were provided.'}
-                      </div>
-                    )}
-                    {interruptMode === 'rejecting' ? (
-                      <input
-                        value={approvalFeedbackByMessageId[rejectNoteKey] || ''}
-                        onChange={(event) => setApprovalValue(rejectNoteKey, event.target.value)}
-                        className="w-full rounded-xl border border-slate-200/80 bg-white/80 px-3 py-2 text-sm text-slate-700 backdrop-blur-sm focus:border-sky-400 focus:outline-none"
-                        placeholder="Reason for rejection (optional)"
-                      />
-                    ) : null}
-                    <div className="mt-1 flex flex-wrap gap-2">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-700">
+                    {pendingInterrupt.title || 'Approval Required'}
+                  </p>
+                  <p className="mt-1 text-sm text-slate-700">
+                    {pendingInterrupt.description || 'Please review the proposed plan below before continuing.'}
+                  </p>
+                  {isPlanApprovalRequest ? (
+                    <div className="mt-3 grid gap-2">
+                      {approvalDisplayPayload}
                       {interruptMode === 'editing' ? (
-                        <>
-                          <button
-                            type="button"
-                            disabled={decisionBusy}
-                            onClick={() => handleInterruptDecision(message, 'edit', pendingInterrupt)}
-                            className="rounded-xl border border-blue-300/80 bg-blue-500/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-all duration-200 hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
-                          >
-                            Save Changes
-                          </button>
-                          <button
-                            type="button"
-                            disabled={decisionBusy}
-                            onClick={() => setInterruptMode('review')}
-                            className="rounded-xl border border-slate-300/80 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition-all duration-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                          >
-                            Cancel
-                          </button>
-                        </>
-                      ) : interruptMode === 'rejecting' ? (
-                        <>
-                          <button
-                            type="button"
-                            disabled={decisionBusy}
-                            onClick={() => handleInterruptDecision(message, 'reject', pendingInterrupt)}
-                            className="rounded-xl border border-rose-300/80 bg-rose-500/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-all duration-200 hover:bg-rose-500 disabled:cursor-not-allowed disabled:opacity-60"
-                          >
-                            Confirm Rejection
-                          </button>
-                          <button
-                            type="button"
-                            disabled={decisionBusy}
-                            onClick={() => setInterruptMode('review')}
-                            className="rounded-xl border border-slate-300/80 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition-all duration-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                          >
-                            Cancel
-                          </button>
-                        </>
+                        <textarea
+                          value={interruptInputByMessageId[planFeedbackKey] || ''}
+                          onChange={(event) => setInterruptValue(planFeedbackKey, event.target.value)}
+                          className="w-full rounded-xl border border-slate-200/80 bg-white/85 p-3 text-sm text-slate-700 backdrop-blur-sm focus:border-sky-400 focus:outline-none"
+                          rows={6}
+                          placeholder="Edit this plan before saving changes"
+                        />
                       ) : (
-                        <>
-                          {allowedInterruptDecisions.includes('approve') ? (
-                            <button
-                              type="button"
-                              disabled={decisionBusy}
-                              onClick={() => handleInterruptDecision(message, 'approve', pendingInterrupt)}
-                              className="rounded-xl border border-emerald-300/80 bg-emerald-500/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-all duration-200 hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
-                            >
-                              Approve
-                            </button>
-                          ) : null}
-                          {allowedInterruptDecisions.includes('edit') ? (
-                            <button
-                              type="button"
-                              disabled={decisionBusy}
-                              onClick={() => {
-                                if (!(approvalFeedbackByMessageId[planFeedbackKey] || '').trim()) {
-                                  setApprovalValue(planFeedbackKey, planText);
-                                }
-                                setInterruptMode('editing');
-                              }}
-                              className="rounded-xl border border-blue-200/90 bg-white px-3 py-1.5 text-xs font-semibold text-blue-700 transition-all duration-200 hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60"
-                            >
-                              Edit
-                            </button>
-                          ) : null}
-                          {allowedInterruptDecisions.includes('reject') ? (
-                            <button
-                              type="button"
-                              disabled={decisionBusy}
-                              onClick={() => setInterruptMode('rejecting')}
-                              className="rounded-xl border border-rose-200/90 bg-white px-3 py-1.5 text-xs font-semibold text-rose-700 transition-all duration-200 hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
-                            >
-                              Reject
-                            </button>
-                          ) : null}
-                        </>
+                        <div className="max-h-48 overflow-y-auto rounded-xl border border-slate-200/70 bg-white/60 p-3 text-sm text-slate-700 whitespace-pre-wrap">
+                          {planText || 'No plan details were provided.'}
+                        </div>
                       )}
-                    </div>
-                  </div>
-                ) : (
-                  <div className="mt-2 grid gap-2">
-                    <textarea
-                      value={approvalFeedbackByMessageId[genericEditKey] || ''}
-                      onChange={(event) => setApprovalValue(genericEditKey, event.target.value)}
-                      className="w-full rounded-xl border border-slate-200/80 bg-white/80 p-2 text-xs text-slate-700 backdrop-blur-sm focus:border-sky-400 focus:outline-none"
-                      rows={4}
-                      placeholder='Optional edit feedback or updated args JSON'
-                    />
-                    {interruptMode === 'rejecting' ? (
-                      <input
-                        value={approvalFeedbackByMessageId[rejectNoteKey] || ''}
-                        onChange={(event) => setApprovalValue(rejectNoteKey, event.target.value)}
-                        className="w-full rounded-xl border border-slate-200/80 bg-white/80 px-2 py-1.5 text-xs text-slate-700 backdrop-blur-sm focus:border-sky-400 focus:outline-none"
-                        placeholder="Reason for rejection (optional)"
-                      />
-                    ) : null}
-                    <div className="mt-1 flex flex-wrap gap-2">
-                      {allowedInterruptDecisions.includes('approve') ? (
-                        <button
-                          type="button"
-                          disabled={decisionBusy}
-                          onClick={() => handleInterruptDecision(message, 'approve', pendingInterrupt)}
-                          className="rounded-xl border border-emerald-300/80 bg-emerald-500/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-all duration-200 hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
-                        >
-                          Approve
-                        </button>
+                      {interruptMode === 'rejecting' ? (
+                        <input
+                          value={interruptInputByMessageId[rejectNoteKey] || ''}
+                          onChange={(event) => setInterruptValue(rejectNoteKey, event.target.value)}
+                          className="w-full rounded-xl border border-slate-200/80 bg-white/80 px-3 py-2 text-sm text-slate-700 backdrop-blur-sm focus:border-sky-400 focus:outline-none"
+                          placeholder="Reason for rejection (optional)"
+                        />
                       ) : null}
-                      {allowedInterruptDecisions.includes('edit') ? (
-                        <button
-                          type="button"
-                          disabled={decisionBusy}
-                          onClick={() => handleInterruptDecision(message, 'edit', pendingInterrupt)}
-                          className="rounded-xl border border-blue-200/90 bg-white px-3 py-1.5 text-xs font-semibold text-blue-700 transition-all duration-200 hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60"
-                        >
-                          Edit
-                        </button>
-                      ) : null}
-                      {allowedInterruptDecisions.includes('reject') ? (
-                        interruptMode === 'rejecting' ? (
+                      <div className="mt-1 flex flex-wrap gap-2">
+                        {interruptMode === 'editing' ? (
                           <>
                             <button
                               type="button"
-                              disabled={decisionBusy}
+                              disabled={interruptBusy}
+                              onClick={() => handleInterruptDecision(message, 'edit', pendingInterrupt)}
+                              className="rounded-xl border border-blue-300/80 bg-blue-500/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-all duration-200 hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              Save Changes
+                            </button>
+                            <button
+                              type="button"
+                              disabled={interruptBusy}
+                              onClick={() => setInterruptMode('review')}
+                              className="rounded-xl border border-slate-300/80 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition-all duration-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              Cancel
+                            </button>
+                          </>
+                        ) : interruptMode === 'rejecting' ? (
+                          <>
+                            <button
+                              type="button"
+                              disabled={interruptBusy}
                               onClick={() => handleInterruptDecision(message, 'reject', pendingInterrupt)}
                               className="rounded-xl border border-rose-300/80 bg-rose-500/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-all duration-200 hover:bg-rose-500 disabled:cursor-not-allowed disabled:opacity-60"
                             >
@@ -356,7 +402,7 @@ export default function ChatMessageBubble({
                             </button>
                             <button
                               type="button"
-                              disabled={decisionBusy}
+                              disabled={interruptBusy}
                               onClick={() => setInterruptMode('review')}
                               className="rounded-xl border border-slate-300/80 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition-all duration-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
                             >
@@ -364,20 +410,212 @@ export default function ChatMessageBubble({
                             </button>
                           </>
                         ) : (
+                          <>
+                            {allowedInterruptDecisions.includes('approve') ? (
+                              <button
+                                type="button"
+                                disabled={interruptBusy}
+                                onClick={() => handleInterruptDecision(message, 'approve', pendingInterrupt)}
+                                className="rounded-xl border border-emerald-300/80 bg-emerald-500/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-all duration-200 hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+                              >
+                                Approve
+                              </button>
+                            ) : null}
+                            {allowedInterruptDecisions.includes('edit') ? (
+                              <button
+                                type="button"
+                                disabled={interruptBusy}
+                                onClick={() => {
+                                  if (!(interruptInputByMessageId[planFeedbackKey] || '').trim()) {
+                                    setInterruptValue(planFeedbackKey, planText);
+                                  }
+                                  setInterruptMode('editing');
+                                }}
+                                className="rounded-xl border border-blue-200/90 bg-white px-3 py-1.5 text-xs font-semibold text-blue-700 transition-all duration-200 hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60"
+                              >
+                                Edit
+                              </button>
+                            ) : null}
+                            {allowedInterruptDecisions.includes('reject') ? (
+                              <button
+                                type="button"
+                                disabled={interruptBusy}
+                                onClick={() => setInterruptMode('rejecting')}
+                                className="rounded-xl border border-rose-200/90 bg-white px-3 py-1.5 text-xs font-semibold text-rose-700 transition-all duration-200 hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+                              >
+                                Reject
+                              </button>
+                            ) : null}
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="mt-2 grid gap-2">
+                      {approvalDisplayPayload}
+                      <textarea
+                        value={interruptInputByMessageId[genericEditKey] || ''}
+                        onChange={(event) => setInterruptValue(genericEditKey, event.target.value)}
+                        className="w-full rounded-xl border border-slate-200/80 bg-white/80 p-2 text-xs text-slate-700 backdrop-blur-sm focus:border-sky-400 focus:outline-none"
+                        rows={4}
+                        placeholder="Optional edit feedback or updated args JSON"
+                      />
+                      {interruptMode === 'rejecting' ? (
+                        <input
+                          value={interruptInputByMessageId[rejectNoteKey] || ''}
+                          onChange={(event) => setInterruptValue(rejectNoteKey, event.target.value)}
+                          className="w-full rounded-xl border border-slate-200/80 bg-white/80 px-2 py-1.5 text-xs text-slate-700 backdrop-blur-sm focus:border-sky-400 focus:outline-none"
+                          placeholder="Reason for rejection (optional)"
+                        />
+                      ) : null}
+                      <div className="mt-1 flex flex-wrap gap-2">
+                        {allowedInterruptDecisions.includes('approve') ? (
                           <button
                             type="button"
-                            disabled={decisionBusy}
-                            onClick={() => setInterruptMode('rejecting')}
-                            className="rounded-xl border border-rose-200/90 bg-white px-3 py-1.5 text-xs font-semibold text-rose-700 transition-all duration-200 hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+                            disabled={interruptBusy}
+                            onClick={() => handleInterruptDecision(message, 'approve', pendingInterrupt)}
+                            className="rounded-xl border border-emerald-300/80 bg-emerald-500/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-all duration-200 hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
                           >
-                            Reject
+                            Approve
                           </button>
-                        )
+                        ) : null}
+                        {allowedInterruptDecisions.includes('edit') ? (
+                          <button
+                            type="button"
+                            disabled={interruptBusy}
+                            onClick={() => handleInterruptDecision(message, 'edit', pendingInterrupt)}
+                            className="rounded-xl border border-blue-200/90 bg-white px-3 py-1.5 text-xs font-semibold text-blue-700 transition-all duration-200 hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60"
+                          >
+                            Edit
+                          </button>
+                        ) : null}
+                        {allowedInterruptDecisions.includes('reject') ? (
+                          interruptMode === 'rejecting' ? (
+                            <>
+                              <button
+                                type="button"
+                                disabled={interruptBusy}
+                                onClick={() => handleInterruptDecision(message, 'reject', pendingInterrupt)}
+                                className="rounded-xl border border-rose-300/80 bg-rose-500/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-all duration-200 hover:bg-rose-500 disabled:cursor-not-allowed disabled:opacity-60"
+                              >
+                                Confirm Rejection
+                              </button>
+                              <button
+                                type="button"
+                                disabled={interruptBusy}
+                                onClick={() => setInterruptMode('review')}
+                                className="rounded-xl border border-slate-300/80 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition-all duration-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                              >
+                                Cancel
+                              </button>
+                            </>
+                          ) : (
+                            <button
+                              type="button"
+                              disabled={interruptBusy}
+                              onClick={() => setInterruptMode('rejecting')}
+                              className="rounded-xl border border-rose-200/90 bg-white px-3 py-1.5 text-xs font-semibold text-rose-700 transition-all duration-200 hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              Reject
+                            </button>
+                          )
+                        ) : null}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            ) : null}
+            {pendingInterrupt && isClarificationInterrupt && !clarificationDismissed ? (
+              <div className="mt-5 rounded-[2rem] border border-white/10 bg-[#121212] p-5 text-white shadow-[0_26px_80px_-34px_rgba(0,0,0,0.95)] ring-1 ring-white/10">
+                <div
+                  className="outline-none"
+                  tabIndex={0}
+                  onKeyDown={handleClarificationKeyDown}
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="text-[30px] font-semibold leading-tight tracking-tight text-white">
+                        {pendingInterrupt.title || 'The agent needs clarification'}
+                      </p>
+                      {pendingInterrupt.description ? (
+                        <p className="mt-3 max-w-2xl text-sm leading-relaxed text-white/70">
+                          {pendingInterrupt.description}
+                        </p>
                       ) : null}
                     </div>
+                    {pendingInterrupt.stepCount && pendingInterrupt.stepCount > 1 ? (
+                      <div className="shrink-0 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/75">
+                        {typeof pendingInterrupt.stepIndex === 'number' ? pendingInterrupt.stepIndex + 1 : 1} of {pendingInterrupt.stepCount}
+                      </div>
+                    ) : null}
                   </div>
-                )}
-              </div>
+                  {clarificationDisplayPayload ? <div className="mt-5">{clarificationDisplayPayload}</div> : null}
+                  {clarificationAllowsChoices && clarificationChoices.length ? (
+                    <div className="mt-5 space-y-3">
+                      {clarificationChoices.map((choice, index) => {
+                        const selected = selectedChoiceIds.includes(choice.id);
+                        return (
+                          <button
+                            key={choice.id}
+                            type="button"
+                            disabled={interruptBusy}
+                            onClick={() => handleClarificationChoiceToggle(choice.id, choice.value)}
+                            className={`flex w-full items-start justify-between rounded-[1.35rem] border px-5 py-4 text-left transition-all duration-200 ${
+                              selected
+                                ? 'border-white/70 bg-white/14 text-white shadow-[0_12px_36px_-24px_rgba(255,255,255,0.65)]'
+                                : 'border-white/10 bg-white/[0.03] text-white/92 hover:border-white/25 hover:bg-white/[0.07]'
+                            } ${interruptBusy ? 'cursor-not-allowed opacity-70' : ''}`}
+                          >
+                            <div className="min-w-0 pr-3">
+                              <div className="flex items-center gap-3">
+                                <span className={`text-2xl font-semibold ${selected ? 'text-white' : 'text-white/45'}`}>{index + 1}.</span>
+                                <span className="text-[18px] font-semibold leading-snug">{choice.label}</span>
+                              </div>
+                              {choice.description ? (
+                                <p className="mt-2 pl-11 text-sm leading-relaxed text-white/62">{choice.description}</p>
+                              ) : null}
+                            </div>
+                            <span className={`mt-1 text-lg ${selected ? 'text-white' : 'text-white/35'}`}>{selected ? '↵' : ''}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  ) : null}
+                  {clarificationAllowsText ? (
+                    <textarea
+                      value={clarificationValue}
+                      onChange={(event) => setInterruptValue(clarificationTextKey, event.target.value)}
+                      rows={4}
+                      disabled={interruptBusy}
+                      placeholder={pendingInterrupt.responseSpec?.placeholder || 'Type your answer for the agent'}
+                      className="mt-5 w-full rounded-[1.35rem] border border-white/10 bg-white/[0.03] px-5 py-4 text-sm leading-relaxed text-white placeholder:text-white/32 focus:border-white/25 focus:outline-none disabled:cursor-not-allowed disabled:opacity-70"
+                    />
+                  ) : null}
+                  <div className="mt-6 flex items-center justify-between gap-4">
+                    <button
+                      type="button"
+                      disabled={!allowDismiss || interruptBusy}
+                      onClick={() => setClarificationDismissed(true)}
+                      className={`rounded-full px-4 py-2 text-sm font-medium transition-all duration-200 ${
+                        allowDismiss
+                          ? 'text-white/70 hover:bg-white/[0.06] hover:text-white'
+                          : 'cursor-not-allowed text-white/25'
+                      }`}
+                    >
+                      {pendingInterrupt.responseSpec?.dismissLabel || 'Dismiss'}
+                    </button>
+                    <button
+                      type="button"
+                      disabled={interruptBusy || (!clarificationValue.trim() && !selectedChoiceIds.length && clarificationInputMode !== 'none')}
+                      onClick={() => handleClarificationResponse(message, pendingInterrupt)}
+                      className="inline-flex items-center gap-2 rounded-full bg-[#94c5f8] px-5 py-3 text-sm font-semibold text-slate-900 transition-all duration-200 hover:bg-[#a8d2fb] disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      {interruptBusy ? <Loader2 size={16} className="animate-spin" /> : null}
+                      <span>{pendingInterrupt.responseSpec?.submitLabel || 'Continue'}</span>
+                    </button>
+                  </div>
+                </div>
               </div>
             ) : null}
             {hasToolEvents ? (
@@ -388,9 +626,7 @@ export default function ChatMessageBubble({
                   onClick={() => toggleToolActivityVisibility(message.id)}
                   className="text-xs font-semibold uppercase tracking-wide text-slate-500 transition-all duration-200 hover:text-slate-700"
                 >
-                  {isToolActivityExpanded
-                    ? 'Hide tool activity'
-                    : `Show tool activity (${toolEvents.length})`}
+                  {isToolActivityExpanded ? 'Hide tool activity' : `Show tool activity (${toolEvents.length})`}
                 </button>
                 {isToolActivityExpanded ? (
                   <div className="mt-2 rounded-2xl border border-slate-200 bg-white/80 px-3 py-3 text-xs text-slate-600 shadow-inner">
@@ -399,28 +635,15 @@ export default function ChatMessageBubble({
                       return (
                         <div key={event.id || `${event.name}-${index}`} className="flex min-w-0 gap-3 pb-3 last:pb-0">
                           <div className="flex flex-col items-center">
-                            <span
-                              className={`h-2.5 w-2.5 rounded-full ${event.status === 'completed' ? 'bg-emerald-500' : 'bg-amber-400'
-                                }`}
-                            />
+                            <span className={`h-2.5 w-2.5 rounded-full ${event.status === 'completed' ? 'bg-emerald-500' : 'bg-amber-400'}`} />
                             {!isLast ? <span className="h-full w-px flex-1 bg-slate-200" /> : null}
                           </div>
                           <div className="min-w-0 flex-1">
-                            <p
-                              className={`break-words text-[11px] font-semibold uppercase tracking-wide ${event.status === 'error' ? 'text-red-500' : 'text-slate-500'
-                                }`}
-                            >
+                            <p className={`break-words text-[11px] font-semibold uppercase tracking-wide ${event.status === 'error' ? 'text-red-500' : 'text-slate-500'}`}>
                               {event.name}
                             </p>
-                            <p
-                              className={`whitespace-pre-wrap break-words text-sm ${event.status === 'error' ? 'text-red-600' : 'text-slate-700'}`}
-                            >
-                              {event.summary ||
-                                (event.status === 'completed'
-                                  ? 'Completed'
-                                  : event.status === 'error'
-                                    ? 'Failed'
-                                    : 'In progress...')}
+                            <p className={`whitespace-pre-wrap break-words text-sm ${event.status === 'error' ? 'text-red-600' : 'text-slate-700'}`}>
+                              {event.summary || (event.status === 'completed' ? 'Completed' : event.status === 'error' ? 'Failed' : 'In progress...')}
                             </p>
                             <p className="mt-1 text-[11px] uppercase tracking-wide text-slate-400">
                               {formatMessageTimestamp(event.startedAt)}
@@ -444,7 +667,7 @@ export default function ChatMessageBubble({
                       );
                     })}
                   </div>
-                  ) : null}
+                ) : null}
               </div>
             ) : null}
           </div>
@@ -456,26 +679,28 @@ export default function ChatMessageBubble({
             ) : null}
           </div>
         )}
-        <button
-          type="button"
-          onClick={() => handleCopyMessageText(message)}
-          disabled={!canCopyMessage}
-          title={copyTitle}
-          aria-label="Copy message text"
-          className={`absolute -top-2 ${copyButtonPositionClass} rounded-full bg-white p-1.5 text-slate-600 shadow ring-1 ring-slate-200 transition-all duration-200 opacity-0 hover:bg-slate-50 group-hover:opacity-100 focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-40`}
-        >
-          <Copy size={14} />
-        </button>
+        {canCopyMessage ? (
+          <button
+            type="button"
+            onClick={() => handleCopyMessageText(message)}
+            title={copyTitle}
+            aria-label="Copy message text"
+            className={`absolute -top-2 ${copyButtonPositionClass} rounded-full bg-white p-1.5 text-slate-600 shadow ring-1 ring-slate-200 transition-all duration-200 opacity-0 hover:bg-slate-50 group-hover:opacity-100 focus-visible:opacity-100`}
+          >
+            <Copy size={14} />
+          </button>
+        ) : null}
         {message.sender === 'user' ? (
           <button
             type="button"
             onClick={() => handleRerunMessage(message.id)}
             disabled={isStreaming}
             title="Rerun this message"
-            className={`absolute -right-2 -top-2 rounded-full bg-blue-500 p-1.5 text-white shadow transition-all duration-200 opacity-0 ${isStreaming
+            className={`absolute -right-2 -top-2 rounded-full bg-blue-500 p-1.5 text-white shadow transition-all duration-200 opacity-0 ${
+              isStreaming
                 ? 'cursor-not-allowed group-hover:opacity-60 hover:opacity-60'
                 : 'group-hover:opacity-100 hover:opacity-100 focus-visible:opacity-100'
-              }`}
+            }`}
           >
             <RotateCcw size={14} />
           </button>

--- a/frontend/src/components/chat/ChatMessageList.tsx
+++ b/frontend/src/components/chat/ChatMessageList.tsx
@@ -13,19 +13,23 @@ export default function ChatMessageList({
   expandedToolMessages,
   expandedThinkingMessages,
   copiedMessageId,
-  approvalFeedbackByMessageId,
-  approvalSubmittingByMessageId,
-  approvalFieldKey,
+  interruptInputByMessageId,
+  interruptSelectedChoicesByMessageId,
+  interruptSubmittingByMessageId,
+  interruptFieldKey,
   formatMessageTimestamp,
+  getInterruptKind,
   getAllowedDecisions,
   getPrimaryInterruptAction,
   isPlanApprovalInterrupt,
-  setApprovalFeedbackByMessageId,
+  setInterruptInputByMessageId,
+  setInterruptSelectedChoicesByMessageId,
   toggleThinkingVisibility,
   toggleToolActivityVisibility,
   handleCopyMessageText,
   handleRerunMessage,
   handleInterruptDecision,
+  handleClarificationResponse,
   workspaceId,
 }: {
   messages: ConversationMessage[];
@@ -36,10 +40,17 @@ export default function ChatMessageList({
   expandedToolMessages: Set<ConversationMessage['id']>;
   expandedThinkingMessages: Set<ConversationMessage['id']>;
   copiedMessageId: ConversationMessage['id'] | null;
-  approvalFeedbackByMessageId: Record<string, string>;
-  approvalSubmittingByMessageId: Record<string, boolean>;
-  approvalFieldKey: (messageKey: string, field: 'feedback' | 'edit-json' | 'reject-note') => string;
+  interruptInputByMessageId: Record<string, string>;
+  interruptSelectedChoicesByMessageId: Record<string, string[]>;
+  interruptSubmittingByMessageId: Record<string, boolean>;
+  interruptFieldKey: (
+    messageKey: string,
+    field: 'feedback' | 'edit-json' | 'reject-note' | 'clarification-text',
+  ) => string;
   formatMessageTimestamp: (value?: string) => string;
+  getInterruptKind: (
+    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  ) => 'approval' | 'clarification';
   getAllowedDecisions: (
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => Array<'approve' | 'edit' | 'reject'>;
@@ -47,7 +58,8 @@ export default function ChatMessageList({
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => { name?: string; args?: Record<string, unknown> } | undefined;
   isPlanApprovalInterrupt: (pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt']) => boolean;
-  setApprovalFeedbackByMessageId: Dispatch<SetStateAction<Record<string, string>>>;
+  setInterruptInputByMessageId: Dispatch<SetStateAction<Record<string, string>>>;
+  setInterruptSelectedChoicesByMessageId: Dispatch<SetStateAction<Record<string, string[]>>>;
   toggleThinkingVisibility: (messageId: ConversationMessage['id']) => void;
   toggleToolActivityVisibility: (messageId: ConversationMessage['id']) => void;
   handleCopyMessageText: (message: ConversationMessage) => void;
@@ -55,6 +67,10 @@ export default function ChatMessageList({
   handleInterruptDecision: (
     message: ConversationMessage,
     decision: 'approve' | 'edit' | 'reject',
+    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  ) => void;
+  handleClarificationResponse: (
+    message: ConversationMessage,
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => void;
   workspaceId?: string;
@@ -123,19 +139,23 @@ export default function ChatMessageList({
           expandedToolMessages={expandedToolMessages}
           expandedThinkingMessages={expandedThinkingMessages}
           copiedMessageId={copiedMessageId}
-          approvalFeedbackByMessageId={approvalFeedbackByMessageId}
-          approvalSubmittingByMessageId={approvalSubmittingByMessageId}
-          approvalFieldKey={approvalFieldKey}
+          interruptInputByMessageId={interruptInputByMessageId}
+          interruptSelectedChoicesByMessageId={interruptSelectedChoicesByMessageId}
+          interruptSubmittingByMessageId={interruptSubmittingByMessageId}
+          interruptFieldKey={interruptFieldKey}
           formatMessageTimestamp={formatMessageTimestamp}
+          getInterruptKind={getInterruptKind}
           getAllowedDecisions={getAllowedDecisions}
           getPrimaryInterruptAction={getPrimaryInterruptAction}
           isPlanApprovalInterrupt={isPlanApprovalInterrupt}
-          setApprovalFeedbackByMessageId={setApprovalFeedbackByMessageId}
+          setInterruptInputByMessageId={setInterruptInputByMessageId}
+          setInterruptSelectedChoicesByMessageId={setInterruptSelectedChoicesByMessageId}
           toggleThinkingVisibility={toggleThinkingVisibility}
           toggleToolActivityVisibility={toggleToolActivityVisibility}
           handleCopyMessageText={handleCopyMessageText}
           handleRerunMessage={handleRerunMessage}
           handleInterruptDecision={handleInterruptDecision}
+          handleClarificationResponse={handleClarificationResponse}
           isStreaming={isStreaming}
           workspaceId={workspaceId}
         />,
@@ -143,16 +163,19 @@ export default function ChatMessageList({
     });
     return nodes;
   }, [
-    approvalFeedbackByMessageId,
-    approvalFieldKey,
-    approvalSubmittingByMessageId,
+    interruptFieldKey,
+    interruptInputByMessageId,
+    interruptSelectedChoicesByMessageId,
+    interruptSubmittingByMessageId,
     copiedMessageId,
     expandedThinkingMessages,
     expandedToolMessages,
     formatMessageTimestamp,
+    getInterruptKind,
     getAllowedDecisions,
     getPrimaryInterruptAction,
     handleCopyMessageText,
+    handleClarificationResponse,
     handleInterruptDecision,
     handleRerunMessage,
     isPlanApprovalInterrupt,
@@ -161,7 +184,8 @@ export default function ChatMessageList({
     messageBubbleMaxWidth,
     messages,
     personaDisplayName,
-    setApprovalFeedbackByMessageId,
+    setInterruptInputByMessageId,
+    setInterruptSelectedChoicesByMessageId,
     toggleThinkingVisibility,
     toggleToolActivityVisibility,
     workspaceId,

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -29,6 +29,7 @@ import {
   startAgentRun,
   streamAgentRun,
   submitRunDecision,
+  submitRunResponse,
   type AgentRunStatus,
   type AgentStreamChunk,
 } from '../services/agentApi';
@@ -66,7 +67,7 @@ import {
   SLASH_COMMANDS,
 } from '../constants/workspace';
 import { getFileDisplayName, getFileTypeIcon, isSystemFile, normalizeFilePath } from '../utils/files';
-import { buildMessageMetadata, mapMessagesToAgentHistory, mergeMessageMetadata } from '../utils/messages';
+import { buildMessageMetadata, mapMessagesToAgentHistory, mergeMessageMetadata, sanitizeRunPolicy } from '../utils/messages';
 
 const drawerWidth = 280;
 
@@ -188,11 +189,17 @@ const mergePersistedAgentMessage = (
   const hydrated = mergeMessageMetadata(persisted);
   const persistedMetadata = (hydrated.metadata as ConversationMessageMetadata | null | undefined) || {};
   const existingMetadata = (existing?.metadata as ConversationMessageMetadata | null | undefined) || {};
-  const effectiveStatus = persistedMetadata.status ?? existingMetadata.status;
+  const persistedStatus = persistedMetadata.status;
+  const existingStatus = existingMetadata.status;
+  const effectiveStatus =
+    (persistedStatus === 'running' || persistedStatus === 'queued') && existingStatus === 'awaiting_approval'
+      ? 'awaiting_approval'
+      : persistedStatus ?? existingStatus;
 
   const mergedMetadata: ConversationMessageMetadata = {
     ...existingMetadata,
     ...persistedMetadata,
+    status: effectiveStatus,
     runPolicy: persistedMetadata.runPolicy ?? existingMetadata.runPolicy,
     pendingInterrupt:
       persistedMetadata.pendingInterrupt !== undefined
@@ -289,6 +296,7 @@ export default function WorkspacePage() {
   const activeRunsRef = useRef<Record<string, ActiveRunInfo>>({});
   const lastPersistedAgentTextRef = useRef<Record<string, string>>({});
   const lastPersistedStatusRef = useRef<Record<string, AgentRunStatus | undefined>>({});
+  const lastPersistedMetadataRef = useRef<Record<string, string | undefined>>({});
   const persistInFlightRef = useRef<Set<string>>(new Set());
   const stopRequestedRef = useRef(false);
   const chatInputRef = useRef<HTMLTextAreaElement | null>(null);
@@ -313,8 +321,9 @@ export default function WorkspacePage() {
   const [ragStatuses, setRagStatuses] = useState<Record<string, { status?: string; updatedAt?: string; error?: string }>>({});
   const [copiedWorkspaceContent, setCopiedWorkspaceContent] = useState(false);
   const [copiedMessageId, setCopiedMessageId] = useState<ConversationMessage['id'] | null>(null);
-  const [approvalFeedbackByMessageId, setApprovalFeedbackByMessageId] = useState<Record<string, string>>({});
-  const [approvalSubmittingByMessageId, setApprovalSubmittingByMessageId] = useState<Record<string, boolean>>({});
+  const [interruptInputByMessageId, setInterruptInputByMessageId] = useState<Record<string, string>>({});
+  const [interruptSelectedChoicesByMessageId, setInterruptSelectedChoicesByMessageId] = useState<Record<string, string[]>>({});
+  const [interruptSubmittingByMessageId, setInterruptSubmittingByMessageId] = useState<Record<string, boolean>>({});
   const ragStatusFetchedRef = useRef<Record<string, boolean>>({});
   const resumeInFlightRef = useRef<Set<string>>(new Set());
   const resumeAttemptedRef = useRef<Set<string>>(new Set());
@@ -367,6 +376,7 @@ export default function WorkspacePage() {
     persistActiveRuns(next);
     delete lastPersistedAgentTextRef.current[runId];
     delete lastPersistedStatusRef.current[runId];
+    delete lastPersistedMetadataRef.current[runId];
     resumeInFlightRef.current.delete(runId);
     resumeAttemptedRef.current.delete(runId);
   }, [persistActiveRuns]);
@@ -2006,18 +2016,20 @@ export default function WorkspacePage() {
       if (persistInFlightRef.current.has(runId)) {
         return;
       }
+      const message = findAgentMessageForRun(conversationId, placeholderId, turnId);
       const text = getBufferedAgentText(runInfo);
       const lastText = lastPersistedAgentTextRef.current[runId];
-      const nextStatus = statusOverride || 'running';
+      const nextStatus = statusOverride || message?.metadata?.status || runInfo.status || 'running';
       const lastStatus = lastPersistedStatusRef.current[runId];
-      if (text === lastText && nextStatus === lastStatus) {
-        return;
-      }
-      const message = findAgentMessageForRun(conversationId, placeholderId, turnId);
-      if (!text && !message?.thinkingText && !message?.toolEvents?.length) {
-        return;
-      }
       const metadata = { ...(buildMessageMetadata(message) || {}), runId, status: nextStatus };
+      const metadataSignature = JSON.stringify(metadata);
+      const lastMetadataSignature = lastPersistedMetadataRef.current[runId];
+      if (text === lastText && nextStatus === lastStatus && metadataSignature === lastMetadataSignature) {
+        return;
+      }
+      if (!text && !message?.thinkingText && !message?.toolEvents?.length && !message?.metadata?.pendingInterrupt) {
+        return;
+      }
       persistInFlightRef.current.add(runId);
       try {
         const persisted = await appendConversationMessage(conversationId, 'agent', text, {
@@ -2041,6 +2053,7 @@ export default function WorkspacePage() {
         });
         lastPersistedAgentTextRef.current[runId] = text;
         lastPersistedStatusRef.current[runId] = nextStatus;
+        lastPersistedMetadataRef.current[runId] = metadataSignature;
         agentMessageBufferRef.current.set(persisted.id, persisted.text || '');
         if (placeholderId !== persisted.id) {
           agentMessageBufferRef.current.delete(placeholderId);
@@ -2095,9 +2108,18 @@ export default function WorkspacePage() {
     return actionRequests[0];
   }, []);
 
+  const getInterruptKind = useCallback((
+    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  ): 'approval' | 'clarification' => (
+    pendingInterrupt?.kind === 'clarification' ? 'clarification' : 'approval'
+  ), []);
+
   const isPlanApprovalInterrupt = useCallback((
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ): boolean => {
+    if (getInterruptKind(pendingInterrupt) === 'clarification') {
+      return false;
+    }
     const actionRequests = Array.isArray(pendingInterrupt?.actionRequests) ? pendingInterrupt.actionRequests : [];
     const reviewConfigs = Array.isArray(pendingInterrupt?.reviewConfigs) ? pendingInterrupt.reviewConfigs : [];
     const firstActionName = typeof actionRequests[0]?.name === 'string'
@@ -2113,11 +2135,11 @@ export default function WorkspacePage() {
       const name = typeof config?.action_name === 'string' ? config.action_name.trim().toLowerCase() : '';
       return name === 'request_plan_approval' || (name.includes('plan') && name.includes('approval'));
     });
-  }, [getPrimaryInterruptAction]);
+  }, [getInterruptKind, getPrimaryInterruptAction]);
 
-  const approvalFieldKey = useCallback((
+  const interruptFieldKey = useCallback((
     messageKey: string,
-    field: 'feedback' | 'edit-json' | 'reject-note',
+    field: 'feedback' | 'edit-json' | 'reject-note' | 'clarification-text',
   ): string => `${messageKey}:${field}`, []);
 
   const getAllowedDecisions = useCallback((
@@ -2153,17 +2175,18 @@ export default function WorkspacePage() {
     }
 
     if (chunk.type === 'policy') {
+      const nextRunPolicy = sanitizeRunPolicy({
+        skill: chunk.skill,
+        requiresHitlPlan: chunk.requiresHitlPlan,
+        requiresArtifacts: chunk.requiresArtifacts,
+        requiredArtifactsMode: chunk.requiredArtifactsMode,
+        prePlanSearchLimit: chunk.prePlanSearchLimit,
+        prePlanSearchUsed: chunk.prePlanSearchUsed,
+      });
       updateMessageMetadataAtIndex(conversationId, agentMessageIndex, (metadata) => ({
         ...metadata,
         ...(runId ? { runId } : {}),
-        runPolicy: {
-          skill: chunk.skill,
-          requiresHitlPlan: chunk.requiresHitlPlan,
-          requiresArtifacts: chunk.requiresArtifacts,
-          requiredArtifactsMode: chunk.requiredArtifactsMode,
-          prePlanSearchLimit: chunk.prePlanSearchLimit,
-          prePlanSearchUsed: chunk.prePlanSearchUsed,
-        },
+        runPolicy: nextRunPolicy,
       }));
       return;
     }
@@ -2199,8 +2222,16 @@ export default function WorkspacePage() {
         ...(runId ? { runId } : {}),
         status: 'awaiting_approval',
         pendingInterrupt: {
+          kind: chunk.kind,
+          interruptId: chunk.interruptId,
+          title: chunk.title,
+          description: chunk.description,
+          stepIndex: chunk.stepIndex,
+          stepCount: chunk.stepCount,
           actionRequests: chunk.actionRequests,
           reviewConfigs: chunk.reviewConfigs,
+          responseSpec: chunk.responseSpec,
+          displayPayload: chunk.displayPayload,
         },
       }));
       return;
@@ -2235,6 +2266,10 @@ export default function WorkspacePage() {
   const streamRunForConversation = useCallback(
     async (runInfo: ActiveRunInfo, replayFromStart = false) => {
       const { conversationId, runId, turnId, placeholderId } = runInfo;
+      // Mark the run as actively handled before any state updates land so the
+      // resume effect does not start a second stream for the same run.
+      resumeAttemptedRef.current.add(runId);
+      resumeInFlightRef.current.add(runId);
       cancelStreamForConversation(conversationId);
       const agentMessageIndex = ensureAgentPlaceholder(conversationId, placeholderId, turnId, replayFromStart);
       if (agentMessageIndex < 0) {
@@ -2254,6 +2289,9 @@ export default function WorkspacePage() {
       streamAbortMapRef.current.set(conversationId, controller);
       setStreamingForConversation(conversationId, true);
       let finalStatus: AgentRunStatus = 'completed';
+      let latestInterrupt:
+        | ConversationMessageMetadata['pendingInterrupt']
+        | undefined;
 
       try {
         if (STREAM_DEBUG_ENABLED) {
@@ -2261,7 +2299,23 @@ export default function WorkspacePage() {
         }
         await streamAgentRun(
           runId,
-          (chunk) => handleStreamChunk(conversationId, agentMessageIndex, chunk, runId),
+          (chunk) => {
+            if (chunk.type === 'interrupt') {
+              latestInterrupt = {
+                kind: chunk.kind,
+                interruptId: chunk.interruptId,
+                title: chunk.title,
+                description: chunk.description,
+                stepIndex: chunk.stepIndex,
+                stepCount: chunk.stepCount,
+                actionRequests: chunk.actionRequests,
+                reviewConfigs: chunk.reviewConfigs,
+                responseSpec: chunk.responseSpec,
+                displayPayload: chunk.displayPayload,
+              };
+            }
+            handleStreamChunk(conversationId, agentMessageIndex, chunk, runId);
+          },
           controller.signal,
           replayFromStart ? undefined : undefined
         );
@@ -2276,11 +2330,37 @@ export default function WorkspacePage() {
           finalStatus = 'failed';
         }
       } finally {
+        let latestRunMeta:
+          | Awaited<ReturnType<typeof getRunStatus>>
+          | null = null;
         try {
-          const latest = await getRunStatus(runId);
-          finalStatus = latest.status;
+          latestRunMeta = await getRunStatus(runId);
+          finalStatus = latestRunMeta.status;
+          // The stream can close before the backend worker updates Redis from
+          // "running" to its settled terminal/approval state. Poll briefly so
+          // we don't persist a stale running bubble and drop the pending interrupt.
+          if (finalStatus === 'running' || finalStatus === 'queued') {
+            for (let attempt = 0; attempt < 8; attempt += 1) {
+              await new Promise((resolve) => window.setTimeout(resolve, 250));
+              latestRunMeta = await getRunStatus(runId);
+              finalStatus = latestRunMeta.status;
+              if (finalStatus !== 'running' && finalStatus !== 'queued') {
+                break;
+              }
+            }
+          }
         } catch (statusError) {
           console.error('Failed to fetch final run status', statusError);
+        }
+        const effectivePendingInterrupt = latestRunMeta?.pendingInterrupt ?? latestInterrupt;
+        if (effectivePendingInterrupt) {
+            finalStatus = 'awaiting_approval';
+            updateMessageMetadataAtIndex(conversationId, agentMessageIndex, (metadata) => ({
+              ...metadata,
+              ...(runId ? { runId } : {}),
+              status: 'awaiting_approval',
+              pendingInterrupt: effectivePendingInterrupt,
+            }));
         }
         if (STREAM_DEBUG_ENABLED) {
           console.debug('[WorkspacePage] stream finished', { runId, status: finalStatus });
@@ -2290,6 +2370,7 @@ export default function WorkspacePage() {
         setStreamingForConversation(conversationId, false);
         streamAbortMapRef.current.delete(conversationId);
         stopRequestedRef.current = false;
+        resumeInFlightRef.current.delete(runId);
         if (finalStatus === 'awaiting_approval') {
           registerActiveRun({ ...runInfo, status: finalStatus });
         } else {
@@ -2348,10 +2429,10 @@ export default function WorkspacePage() {
       const primaryAction = getPrimaryInterruptAction(pendingInterrupt);
       const isPlanApproval = isPlanApprovalInterrupt(pendingInterrupt);
       const feedbackKey = isPlanApproval
-        ? approvalFieldKey(messageKey, 'feedback')
-        : approvalFieldKey(messageKey, 'reject-note');
-      const rawFeedback = (approvalFeedbackByMessageId[feedbackKey] || '').trim();
-      setApprovalSubmittingByMessageId((prev) => ({ ...prev, [messageKey]: true }));
+        ? interruptFieldKey(messageKey, 'feedback')
+        : interruptFieldKey(messageKey, 'reject-note');
+      const rawFeedback = (interruptInputByMessageId[feedbackKey] || '').trim();
+      setInterruptSubmittingByMessageId((prev) => ({ ...prev, [messageKey]: true }));
       try {
         const options: {
           editedAction?: { name: string; args: Record<string, unknown> };
@@ -2375,7 +2456,7 @@ export default function WorkspacePage() {
             };
             options.message = rawFeedback || 'User requested edits.';
           } else {
-            const rawEditArgs = (approvalFeedbackByMessageId[approvalFieldKey(messageKey, 'edit-json')] || '').trim();
+            const rawEditArgs = (interruptInputByMessageId[interruptFieldKey(messageKey, 'edit-json')] || '').trim();
             let parsedArgs: Record<string, unknown> = {};
             if (rawEditArgs) {
               try {
@@ -2419,17 +2500,97 @@ export default function WorkspacePage() {
         console.error('Failed to submit approval decision', error);
         addLocalSystemMessage(error instanceof Error ? error.message : 'Failed to submit approval decision.');
       } finally {
-        setApprovalSubmittingByMessageId((prev) => ({ ...prev, [messageKey]: false }));
+        setInterruptSubmittingByMessageId((prev) => ({ ...prev, [messageKey]: false }));
       }
     },
     [
       addLocalSystemMessage,
-      approvalFeedbackByMessageId,
-      approvalFieldKey,
+      interruptInputByMessageId,
+      interruptFieldKey,
       findRunIdForMessage,
       getPrimaryInterruptAction,
       getAllowedDecisions,
       isPlanApprovalInterrupt,
+      streamRunForConversation,
+      updateMessagesForConversation,
+    ],
+  );
+
+  const handleClarificationResponse = useCallback(
+    async (
+      message: ConversationMessage,
+      pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+    ) => {
+      if (getInterruptKind(pendingInterrupt) !== 'clarification') {
+        addLocalSystemMessage('This interruption expects an approval decision, not a clarification response.');
+        return;
+      }
+      const runId = findRunIdForMessage(message);
+      if (!runId) {
+        addLocalSystemMessage('Missing run id for clarification response.');
+        return;
+      }
+      const messageKey = String(message.id);
+      const textKey = interruptFieldKey(messageKey, 'clarification-text');
+      const rawMessage = (interruptInputByMessageId[textKey] || '').trim();
+      const selectedChoiceIds = interruptSelectedChoicesByMessageId[messageKey] || [];
+      const choices = pendingInterrupt?.responseSpec?.choices || [];
+      const selectedValues = selectedChoiceIds
+        .map((choiceId) => choices.find((choice) => choice.id === choiceId)?.value)
+        .filter((value): value is string => typeof value === 'string');
+
+      if (!rawMessage && !selectedChoiceIds.length && !selectedValues.length) {
+        addLocalSystemMessage('Choose an option or enter a clarification response before continuing.');
+        return;
+      }
+
+      setInterruptSubmittingByMessageId((prev) => ({ ...prev, [messageKey]: true }));
+      try {
+        await submitRunResponse(runId, {
+          message: rawMessage || undefined,
+          selectedChoiceIds: selectedChoiceIds.length ? selectedChoiceIds : undefined,
+          selectedValues: selectedValues.length ? selectedValues : undefined,
+        });
+        updateMessagesForConversation(message.conversationId, (prev) => {
+          const next = [...prev];
+          const idx = next.findIndex((item) => item.id === message.id);
+          if (idx === -1) return next;
+          const current = next[idx];
+          const metadata = { ...((current.metadata as ConversationMessageMetadata | undefined) || {}) };
+          metadata.pendingInterrupt = undefined;
+          next[idx] = { ...current, metadata };
+          return next;
+        });
+        setInterruptInputByMessageId((prev) => {
+          const next = { ...prev };
+          delete next[textKey];
+          return next;
+        });
+        setInterruptSelectedChoicesByMessageId((prev) => {
+          const next = { ...prev };
+          delete next[messageKey];
+          return next;
+        });
+        const runInfo = activeRunsRef.current[runId];
+        if (runInfo) {
+          await streamRunForConversation(runInfo, false);
+        } else {
+          addLocalSystemMessage('Response saved. Refreshing stream state...');
+        }
+      } catch (error) {
+        console.error('Failed to submit clarification response', error);
+        addLocalSystemMessage(error instanceof Error ? error.message : 'Failed to submit clarification response.');
+      } finally {
+        setInterruptSubmittingByMessageId((prev) => ({ ...prev, [messageKey]: false }));
+      }
+    },
+    [
+      addLocalSystemMessage,
+      findRunIdForMessage,
+      getInterruptKind,
+      interruptFieldKey,
+      interruptInputByMessageId,
+      interruptSelectedChoicesByMessageId,
       streamRunForConversation,
       updateMessagesForConversation,
     ],
@@ -2473,6 +2634,29 @@ export default function WorkspacePage() {
                 resumeInFlightRef.current.delete(activeRun.runId);
               });
           } else if (status.status === 'awaiting_approval') {
+            const targetMessage = findAgentMessageForRun(
+              activeRun.conversationId,
+              activeRun.placeholderId,
+              activeRun.turnId
+            );
+            if (targetMessage?.metadata?.runId || status.pendingInterrupt) {
+              updateMessagesForConversation(activeRun.conversationId, (prev) => {
+                const updated = [...prev];
+                const idx = updated.findIndex((message) => message.id === targetMessage?.id);
+                if (idx === -1) {
+                  return updated;
+                }
+                const current = updated[idx];
+                const metadata = { ...((current.metadata as ConversationMessageMetadata | undefined) || {}) };
+                metadata.runId = metadata.runId || activeRun.runId;
+                metadata.status = 'awaiting_approval';
+                if (status.pendingInterrupt) {
+                  metadata.pendingInterrupt = status.pendingInterrupt;
+                }
+                updated[idx] = { ...current, metadata };
+                return updated;
+              });
+            }
             resumeInFlightRef.current.delete(activeRun.runId);
           } else {
             resumeInFlightRef.current.delete(activeRun.runId);
@@ -3809,8 +3993,9 @@ export default function WorkspacePage() {
               expandedToolMessages={expandedToolMessages}
               expandedThinkingMessages={expandedThinkingMessages}
               copiedMessageId={copiedMessageId}
-              approvalFeedbackByMessageId={approvalFeedbackByMessageId}
-              approvalSubmittingByMessageId={approvalSubmittingByMessageId}
+              interruptInputByMessageId={interruptInputByMessageId}
+              interruptSelectedChoicesByMessageId={interruptSelectedChoicesByMessageId}
+              interruptSubmittingByMessageId={interruptSubmittingByMessageId}
               chatMessage={chatMessage}
               chatAttachments={chatAttachments}
               showPaper2SlidesControls={showPaper2SlidesControls}
@@ -3826,11 +4011,13 @@ export default function WorkspacePage() {
               attachmentInputRef={attachmentInputRef}
               workspaceId={selectedWorkspace?.id}
               formatMessageTimestamp={formatMessageTimestamp}
-              approvalFieldKey={approvalFieldKey}
+              interruptFieldKey={interruptFieldKey}
+              getInterruptKind={getInterruptKind}
               getAllowedDecisions={getAllowedDecisions}
               getPrimaryInterruptAction={getPrimaryInterruptAction}
               isPlanApprovalInterrupt={isPlanApprovalInterrupt}
-              setApprovalFeedbackByMessageId={setApprovalFeedbackByMessageId}
+              setInterruptInputByMessageId={setInterruptInputByMessageId}
+              setInterruptSelectedChoicesByMessageId={setInterruptSelectedChoicesByMessageId}
               onToggleAgentPaneVisibility={() => setIsAgentPaneVisible((prev) => !prev)}
               onModeChange={handleModeChange}
               onToggleHistory={() => setIsHistoryOpen((prev) => !prev)}
@@ -3844,6 +4031,7 @@ export default function WorkspacePage() {
               onCopyMessageText={handleCopyMessageText}
               onRerunMessage={handleRerunMessage}
               onInterruptDecision={handleInterruptDecision}
+              onClarificationResponse={handleClarificationResponse}
               onChatInputChange={handleChatInputChange}
               onChatInputKeyDown={handleChatInputKeyDown}
               onChatInputKeyUp={handleChatInputKeyUp}

--- a/frontend/src/services/agentApi.ts
+++ b/frontend/src/services/agentApi.ts
@@ -1,6 +1,7 @@
 import { streamAgentRunWithReconnect, type AgentStreamChunk } from '../../../packages/shared/src/services/agentStream';
 export type { AgentStreamChunk };
 import { API_URL, apiFetch } from './apiClient';
+import type { ConversationMessageMetadata } from '../types';
 
 const STREAM_DEBUG_ENABLED =
   typeof import.meta !== 'undefined' &&
@@ -63,7 +64,15 @@ export const streamAgentRun = async (
   });
 };
 
-export const getRunStatus = async (runId: string): Promise<{ status: AgentRunStatus; workspaceId: string; persona: string; turnId?: string }> => {
+export const getRunStatus = async (
+  runId: string,
+): Promise<{
+  status: AgentRunStatus;
+  workspaceId: string;
+  persona: string;
+  turnId?: string;
+  pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'];
+}> => {
   const response = await apiFetch(`${API_URL}/agent/runs/${runId}`);
   if (!response.ok) {
     throw new Error('Failed to fetch run status');
@@ -102,6 +111,27 @@ export const submitRunDecision = async (
   });
   if (!response.ok) {
     throw new Error('Failed to submit run decision');
+  }
+  return response.json();
+};
+
+export const submitRunResponse = async (
+  runId: string,
+  payload: {
+    message?: string;
+    selectedChoiceIds?: string[];
+    selectedValues?: string[];
+  },
+) => {
+  const response = await apiFetch(`${API_URL}/agent/runs/${runId}/respond`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error('Failed to submit clarification response');
   }
   return response.json();
 };

--- a/frontend/src/utils/messages.ts
+++ b/frontend/src/utils/messages.ts
@@ -1,5 +1,35 @@
 import type { ConversationMessage, ConversationMessageMetadata } from '../types';
 
+const sanitizeRunPolicy = (
+  runPolicy?: ConversationMessageMetadata['runPolicy'],
+): ConversationMessageMetadata['runPolicy'] | undefined => {
+  if (!runPolicy) {
+    return undefined;
+  }
+
+  const sanitized: NonNullable<ConversationMessageMetadata['runPolicy']> = {};
+  if (typeof runPolicy.skill === 'string' && runPolicy.skill.trim()) {
+    sanitized.skill = runPolicy.skill;
+  }
+  if (typeof runPolicy.requiresHitlPlan === 'boolean') {
+    sanitized.requiresHitlPlan = runPolicy.requiresHitlPlan;
+  }
+  if (typeof runPolicy.requiresArtifacts === 'boolean') {
+    sanitized.requiresArtifacts = runPolicy.requiresArtifacts;
+  }
+  if (typeof runPolicy.requiredArtifactsMode === 'string' && runPolicy.requiredArtifactsMode.trim()) {
+    sanitized.requiredArtifactsMode = runPolicy.requiredArtifactsMode;
+  }
+  if (typeof runPolicy.prePlanSearchLimit === 'number') {
+    sanitized.prePlanSearchLimit = runPolicy.prePlanSearchLimit;
+  }
+  if (typeof runPolicy.prePlanSearchUsed === 'number') {
+    sanitized.prePlanSearchUsed = runPolicy.prePlanSearchUsed;
+  }
+
+  return Object.keys(sanitized).length ? sanitized : undefined;
+};
+
 export const mapMessagesToAgentHistory = (messages: ConversationMessage[]) => {
   return messages
     .filter((message) => typeof message.text === 'string' && message.text.trim().length > 0)
@@ -41,10 +71,15 @@ export const buildMessageMetadata = (
     metadata.toolEvents = message.toolEvents;
   }
   if (existingMetadata?.runPolicy) {
-    metadata.runPolicy = existingMetadata.runPolicy;
+    const sanitizedRunPolicy = sanitizeRunPolicy(existingMetadata.runPolicy);
+    if (sanitizedRunPolicy) {
+      metadata.runPolicy = sanitizedRunPolicy;
+    }
   }
   if (existingMetadata?.pendingInterrupt) {
     metadata.pendingInterrupt = existingMetadata.pendingInterrupt;
   }
   return Object.keys(metadata).length ? metadata : undefined;
 };
+
+export { sanitizeRunPolicy };

--- a/packages/shared/src/services/agentStream.ts
+++ b/packages/shared/src/services/agentStream.ts
@@ -16,8 +16,23 @@ export type AgentStreamChunk =
   | {
       type: 'interrupt';
       interruptId?: string;
+      kind?: 'approval' | 'clarification';
+      title?: string;
+      description?: string;
+      stepIndex?: number;
+      stepCount?: number;
       actionRequests?: Array<{ name?: string; args?: Record<string, unknown> }>;
       reviewConfigs?: Array<{ action_name?: string; allowed_decisions?: string[] }>;
+      responseSpec?: {
+        inputMode?: 'none' | 'text' | 'choice' | 'text_or_choice';
+        multiple?: boolean;
+        submitLabel?: string;
+        placeholder?: string;
+        allowDismiss?: boolean;
+        dismissLabel?: string;
+        choices?: Array<{ id: string; label: string; description?: string; value: string }>;
+      };
+      displayPayload?: Record<string, unknown>;
     }
   | { type: 'keepalive' }
   | { type: 'done' }
@@ -83,6 +98,7 @@ export const streamAgentRunWithReconnect = async ({
       const decoder = new TextDecoder();
       let buffer = '';
       let sawChunk = false;
+      let sawTerminalChunk = false;
 
       while (true) {
         const { value, done } = await reader.read();
@@ -100,6 +116,9 @@ export const streamAgentRunWithReconnect = async ({
               const chunk = JSON.parse(line);
               onChunkWithResume(chunk);
               sawChunk = true;
+              if (chunk?.type === 'done') {
+                sawTerminalChunk = true;
+              }
               if (debug) {
                 console.debug('[AgentRunStream] chunk', chunk);
               }
@@ -107,21 +126,34 @@ export const streamAgentRunWithReconnect = async ({
               console.error('Failed to parse stream chunk', error, line);
             }
           }
+          if (sawTerminalChunk) {
+            break;
+          }
           newlineIndex = buffer.indexOf('\n');
+        }
+        if (sawTerminalChunk) {
+          break;
         }
       }
 
-      if (buffer.trim()) {
+      if (!sawTerminalChunk && buffer.trim()) {
         try {
           const chunk = JSON.parse(buffer.trim());
           onChunkWithResume(chunk);
           sawChunk = true;
+          if (chunk?.type === 'done') {
+            sawTerminalChunk = true;
+          }
           if (debug) {
             console.debug('[AgentRunStream] trailing chunk', chunk);
           }
         } catch (error) {
           console.error('Failed to parse trailing stream chunk', error, buffer);
         }
+      }
+
+      if (sawTerminalChunk) {
+        await reader.cancel().catch(() => undefined);
       }
 
       if (sawChunk) {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -46,15 +46,42 @@ export interface ToolOutputFile {
   size?: number;
 }
 
+export interface InterruptChoice {
+  id: string;
+  label: string;
+  description?: string;
+  value: string;
+}
+
+export interface InterruptResponseSpec {
+  inputMode?: 'none' | 'text' | 'choice' | 'text_or_choice';
+  multiple?: boolean;
+  submitLabel?: string;
+  placeholder?: string;
+  allowDismiss?: boolean;
+  dismissLabel?: string;
+  choices?: InterruptChoice[];
+}
+
+export interface PendingInterrupt {
+  kind?: 'approval' | 'clarification';
+  interruptId?: string;
+  title?: string;
+  description?: string;
+  stepIndex?: number;
+  stepCount?: number;
+  actionRequests?: Array<{ name?: string; args?: Record<string, unknown> }>;
+  reviewConfigs?: Array<{ action_name?: string; allowed_decisions?: string[] }>;
+  responseSpec?: InterruptResponseSpec;
+  displayPayload?: Record<string, unknown>;
+}
+
 export interface ConversationMessageMetadata {
   thinkingText?: string;
   toolEvents?: ToolEvent[];
   runId?: string;
   status?: 'queued' | 'running' | 'awaiting_approval' | 'completed' | 'failed' | 'cancelled';
-  pendingInterrupt?: {
-    actionRequests?: Array<{ name?: string; args?: Record<string, unknown> }>;
-    reviewConfigs?: Array<{ action_name?: string; allowed_decisions?: string[] }>;
-  };
+  pendingInterrupt?: PendingInterrupt;
   runPolicy?: {
     skill?: string;
     requiresHitlPlan?: boolean;


### PR DESCRIPTION
## Summary
- add additive HITL interrupt support for clarification prompts alongside existing approval interrupts
- add same-run clarification resume APIs and agent runtime plumbing, including a new `request_clarification` builtin tool
- render clarification interrupts in the workspace chat as a poll-style card with choices, optional text input, keyboard navigation, and continue action
- add the missing backend `@types/ws` dev dependency so backend typecheck can pass

## Verification
- `python3 -m py_compile agent/helpudoc_agent/app.py agent/helpudoc_agent/tools_and_schemas.py agent/helpudoc_agent/graph.py`
- `npm exec -- tsc -b --pretty false` in `frontend`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run build` in `frontend`
- `npm exec -- tsc -p tsconfig.json --noEmit --pretty false` in `backend`
