### PR TITLE
Fix dynamic HITL run state and chat stream rendering

### DIFF
--- a/.github/workflows/deploy-frontend-gke.yml
+++ b/.github/workflows/deploy-frontend-gke.yml
@@ -79,7 +79,10 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
         run: |
           set -euo pipefail
-          docker build -f frontend/Dockerfile.gke --build-arg "VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID}" -t "gcr.io/${PROJECT_ID}/helpudoc-frontend:${IMAGE_TAG}" .
+          docker build -f frontend/Dockerfile.gke \
+            --build-arg "VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID}" \
+            --build-arg "VITE_AUTH_MODE=hybrid" \
+            -t "gcr.io/${PROJECT_ID}/helpudoc-frontend:${IMAGE_TAG}" .
           docker push "gcr.io/${PROJECT_ID}/helpudoc-frontend:${IMAGE_TAG}"
 
       - name: Deploy Frontend

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -110,7 +110,10 @@ jobs:
           set -euo pipefail
 
           docker build -f backend/Dockerfile.gke -t "gcr.io/${PROJECT_ID}/helpudoc-backend:${IMAGE_TAG}" .
-          docker build -f frontend/Dockerfile.gke --build-arg "VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID}" -t "gcr.io/${PROJECT_ID}/helpudoc-frontend:${IMAGE_TAG}" .
+          docker build -f frontend/Dockerfile.gke \
+            --build-arg "VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID}" \
+            --build-arg "VITE_AUTH_MODE=hybrid" \
+            -t "gcr.io/${PROJECT_ID}/helpudoc-frontend:${IMAGE_TAG}" .
           docker build -f agent/Dockerfile.gke -t "gcr.io/${PROJECT_ID}/helpudoc-agent:${IMAGE_TAG}" .
 
           docker push "gcr.io/${PROJECT_ID}/helpudoc-backend:${IMAGE_TAG}"

--- a/agent/helpudoc_agent/app.py
+++ b/agent/helpudoc_agent/app.py
@@ -28,10 +28,12 @@ from .rag_worker import RagIndexWorker
 from .skills_registry import collect_tool_names, load_skills
 from .paper2slides_runner import run_paper2slides, export_pptx_from_pdf
 from .jwt_utils import decode_and_verify_hs256_jwt
+from langgraph.errors import GraphInterrupt
 from langgraph.types import Command
 
 
 logger = logging.getLogger(__name__)
+_INTERRUPT_TOOL_NAMES: Set[str] = {"request_clarification", "request_human_action"}
 
 
 def _format_exception(exc: BaseException) -> str:
@@ -676,6 +678,9 @@ def create_app() -> FastAPI:
             run_key = str(run_id)
             name = self._tool_names.pop(run_key, "tool")
             text = self._to_text(output)
+            if name in _INTERRUPT_TOOL_NAMES and text.strip().startswith("Interrupt(value="):
+                self._tool_meta.pop(run_key, None)
+                return
             payload: Dict[str, Any] = {
                 "type": "tool_end",
                 "name": name,
@@ -696,7 +701,11 @@ def create_app() -> FastAPI:
             await self._emit(payload)
 
         async def on_tool_error(self, error, *, run_id, **_: Any) -> None:
-            name = self._tool_names.pop(str(run_id), "tool")
+            run_key = str(run_id)
+            name = self._tool_names.pop(run_key, "tool")
+            if _extract_interrupt_from_exception(error):
+                self._tool_meta.pop(run_key, None)
+                return
             await self._emit(
                 {
                     "type": "tool_error",
@@ -792,11 +801,8 @@ def create_app() -> FastAPI:
                     return item.get("messages")  # type: ignore[return-value]
         return None
 
-    def _extract_interrupt_payload(chunk: Any) -> Dict[str, Any] | None:
-        if not isinstance(chunk, dict):
-            return None
-        raw = chunk.get("__interrupt__")
-        if not raw or not isinstance(raw, list):
+    def _build_interrupt_payload(raw: Any) -> Dict[str, Any] | None:
+        if not raw or not isinstance(raw, (list, tuple)):
             return None
         first = raw[0] if raw else None
         if first is None:
@@ -837,6 +843,22 @@ def create_app() -> FastAPI:
         if isinstance(interrupt_id, str) and interrupt_id:
             payload["interruptId"] = interrupt_id
         return payload
+
+    def _extract_interrupt_payload(chunk: Any) -> Dict[str, Any] | None:
+        if not isinstance(chunk, dict):
+            return None
+        return _build_interrupt_payload(chunk.get("__interrupt__"))
+
+    def _extract_interrupt_from_exception(error: BaseException) -> Dict[str, Any] | None:
+        if isinstance(error, BaseExceptionGroup):
+            for inner in error.exceptions:
+                payload = _extract_interrupt_from_exception(inner)
+                if payload:
+                    return payload
+            return None
+        if isinstance(error, GraphInterrupt):
+            return _build_interrupt_payload(error.args[0] if error.args else None)
+        return None
 
     def _active_skill_policy(runtime: AgentRuntimeState) -> Dict[str, Any]:
         context = runtime.workspace_state.context or {}
@@ -1021,6 +1043,13 @@ def create_app() -> FastAPI:
                             "content": "Model returned no output",
                         }
                     )
+            except GraphInterrupt as exc:
+                interrupt_payload = _extract_interrupt_from_exception(exc)
+                if interrupt_payload:
+                    saw_interrupt = True
+                    await handler._emit(interrupt_payload)
+                    return
+                raise
             except Exception as exc:  # pragma: no cover - streaming guard
                 error_message = _format_exception(exc)
                 logger.exception("Agent stream error: %s", error_message)

--- a/agent/helpudoc_agent/graph.py
+++ b/agent/helpudoc_agent/graph.py
@@ -97,11 +97,13 @@ class AgentRegistry:
         policy_key = json.dumps(context_payload.get("mcp_policy", {}) or {}, sort_keys=True, default=str)
         mcp_auth_fingerprint = str(context_payload.get("mcp_auth_fingerprint") or "")
         user_key = str(context_payload.get("user_id") or "")
-        trusted_plan_key = "trusted" if bool(context_payload.get("skip_plan_approvals") or context_payload.get("skipPlanApprovals")) else "reviewed"
-        cache_scope_prefix = f"{user_key}:{policy_key}:{trusted_plan_key}:"
-        key = (resolved_name, workspace_id, f"{user_key}:{policy_key}:{trusted_plan_key}:{mcp_auth_fingerprint}")
+        cache_scope_prefix = f"{user_key}:{policy_key}:"
+        key = (resolved_name, workspace_id, f"{user_key}:{policy_key}:{mcp_auth_fingerprint}")
         if key in self._cache:
-            return self._cache[key]
+            runtime = self._cache[key]
+            if context_payload:
+                runtime.workspace_state.context.update(context_payload)
+            return runtime
         # Prevent unbounded growth when delegated auth fingerprints rotate over time.
         stale_keys = [
             cache_key

--- a/agent/helpudoc_agent/graph.py
+++ b/agent/helpudoc_agent/graph.py
@@ -28,7 +28,7 @@ GENERAL_SYSTEM_PROMPT = (
     "Do not assume skills are copied into the workspace. "
     "For proposal/SOW/RFP requests, always load the proposal-writing skill and write "
     "the proposal to workspace markdown files using write_file (and append_to_report if needed). "
-    "Before executing a multi-step skill-driven plan, first call request_plan_approval with a concise plan, markdown summary, step list, tool/file impact, and target plan file path when possible. "
+    "Only call request_plan_approval when the loaded skill explicitly requires a plan review checkpoint or the active skill policy says requires_hitl_plan=true. "
     "If execution is blocked on missing user intent or an unresolved choice, call request_clarification instead of guessing. "
     "If you need the human to choose from arbitrary next-step actions, call request_human_action. "
     "Only proceed with side-effecting tools after approval (or after applying user edits). "

--- a/agent/helpudoc_agent/skills_registry.py
+++ b/agent/helpudoc_agent/skills_registry.py
@@ -50,9 +50,23 @@ def _normalize_tools(value: object) -> List[str]:
     return []
 
 
+def _normalize_optional_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "y", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "n", "off"}:
+            return False
+    return None
+
+
 def _infer_skill_policy(skill_id: str, content: str, meta: dict) -> SkillPolicy:
     tools = _normalize_tools(meta.get("tools"))
     lower = content.lower()
+    explicit_requires_hitl_plan = _normalize_optional_bool(meta.get("requires_hitl_plan"))
+    explicit_requires_workspace_artifacts = _normalize_optional_bool(meta.get("requires_workspace_artifacts"))
     has_hitl_keyword = any(
         keyword in lower
         for keyword in (
@@ -74,8 +88,16 @@ def _infer_skill_policy(skill_id: str, content: str, meta: dict) -> SkillPolicy:
             "consolidate final report",
         )
     )
-    requires_hitl_plan = has_hitl_keyword or ("request_plan_approval" in tools)
-    requires_workspace_artifacts = has_file_keyword or ("write_file" in lower)
+    requires_hitl_plan = (
+        explicit_requires_hitl_plan
+        if explicit_requires_hitl_plan is not None
+        else has_hitl_keyword or ("request_plan_approval" in tools)
+    )
+    requires_workspace_artifacts = (
+        explicit_requires_workspace_artifacts
+        if explicit_requires_workspace_artifacts is not None
+        else has_file_keyword or ("write_file" in lower)
+    )
     raw_pre_plan_limit = meta.get("pre_plan_search_limit")
     pre_plan_search_limit = 0
     if isinstance(raw_pre_plan_limit, int):

--- a/agent/helpudoc_agent/tools_and_schemas.py
+++ b/agent/helpudoc_agent/tools_and_schemas.py
@@ -488,6 +488,7 @@ class ToolFactory:
             title: str,
             description: str = "",
             options_json: str = "[]",
+            questions_json: str = "[]",
             allow_freeform: bool = True,
             multi_select: bool = False,
             placeholder: str = "",
@@ -538,11 +539,63 @@ class ToolFactory:
                             }
                         )
 
+            parsed_questions: List[Dict[str, Any]] = []
+            try:
+                raw_questions = json.loads(questions_json or "[]")
+            except json.JSONDecodeError:
+                raw_questions = []
+            if isinstance(raw_questions, list):
+                for index, item in enumerate(raw_questions):
+                    if not isinstance(item, dict):
+                        continue
+                    header = str(item.get("header") or item.get("title") or f"Question {index + 1}").strip()
+                    question = str(item.get("question") or item.get("prompt") or item.get("description") or "").strip()
+                    if not header or not question:
+                        continue
+                    parsed_question_options: List[Dict[str, str]] = []
+                    raw_question_options = item.get("options")
+                    if isinstance(raw_question_options, list):
+                        for option_index, option in enumerate(raw_question_options):
+                            if isinstance(option, str) and option.strip():
+                                parsed_question_options.append(
+                                    {
+                                        "id": f"{header.lower().replace(' ', '-')}-{option_index + 1}",
+                                        "label": option.strip(),
+                                        "value": option.strip(),
+                                    }
+                                )
+                            elif isinstance(option, dict):
+                                label = str(option.get("label") or option.get("value") or "").strip()
+                                value = str(option.get("value") or label).strip()
+                                if not label or not value:
+                                    continue
+                                parsed_question_options.append(
+                                    {
+                                        "id": str(option.get("id") or f"{header.lower().replace(' ', '-')}-{option_index + 1}").strip(),
+                                        "label": label,
+                                        "value": value,
+                                        **(
+                                            {"description": str(option.get("description")).strip()}
+                                            if str(option.get("description") or "").strip()
+                                            else {}
+                                        ),
+                                    }
+                                )
+                    parsed_questions.append(
+                        {
+                            "id": str(item.get("id") or header.lower().replace(" ", "-")).strip(),
+                            "header": header,
+                            "question": question,
+                            **({"options": parsed_question_options} if parsed_question_options else {}),
+                        }
+                    )
+
             input_mode = "text"
-            if parsed_choices and allow_freeform:
-                input_mode = "text_or_choice"
-            elif parsed_choices:
-                input_mode = "choice"
+            if not parsed_questions:
+                if parsed_choices and allow_freeform:
+                    input_mode = "text_or_choice"
+                elif parsed_choices:
+                    input_mode = "choice"
 
             display_payload: Dict[str, Any] = {}
             try:
@@ -552,6 +605,7 @@ class ToolFactory:
             except json.JSONDecodeError:
                 display_payload = {}
 
+            action_choices = [] if parsed_questions else parsed_choices
             interrupt_payload = {
                 "kind": "clarification",
                 "title": prompt_title,
@@ -567,7 +621,7 @@ class ToolFactory:
                         "value": choice["value"],
                         **({"payload": {"selectedChoiceId": choice["id"]}} if choice.get("id") else {}),
                     }
-                    for choice in parsed_choices
+                    for choice in action_choices
                 ]
                 + (
                     [
@@ -589,6 +643,7 @@ class ToolFactory:
                     "submitLabel": (submit_label or "Continue").strip() or "Continue",
                     "placeholder": (placeholder or "").strip(),
                     "choices": parsed_choices,
+                    **({"questions": parsed_questions} if parsed_questions else {}),
                 },
                 "display_payload": display_payload,
             }
@@ -606,7 +661,10 @@ class ToolFactory:
         request_clarification.name = "request_clarification"
         request_clarification.description = (
             "Pause execution to ask the human a clarification question. "
-            "Use options_json for clickable choices and allow_freeform for typed input."
+            "Use options_json for clickable suggestions and allow_freeform for typed input. "
+            "For multi-question discovery forms, pass questions_json with objects like "
+            '{"header":"Purpose","question":"What is this presentation for?","options":[{"label":"Pitch deck","value":"Pitch deck","description":"Selling an idea to investors"}]}. '
+            "Do not pass section headers like Purpose or Length as the only options."
         )
         return request_clarification
 

--- a/agent/helpudoc_agent/tools_and_schemas.py
+++ b/agent/helpudoc_agent/tools_and_schemas.py
@@ -342,7 +342,21 @@ class ToolFactory:
                         workspace_state.context.get("skip_plan_approvals")
                     )
                     workspace_state.context["pre_plan_search_count"] = 0
-                    return f"Loaded skill: {skill.skill_id}\n\n{content}"
+                    policy_lines = [
+                        f"Skill policy for {skill.skill_id}:",
+                        f"- requires_hitl_plan: {'true' if skill.policy.requires_hitl_plan else 'false'}",
+                        f"- requires_workspace_artifacts: {'true' if skill.policy.requires_workspace_artifacts else 'false'}",
+                    ]
+                    if skill.policy.requires_hitl_plan:
+                        policy_lines.append(
+                            "- You must call request_plan_approval before side-effecting execution."
+                        )
+                    else:
+                        policy_lines.append(
+                            "- Do not call request_plan_approval for this skill unless the user explicitly asks for a review gate."
+                        )
+                    policy_lines.append("")
+                    return f"Loaded skill: {skill.skill_id}\n\n" + "\n".join(policy_lines) + f"\n{content}"
             available = ", ".join(sorted({skill.skill_id for skill in skills}))
             return f"Skill '{normalized}' not found. Available skills: {available}"
 

--- a/agent/helpudoc_agent/tools_and_schemas.py
+++ b/agent/helpudoc_agent/tools_and_schemas.py
@@ -34,6 +34,28 @@ from .utils import SourceTracker, extract_web_url
 logger = logging.getLogger(__name__)
 
 
+def _dict_has_keys(value: Any, keys: set[str]) -> bool:
+    return isinstance(value, dict) and any(key in value for key in keys)
+
+
+def _interrupt_with_retry(
+    payload: Dict[str, Any],
+    *,
+    valid_keys: set[str],
+    stale_keys: set[str],
+    label: str,
+    attempts: int = 2,
+) -> Any:
+    """Retry once when an interrupt receives a stale resume payload from a prior step."""
+    response: Any = None
+    for attempt in range(attempts):
+        response = interrupt(payload)
+        if not _dict_has_keys(response, stale_keys) or _dict_has_keys(response, valid_keys):
+            return response
+        logger.warning("%s received stale interrupt resume payload on attempt %s; retrying", label, attempt + 1)
+    return response
+
+
 def _get_active_skill_policy(workspace_state: WorkspaceState) -> SkillPolicy:
     raw = workspace_state.context.get("active_skill_policy")
     if isinstance(raw, SkillPolicy):
@@ -530,47 +552,52 @@ class ToolFactory:
             except json.JSONDecodeError:
                 display_payload = {}
 
-            response = interrupt(
-                {
-                    "kind": "clarification",
-                    "title": prompt_title,
-                    "description": prompt_description,
-                    "step_index": max(0, int(step_index or 0)),
-                    "step_count": max(1, int(step_count or 1)),
-                    "actions": [
+            interrupt_payload = {
+                "kind": "clarification",
+                "title": prompt_title,
+                "description": prompt_description,
+                "step_index": max(0, int(step_index or 0)),
+                "step_count": max(1, int(step_count or 1)),
+                "actions": [
+                    {
+                        "id": choice["id"],
+                        "label": choice["label"],
+                        "style": "secondary",
+                        "inputMode": "none",
+                        "value": choice["value"],
+                        **({"payload": {"selectedChoiceId": choice["id"]}} if choice.get("id") else {}),
+                    }
+                    for choice in parsed_choices
+                ]
+                + (
+                    [
                         {
-                            "id": choice["id"],
-                            "label": choice["label"],
-                            "style": "secondary",
-                            "inputMode": "none",
-                            "value": choice["value"],
-                            **({"payload": {"selectedChoiceId": choice["id"]}} if choice.get("id") else {}),
+                            "id": "clarification-text",
+                            "label": (submit_label or "Continue").strip() or "Continue",
+                            "style": "primary",
+                            "inputMode": "text",
+                            "placeholder": (placeholder or "").strip(),
+                            "submitLabel": (submit_label or "Continue").strip() or "Continue",
                         }
-                        for choice in parsed_choices
                     ]
-                    + (
-                        [
-                            {
-                                "id": "clarification-text",
-                                "label": (submit_label or "Continue").strip() or "Continue",
-                                "style": "primary",
-                                "inputMode": "text",
-                                "placeholder": (placeholder or "").strip(),
-                                "submitLabel": (submit_label or "Continue").strip() or "Continue",
-                            }
-                        ]
-                        if allow_freeform or not parsed_choices
-                        else []
-                    ),
-                    "response_spec": {
-                        "inputMode": input_mode,
-                        "multiple": bool(multi_select),
-                        "submitLabel": (submit_label or "Continue").strip() or "Continue",
-                        "placeholder": (placeholder or "").strip(),
-                        "choices": parsed_choices,
-                    },
-                    "display_payload": display_payload,
-                }
+                    if allow_freeform or not parsed_choices
+                    else []
+                ),
+                "response_spec": {
+                    "inputMode": input_mode,
+                    "multiple": bool(multi_select),
+                    "submitLabel": (submit_label or "Continue").strip() or "Continue",
+                    "placeholder": (placeholder or "").strip(),
+                    "choices": parsed_choices,
+                },
+                "display_payload": display_payload,
+            }
+
+            response = _interrupt_with_retry(
+                interrupt_payload,
+                valid_keys={"message", "selectedChoiceIds", "selectedValues"},
+                stale_keys={"decisions", "action"},
+                label="request_clarification",
             )
             if isinstance(response, dict):
                 return json.dumps(response, ensure_ascii=False)
@@ -658,16 +685,21 @@ class ToolFactory:
             except json.JSONDecodeError:
                 display_payload = {}
 
-            response = interrupt(
-                {
-                    "kind": interrupt_kind,
-                    "title": prompt_title,
-                    "description": prompt_description,
-                    "step_index": max(0, int(step_index or 0)),
-                    "step_count": max(1, int(step_count or 1)),
-                    "actions": parsed_actions,
-                    "display_payload": display_payload,
-                }
+            interrupt_payload = {
+                "kind": interrupt_kind,
+                "title": prompt_title,
+                "description": prompt_description,
+                "step_index": max(0, int(step_index or 0)),
+                "step_count": max(1, int(step_count or 1)),
+                "actions": parsed_actions,
+                "display_payload": display_payload,
+            }
+
+            response = _interrupt_with_retry(
+                interrupt_payload,
+                valid_keys={"action"},
+                stale_keys={"decisions", "message", "selectedChoiceIds", "selectedValues"},
+                label="request_human_action",
             )
             if isinstance(response, dict):
                 return json.dumps(response, ensure_ascii=False)

--- a/backend/src/api/agent.ts
+++ b/backend/src/api/agent.ts
@@ -761,7 +761,7 @@ export default function(
             }
           }
 
-          if (terminalStatus && (!streams || !streams.length)) {
+          if (terminalStatus) {
             break;
           }
         }

--- a/backend/src/services/agentRunService.ts
+++ b/backend/src/services/agentRunService.ts
@@ -58,6 +58,12 @@ type RunPendingInterrupt = {
     allowDismiss?: boolean;
     dismissLabel?: string;
     choices?: Array<{ id?: string; label?: string; description?: string; value?: string }>;
+    questions?: Array<{
+      id?: string;
+      header?: string;
+      question?: string;
+      options?: Array<{ id?: string; label?: string; description?: string; value?: string }>;
+    }>;
   };
   displayPayload?: Record<string, unknown>;
 };

--- a/docs/clarification-form-design.md
+++ b/docs/clarification-form-design.md
@@ -1,0 +1,77 @@
+# Clarification Form Design
+
+This document captures the intended UX and transport contract for `request_clarification` when a skill needs guided human input rather than a simple yes/no approval.
+
+## Goals
+
+- Keep clarification visually aligned with the main chat UI.
+- Let the agent ask concrete questions with suggested answers.
+- Keep a visible freeform area for custom constraints or corrections.
+- Make the primary confirmation action obvious and always in view.
+
+## UX Pattern
+
+The clarification card should contain:
+
+1. A title and short description of what the agent needs.
+2. Question groups, each with:
+   - a section header
+   - the actual question text
+   - suggested answer tiles with short descriptions
+3. A visible notes area that collects the selected answers and lets the user override them.
+4. A primary `Continue` button near the notes heading so the action is not lost below the fold.
+
+The user flow is:
+
+1. Click suggested answers for any question.
+2. The notes field is auto-populated with a structured draft.
+3. Edit the draft if needed.
+4. Click `Continue` to resume the agent run.
+
+## Tool Contract
+
+The heavy-weight contract lives in `request_clarification`, not in a skill-specific prompt workaround.
+
+Recommended structured payload:
+
+```json
+{
+  "title": "Presentation Setup",
+  "description": "Confirm the inputs I should use before generating the deck.",
+  "questions_json": [
+    {
+      "id": "purpose",
+      "header": "Purpose",
+      "question": "What is this presentation for?",
+      "options": [
+        {
+          "id": "pitch",
+          "label": "Pitch deck",
+          "value": "Pitch deck",
+          "description": "Selling an idea, product, or company to investors or clients"
+        }
+      ]
+    }
+  ],
+  "allow_freeform": true,
+  "placeholder": "Add any other constraints, references, or image paths here.",
+  "submit_label": "Continue"
+}
+```
+
+Notes:
+
+- `options_json` is still fine for simple one-question clarification.
+- `questions_json` is the preferred path for multi-question discovery forms.
+- Bare section headers like `Purpose` or `Length` should not be used as the only options.
+
+## Frontend Behavior
+
+When `responseSpec.questions` exists, the frontend should:
+
+- render the structured form UI
+- keep the notes textarea visible at all times
+- synthesize a structured draft from the selected tiles
+- submit the textarea content back as the clarification response
+
+If a legacy payload arrives with only flattened headers, the frontend may apply a local fallback for known flows such as `frontend-slides` so the user still sees a usable form.

--- a/frontend/e2e/frontend-slides-clarification.spec.ts
+++ b/frontend/e2e/frontend-slides-clarification.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from '@playwright/test';
+
+test.setTimeout(150_000);
+
+const E2E_USER = {
+  id: 'local-e2e',
+  name: 'E2E User',
+  email: 'e2e@example.com',
+  provider: 'local',
+};
+
+const REPORT_CONTENT = `# Operation Epic Fury
+
+## TL;DR
+- Major regional conflict scenario
+- Strategic, economic, and geopolitical impacts
+
+## Sections
+1. Background
+2. Military narrative
+3. Economic implications
+4. Regional shifts
+`;
+
+test('frontend-slides pauses on clarification instead of approval', async ({ page, baseURL }) => {
+  const resolvedBaseUrl = baseURL || 'https://lc-demo.com';
+  const workspaceName = `e2e-slides-${Date.now()}`;
+
+  page.on('console', (message) => {
+    console.log(`[browser:${message.type()}] ${message.text()}`);
+  });
+  page.on('pageerror', (error) => {
+    console.log(`[pageerror] ${error.message}`);
+  });
+  page.on('requestfailed', (request) => {
+    console.log(`[requestfailed] ${request.method()} ${request.url()} ${request.failure()?.errorText || ''}`);
+  });
+  page.on('response', async (response) => {
+    if (!response.url().includes('/api/')) {
+      return;
+    }
+    const request = response.request();
+    console.log(`[response] ${request.method()} ${response.status()} ${response.url()}`);
+  });
+
+  await page.addInitScript((payload) => {
+    window.localStorage.setItem('helpudoc-auth-user', JSON.stringify(payload));
+  }, E2E_USER);
+
+  await page.goto(resolvedBaseUrl, { waitUntil: 'domcontentloaded' });
+
+  // Open the workspace drawer.
+  await page.getByRole('button').first().click();
+
+  // Create and select a disposable workspace.
+  await page.getByPlaceholder('New workspace').fill(workspaceName);
+  await page.getByRole('button', { name: /^Create$/ }).click();
+  await page.getByRole('button', { name: new RegExp(workspaceName) }).click();
+  await page.getByRole('button').first().click();
+
+  // Upload the source markdown through the workspace file input.
+  await page.locator('#file-upload').setInputFiles({
+    name: 'operation-epic-fury-report.md',
+    mimeType: 'text/markdown',
+    buffer: Buffer.from(REPORT_CONTENT, 'utf-8'),
+  });
+  await expect(page.getByText('operation-epic-fury-report.md', { exact: true })).toBeVisible();
+
+  // Trigger the frontend-slides flow using a tagged workspace file.
+  const composer = page.getByPlaceholder('Interact with the agent... (Type / for commands)');
+  await composer.fill('use frontend-slide skill, build the presentation slide for @operation-epic-fury-report.md');
+  const startRunResponse = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' &&
+      /\/api\/agent\/runs(?:\?|$)/.test(response.url()),
+    { timeout: 30_000 },
+  );
+  await page.getByRole('button', { name: 'Send message' }).click();
+  await expect(page.getByText('use frontend-slide skill, build the presentation slide for @operation-epic-fury-report.md')).toBeVisible();
+  const runResponse = await startRunResponse;
+  console.log(`[start-run-body] ${await runResponse.text()}`);
+
+  // The desired blocked state is a clarification pause, not a plan approval card.
+  await expect
+    .poll(
+      async () => {
+        const purposeQuestionCount = await page.getByText(/Purpose: What is this presentation for\?/i).count();
+        const discoveryTitleCount = await page.getByText(/Presentation Discovery|File Not Found/i).count();
+        const continueCount = await page.getByRole('button', { name: 'Continue' }).count();
+        return (
+          (continueCount > 0 && discoveryTitleCount > 0) ||
+          (continueCount > 0 && purposeQuestionCount > 0)
+        );
+      },
+      { timeout: 120_000, message: 'expected clarification UI to appear' },
+    )
+    .toBe(true);
+
+  await expect(page.getByText(/Review Research Strategy/i)).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Approve' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Edit' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Reject' })).toHaveCount(0);
+  await expect(page.getByText('Generating...')).toHaveCount(0, { timeout: 30_000 });
+});

--- a/frontend/src/components/chat/AgentChatPane.tsx
+++ b/frontend/src/components/chat/AgentChatPane.tsx
@@ -49,6 +49,7 @@ export default function AgentChatPane({
   expandedThinkingMessages,
   copiedMessageId,
   interruptInputByMessageId,
+  interruptSelectedChoicesByMessageId,
   interruptSubmittingByMessageId,
   interruptErrorByMessageId,
   chatMessage,
@@ -73,6 +74,7 @@ export default function AgentChatPane({
   getPrimaryInterruptAction,
   isPlanApprovalInterrupt,
   setInterruptInputByMessageId,
+  toggleInterruptSelectedChoice,
   workspaceSkipPlanApprovals,
   workspaceSettingsBusy,
   onToggleAgentPaneVisibility,
@@ -123,6 +125,7 @@ export default function AgentChatPane({
   expandedThinkingMessages: Set<ConversationMessage['id']>;
   copiedMessageId: ConversationMessage['id'] | null;
   interruptInputByMessageId: Record<string, string>;
+  interruptSelectedChoicesByMessageId: Record<string, string[]>;
   interruptSubmittingByMessageId: Record<string, boolean>;
   interruptErrorByMessageId: Record<string, string>;
   chatMessage: string;
@@ -156,6 +159,7 @@ export default function AgentChatPane({
   ) => { name?: string; args?: Record<string, unknown> } | undefined;
   isPlanApprovalInterrupt: (pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt']) => boolean;
   setInterruptInputByMessageId: Dispatch<SetStateAction<Record<string, string>>>;
+  toggleInterruptSelectedChoice: (messageKey: string, choiceId: string, multiple: boolean) => void;
   workspaceSkipPlanApprovals: boolean;
   workspaceSettingsBusy: boolean;
   onToggleAgentPaneVisibility: () => void;
@@ -236,6 +240,7 @@ export default function AgentChatPane({
           expandedThinkingMessages={expandedThinkingMessages}
           copiedMessageId={copiedMessageId}
           interruptInputByMessageId={interruptInputByMessageId}
+          interruptSelectedChoicesByMessageId={interruptSelectedChoicesByMessageId}
           interruptSubmittingByMessageId={interruptSubmittingByMessageId}
           interruptErrorByMessageId={interruptErrorByMessageId}
           interruptFieldKey={interruptFieldKey}
@@ -246,6 +251,7 @@ export default function AgentChatPane({
           getPrimaryInterruptAction={getPrimaryInterruptAction}
           isPlanApprovalInterrupt={isPlanApprovalInterrupt}
           setInterruptInputByMessageId={setInterruptInputByMessageId}
+          toggleInterruptSelectedChoice={toggleInterruptSelectedChoice}
           workspaceSkipPlanApprovals={workspaceSkipPlanApprovals}
           workspaceSettingsBusy={workspaceSettingsBusy}
           toggleThinkingVisibility={onToggleThinkingVisibility}

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -70,6 +70,7 @@ export default function ChatMessageBubble({
   expandedThinkingMessages,
   copiedMessageId,
   interruptInputByMessageId,
+  interruptSelectedChoicesByMessageId,
   interruptSubmittingByMessageId,
   interruptErrorByMessageId,
   interruptFieldKey,
@@ -80,6 +81,7 @@ export default function ChatMessageBubble({
   getPrimaryInterruptAction,
   isPlanApprovalInterrupt,
   setInterruptInputByMessageId,
+  toggleInterruptSelectedChoice,
   workspaceSkipPlanApprovals,
   workspaceSettingsBusy,
   toggleThinkingVisibility,
@@ -100,6 +102,7 @@ export default function ChatMessageBubble({
   expandedThinkingMessages: Set<ConversationMessage['id']>;
   copiedMessageId: ConversationMessage['id'] | null;
   interruptInputByMessageId: Record<string, string>;
+  interruptSelectedChoicesByMessageId: Record<string, string[]>;
   interruptSubmittingByMessageId: Record<string, boolean>;
   interruptErrorByMessageId: Record<string, string>;
   interruptFieldKey: (
@@ -119,6 +122,7 @@ export default function ChatMessageBubble({
   ) => { name?: string; args?: Record<string, unknown> } | undefined;
   isPlanApprovalInterrupt: (pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt']) => boolean;
   setInterruptInputByMessageId: Dispatch<SetStateAction<Record<string, string>>>;
+  toggleInterruptSelectedChoice: (messageKey: string, choiceId: string, multiple: boolean) => void;
   workspaceSkipPlanApprovals: boolean;
   workspaceSettingsBusy: boolean;
   toggleThinkingVisibility: (messageId: ConversationMessage['id']) => void;
@@ -193,6 +197,8 @@ export default function ChatMessageBubble({
   const clarificationTextKey = interruptFieldKey(messageKey, 'clarification-text');
   const interruptError = interruptErrorByMessageId[messageKey] || '';
   const allowDismiss = Boolean(pendingInterrupt?.responseSpec?.allowDismiss);
+  const clarificationAllowsMultiple = Boolean(pendingInterrupt?.responseSpec?.multiple);
+  const selectedChoiceIds = interruptSelectedChoicesByMessageId[messageKey] || [];
 
   const planText = useMemo(() => {
     const args = primaryInterruptAction?.args;
@@ -252,6 +258,10 @@ export default function ChatMessageBubble({
 
   const handleActionTrigger = (action: RenderableInterruptAction) => {
     if (interruptControlsDisabled) {
+      return;
+    }
+    if (action.source === 'clarification-choice' && clarificationAllowsMultiple && action.choiceId) {
+      toggleInterruptSelectedChoice(messageKey, action.choiceId, true);
       return;
     }
     handlePrepareInterruptAction(message, action, pendingInterrupt);
@@ -318,6 +328,16 @@ export default function ChatMessageBubble({
           const showConfirmationOnly = needsExplicitConfirm && action.inputMode !== 'text';
           const showPrimaryRow = !isTextMode && !showConfirmationOnly;
           const numberedChoice = tone === 'dark' && action.source === 'clarification-choice';
+          const isSelectedChoice = Boolean(
+            action.source === 'clarification-choice' &&
+            action.choiceId &&
+            selectedChoiceIds.includes(action.choiceId),
+          );
+          const standardChoiceSelectionClass = !numberedChoice && isSelectedChoice
+            ? tone === 'dark'
+              ? 'ring-2 ring-[#94c5f8]/65 ring-offset-0'
+              : 'border-[#94c5f8] bg-blue-50 text-blue-800 shadow-[0_0_0_1px_rgba(148,197,248,0.35)]'
+            : '';
 
           return (
             <div key={action.id} className={tone === 'dark' ? 'space-y-3' : 'space-y-2'}>
@@ -329,13 +349,15 @@ export default function ChatMessageBubble({
                   className={
                     numberedChoice
                       ? `flex w-full items-start justify-between rounded-[1.35rem] border px-5 py-4 text-left transition-all duration-200 ${
-                          action.style === 'primary'
-                            ? 'border-[#94c5f8]/55 bg-[#94c5f8]/10 text-white hover:bg-[#94c5f8]/15'
-                            : action.style === 'danger'
-                              ? 'border-rose-400/25 bg-rose-500/10 text-rose-100 hover:bg-rose-500/15'
-                              : 'border-white/10 bg-white/[0.03] text-white/92 hover:border-white/25 hover:bg-white/[0.07]'
+                          isSelectedChoice
+                            ? 'border-[#94c5f8] bg-[#94c5f8]/18 text-white shadow-[0_0_0_1px_rgba(148,197,248,0.35)]'
+                            : action.style === 'primary'
+                              ? 'border-[#94c5f8]/55 bg-[#94c5f8]/10 text-white hover:bg-[#94c5f8]/15'
+                              : action.style === 'danger'
+                                ? 'border-rose-400/25 bg-rose-500/10 text-rose-100 hover:bg-rose-500/15'
+                                : 'border-white/10 bg-white/[0.03] text-white/92 hover:border-white/25 hover:bg-white/[0.07]'
                         } ${interruptControlsDisabled ? 'cursor-not-allowed opacity-70' : ''}`
-                      : getActionButtonClass(action, tone)
+                      : `${getActionButtonClass(action, tone)} ${standardChoiceSelectionClass}`
                   }
                 >
                   {numberedChoice ? (
@@ -346,7 +368,9 @@ export default function ChatMessageBubble({
                           <span className="text-[18px] font-semibold leading-snug">{action.label}</span>
                         </div>
                       </div>
-                      <span className="mt-1 text-lg text-white/35">{needsExplicitConfirm ? '!' : ''}</span>
+                      <span className="mt-1 text-lg text-white/35">
+                        {isSelectedChoice ? '✓' : needsExplicitConfirm ? '!' : ''}
+                      </span>
                     </>
                   ) : (
                     action.label

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -10,6 +10,149 @@ import { buildApprovalReview } from './approvalReview';
 
 const THOUGHT_PREVIEW_LIMIT = 320;
 const DEFAULT_THINKING_PLACEHOLDER = 'Working through your request based on the current workspace context.';
+const FRONTEND_SLIDES_DISCOVERY_HEADERS = ['purpose', 'length', 'content', 'images', 'editing'] as const;
+
+type ClarificationQuestionOption = {
+  id: string;
+  label: string;
+  value: string;
+  description?: string;
+};
+
+type ClarificationQuestion = {
+  id: string;
+  header: string;
+  question: string;
+  options: ClarificationQuestionOption[];
+};
+
+const FRONTEND_SLIDES_DISCOVERY_QUESTIONS: ClarificationQuestion[] = [
+  {
+    id: 'purpose',
+    header: 'Purpose',
+    question: 'What is this presentation for?',
+    options: [
+      {
+        id: 'purpose-pitch',
+        label: 'Pitch deck',
+        value: 'Pitch deck',
+        description: 'Selling an idea, product, or company to investors or clients.',
+      },
+      {
+        id: 'purpose-teaching',
+        label: 'Teaching / Tutorial',
+        value: 'Teaching / Tutorial',
+        description: 'Explaining concepts, how-to guides, or educational material.',
+      },
+      {
+        id: 'purpose-conference',
+        label: 'Conference talk',
+        value: 'Conference talk',
+        description: 'A keynote, event session, or tech talk.',
+      },
+      {
+        id: 'purpose-internal',
+        label: 'Internal presentation',
+        value: 'Internal presentation',
+        description: 'Team updates, strategy reviews, or company meetings.',
+      },
+    ],
+  },
+  {
+    id: 'length',
+    header: 'Length',
+    question: 'Approximately how many slides should it have?',
+    options: [
+      {
+        id: 'length-short',
+        label: 'Short (5-10)',
+        value: 'Short (5-10)',
+        description: 'Quick pitch or lightning talk.',
+      },
+      {
+        id: 'length-medium',
+        label: 'Medium (10-20)',
+        value: 'Medium (10-20)',
+        description: 'Standard presentation length.',
+      },
+      {
+        id: 'length-long',
+        label: 'Long (20+)',
+        value: 'Long (20+)',
+        description: 'Deep dive or comprehensive talk.',
+      },
+    ],
+  },
+  {
+    id: 'content',
+    header: 'Content',
+    question: 'How ready is the content?',
+    options: [
+      {
+        id: 'content-ready',
+        label: 'All content is ready',
+        value: 'I have all content ready',
+        description: 'Only the presentation design is needed.',
+      },
+      {
+        id: 'content-notes',
+        label: 'Rough notes',
+        value: 'I have rough notes',
+        description: 'Need help organizing the material into slides.',
+      },
+      {
+        id: 'content-topic',
+        label: 'Topic only',
+        value: 'I have a topic only',
+        description: 'Need help creating the full outline.',
+      },
+    ],
+  },
+  {
+    id: 'images',
+    header: 'Images',
+    question: 'What should happen with images?',
+    options: [
+      {
+        id: 'images-none',
+        label: 'No images',
+        value: 'No images',
+        description: 'Use CSS-generated visuals instead.',
+      },
+      {
+        id: 'images-assets',
+        label: 'Use ./assets',
+        value: './assets',
+        description: 'Use the assets folder in the current project.',
+      },
+      {
+        id: 'images-other',
+        label: 'Other path',
+        value: 'Custom image path',
+        description: 'Type or paste another image folder path in the notes field.',
+      },
+    ],
+  },
+  {
+    id: 'editing',
+    header: 'Editing',
+    question: 'Should the generated deck support inline browser editing?',
+    options: [
+      {
+        id: 'editing-yes',
+        label: 'Yes (Recommended)',
+        value: 'Yes',
+        description: 'Edit text in-browser, auto-save locally, and export later.',
+      },
+      {
+        id: 'editing-no',
+        label: 'No',
+        value: 'No',
+        description: 'Presentation only, with a smaller output file.',
+      },
+    ],
+  },
+];
 
 const getThinkingPlaceholder = (
   metadata?: ConversationMessageMetadata,
@@ -77,6 +220,144 @@ const renderDisplayPayload = (
       </div>
     </div>
   );
+};
+
+const parseClarificationQuestions = (
+  pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  activeSkill?: string,
+): ClarificationQuestion[] => {
+  const responseQuestions = Array.isArray(pendingInterrupt?.responseSpec?.questions)
+    ? pendingInterrupt.responseSpec.questions
+    : [];
+  if (responseQuestions.length) {
+    return responseQuestions.reduce<ClarificationQuestion[]>((acc, question) => {
+      if (!question || typeof question !== 'object' || !question.question) {
+        return acc;
+      }
+      acc.push({
+        id: question.id,
+        header: question.header,
+        question: question.question,
+        options: Array.isArray(question.options)
+          ? question.options.reduce<ClarificationQuestionOption[]>((optionAcc, option) => {
+              if (!option?.label || !option?.value) {
+                return optionAcc;
+              }
+              optionAcc.push({
+                id: option.id,
+                label: option.label,
+                value: option.value,
+                description: option.description,
+              });
+              return optionAcc;
+            }, [])
+          : [],
+      });
+      return acc;
+    }, []);
+  }
+
+  const rawQuestions = pendingInterrupt?.displayPayload?.questions;
+  if (Array.isArray(rawQuestions)) {
+    const parsedQuestions = rawQuestions
+      .map((item, index) => {
+        if (!item || typeof item !== 'object' || Array.isArray(item)) {
+          return null;
+        }
+        const payload = item as Record<string, unknown>;
+        const header = String(payload.header || payload.title || `Question ${index + 1}`).trim();
+        const question = String(payload.question || payload.prompt || payload.description || '').trim();
+        const rawOptions = Array.isArray(payload.options) ? payload.options : [];
+        const options = rawOptions
+          .map((option, optionIndex) => {
+            if (typeof option === 'string' && option.trim()) {
+              return {
+                id: `${header.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${optionIndex + 1}`,
+                label: option.trim(),
+                value: option.trim(),
+              } satisfies ClarificationQuestionOption;
+            }
+            if (!option || typeof option !== 'object' || Array.isArray(option)) {
+              return null;
+            }
+            const optionPayload = option as Record<string, unknown>;
+            const label = String(optionPayload.label || optionPayload.value || '').trim();
+            const value = String(optionPayload.value || label).trim();
+            if (!label || !value) {
+              return null;
+            }
+            return {
+              id: String(optionPayload.id || `${header.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${optionIndex + 1}`).trim(),
+              label,
+              value,
+              description: String(optionPayload.description || '').trim() || undefined,
+            } satisfies ClarificationQuestionOption;
+          })
+          .filter((option): option is ClarificationQuestionOption => Boolean(option));
+        return {
+          id: String(payload.id || header.toLowerCase().replace(/[^a-z0-9]+/g, '-')).trim(),
+          header,
+          question,
+          options,
+        } satisfies ClarificationQuestion;
+      })
+      .filter((question): question is ClarificationQuestion => question !== null && question.question.length > 0);
+    if (parsedQuestions.length) {
+      return parsedQuestions;
+    }
+  }
+
+  const skill = activeSkill?.trim().toLowerCase();
+  const responseChoices = Array.isArray(pendingInterrupt?.responseSpec?.choices) ? pendingInterrupt?.responseSpec?.choices : [];
+  const normalizedChoiceLabels = responseChoices.map((choice) => choice.label.trim().toLowerCase());
+  const looksLikeFrontendSlidesDiscovery =
+    skill === 'frontend-slides' &&
+    normalizedChoiceLabels.length === FRONTEND_SLIDES_DISCOVERY_HEADERS.length &&
+    normalizedChoiceLabels.every((label) => FRONTEND_SLIDES_DISCOVERY_HEADERS.includes(label as (typeof FRONTEND_SLIDES_DISCOVERY_HEADERS)[number]));
+
+  return looksLikeFrontendSlidesDiscovery ? FRONTEND_SLIDES_DISCOVERY_QUESTIONS : [];
+};
+
+const buildClarificationTemplate = (questions: ClarificationQuestion[]): string =>
+  questions
+    .map((question) => `${question.header}:`)
+    .join('\n');
+
+const readStructuredAnswerMap = (
+  value: string,
+  questions: ClarificationQuestion[],
+): Record<string, string> => {
+  const answers: Record<string, string> = {};
+  const lines = value.split('\n');
+  questions.forEach((question) => {
+    const prefix = `${question.header.toLowerCase()}:`;
+    const matchingLine = lines.find((line) => line.trim().toLowerCase().startsWith(prefix));
+    if (matchingLine) {
+      answers[question.id] = matchingLine.slice(matchingLine.indexOf(':') + 1).trim();
+    }
+  });
+  return answers;
+};
+
+const upsertStructuredAnswer = (
+  value: string,
+  question: ClarificationQuestion,
+  answer: string,
+  questions: ClarificationQuestion[],
+): string => {
+  const existingLines = value
+    ? value.split('\n')
+    : buildClarificationTemplate(questions).split('\n');
+  const prefix = `${question.header}:`;
+  const nextLines = [...existingLines];
+  const lineIndex = nextLines.findIndex((line) => line.trim().toLowerCase().startsWith(prefix.toLowerCase()));
+  const nextLine = `${prefix} ${answer}`.trimEnd();
+  if (lineIndex >= 0) {
+    nextLines[lineIndex] = nextLine;
+  } else {
+    nextLines.push(nextLine);
+  }
+  return nextLines.join('\n').trim();
 };
 
 export default function ChatMessageBubble({
@@ -181,6 +462,7 @@ export default function ChatMessageBubble({
   const isToolActivityExpanded = expandedToolMessages.has(message.id);
   const isThinkingExpanded = expandedThinkingMessages.has(message.id);
   const rawThinkingText = message.thinkingText?.trim() || '';
+  const activeSkill = messageMetadata?.runPolicy?.skill?.trim().toLowerCase();
   const isSystemThinking = /available skills/i.test(rawThinkingText);
   const displayThinkingText = isSystemThinking
     ? getThinkingPlaceholder(messageMetadata, toolEvents)
@@ -219,6 +501,17 @@ export default function ChatMessageBubble({
   const allowDismiss = Boolean(pendingInterrupt?.responseSpec?.allowDismiss);
   const clarificationAllowsMultiple = Boolean(pendingInterrupt?.responseSpec?.multiple);
   const selectedChoiceIds = interruptSelectedChoicesByMessageId[messageKey] || [];
+  const structuredClarificationQuestions = useMemo(
+    () => parseClarificationQuestions(pendingInterrupt, activeSkill),
+    [activeSkill, pendingInterrupt],
+  );
+  const hasStructuredClarificationForm = isClarificationInterrupt && structuredClarificationQuestions.length > 0;
+  const clarificationDraftValue = interruptInputByMessageId[clarificationTextKey] || '';
+  const structuredClarificationSubmitActions = interruptActions.filter((action) => action.inputMode === 'text');
+  const structuredAnswerMap = useMemo(
+    () => readStructuredAnswerMap(clarificationDraftValue, structuredClarificationQuestions),
+    [clarificationDraftValue, structuredClarificationQuestions],
+  );
 
   const planText = useMemo(() => {
     const args = primaryInterruptAction?.args;
@@ -306,7 +599,15 @@ export default function ChatMessageBubble({
     setConfirmActionId(null);
   };
 
-  const clarificationDisplayPayload = renderDisplayPayload(pendingInterrupt?.displayPayload, 'Context', 'dark');
+  const clarificationDisplayPayload = renderDisplayPayload(
+    pendingInterrupt?.displayPayload && typeof pendingInterrupt.displayPayload === 'object'
+      ? Object.fromEntries(
+          Object.entries(pendingInterrupt.displayPayload).filter(([key]) => key !== 'questions'),
+        )
+      : undefined,
+    'Context',
+    'light',
+  );
   const approvalDisplayPayload = approvalReview
     ? null
     : renderDisplayPayload(pendingInterrupt?.displayPayload, 'Plan details', 'light');
@@ -393,7 +694,14 @@ export default function ChatMessageBubble({
                       </span>
                     </>
                   ) : (
-                    action.label
+                    <span className="min-w-0 text-left">
+                      <span className="block">{action.label}</span>
+                      {action.description ? (
+                        <span className={tone === 'dark' ? 'mt-1 block text-xs font-normal text-white/58' : 'mt-1 block text-[11px] font-normal leading-relaxed text-slate-500'}>
+                          {action.description}
+                        </span>
+                      ) : null}
+                    </span>
                   )}
                 </button>
               ) : null}
@@ -732,31 +1040,127 @@ export default function ChatMessageBubble({
               </div>
             ) : null}
             {pendingInterrupt && isClarificationInterrupt && !clarificationDismissed ? (
-              <div className="mt-5 rounded-[2rem] border border-white/10 bg-[#121212] p-5 text-white shadow-[0_26px_80px_-34px_rgba(0,0,0,0.95)] ring-1 ring-white/10">
+              <div className="mt-5 rounded-[2rem] border border-slate-200/80 bg-gradient-to-br from-white via-slate-50 to-sky-50/55 p-5 text-slate-900 shadow-[0_26px_80px_-34px_rgba(15,23,42,0.32)] ring-1 ring-white/70">
                 <div className="flex items-start justify-between gap-4">
                   <div className="min-w-0">
-                    <p className="text-[30px] font-semibold leading-tight tracking-tight text-white">
+                    <p className="text-[30px] font-semibold leading-tight tracking-tight text-slate-900">
                       {pendingInterrupt.title || (isDynamicActionInterrupt ? 'Select the next step' : 'The agent needs clarification')}
                     </p>
                     {pendingInterrupt.description ? (
-                      <p className="mt-3 max-w-2xl text-sm leading-relaxed text-white/70">
+                      <p className="mt-3 max-w-2xl text-sm leading-relaxed text-slate-600">
                         {pendingInterrupt.description}
                       </p>
                     ) : null}
                   </div>
                   {pendingInterrupt.stepCount && pendingInterrupt.stepCount > 1 ? (
-                    <div className="shrink-0 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/75">
+                    <div className="shrink-0 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-medium text-slate-600">
                       {typeof pendingInterrupt.stepIndex === 'number' ? pendingInterrupt.stepIndex + 1 : 1} of {pendingInterrupt.stepCount}
                     </div>
                   ) : null}
                 </div>
                 {clarificationDisplayPayload ? <div className="mt-5">{clarificationDisplayPayload}</div> : null}
                 {interruptError ? (
-                  <div className="mt-4 rounded-[1.25rem] border border-rose-400/35 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+                  <div className="mt-4 rounded-[1.25rem] border border-rose-200/90 bg-rose-50 px-4 py-3 text-sm text-rose-700">
                     {interruptError}
                   </div>
                 ) : null}
-                {renderInterruptActions('dark')}
+                {hasStructuredClarificationForm ? (
+                  <div className="mt-5 space-y-5">
+                    <div className="grid gap-4 md:grid-cols-2">
+                      {structuredClarificationQuestions.map((question) => (
+                        <div key={question.id} className="rounded-[1.5rem] border border-slate-200/80 bg-white/85 p-4 shadow-sm">
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+                            {question.header}
+                          </p>
+                          <p className="mt-2 text-sm font-medium leading-relaxed text-slate-700">
+                            {question.question}
+                          </p>
+                          {question.options.length ? (
+                            <div className="mt-3 space-y-2">
+                              {question.options.map((option) => {
+                                const currentAnswer = (structuredAnswerMap[question.id] || '').trim().toLowerCase();
+                                const isSelected = currentAnswer === option.value.trim().toLowerCase();
+                                return (
+                                  <button
+                                    key={option.id}
+                                    type="button"
+                                    disabled={interruptControlsDisabled}
+                                    onClick={() => {
+                                      const nextValue = upsertStructuredAnswer(
+                                        clarificationDraftValue,
+                                        question,
+                                        option.value,
+                                        structuredClarificationQuestions,
+                                      );
+                                      setInterruptValue(clarificationTextKey, nextValue);
+                                    }}
+                                    className={`w-full rounded-[1.15rem] border px-3 py-3 text-left transition-all duration-200 ${
+                                      isSelected
+                                        ? 'border-sky-300 bg-sky-50 text-sky-900 shadow-[0_0_0_1px_rgba(14,165,233,0.12)]'
+                                        : 'border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50'
+                                    } ${interruptControlsDisabled ? 'cursor-not-allowed opacity-60' : ''}`}
+                                  >
+                                    <span className="block text-sm font-semibold">{option.label}</span>
+                                    {option.description ? (
+                                      <span className="mt-1 block text-xs leading-relaxed text-slate-500">
+                                        {option.description}
+                                      </span>
+                                    ) : null}
+                                  </button>
+                                );
+                              })}
+                            </div>
+                          ) : null}
+                        </div>
+                      ))}
+                    </div>
+                    <div className="rounded-[1.5rem] border border-slate-200/80 bg-white/90 p-4 shadow-sm">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                          <p className="text-sm font-semibold text-slate-800">Notes for the agent</p>
+                          <p className="mt-1 text-xs text-slate-500">Adjust any suggestion or add your own details, then continue.</p>
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          {structuredClarificationSubmitActions.map((action) => (
+                            <button
+                              key={action.id}
+                              type="button"
+                              disabled={interruptControlsDisabled || !clarificationDraftValue.trim()}
+                              onClick={() => void handleInterruptAction(message, action, pendingInterrupt)}
+                              className={getActionButtonClass(
+                                {
+                                  ...action,
+                                  label: action.submitLabel || action.label,
+                                  style: 'primary',
+                                },
+                                'light',
+                              )}
+                            >
+                              {interruptBusy ? (
+                                <span className="inline-flex items-center gap-2">
+                                  <Loader2 size={16} className="animate-spin" />
+                                  {action.submitLabel || action.label}
+                                </span>
+                              ) : (
+                                action.submitLabel || action.label
+                              )}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                      <textarea
+                        value={clarificationDraftValue}
+                        onChange={(event) => setInterruptValue(clarificationTextKey, event.target.value)}
+                        rows={Math.max(6, structuredClarificationQuestions.length + 1)}
+                        disabled={interruptControlsDisabled}
+                        placeholder={buildClarificationTemplate(structuredClarificationQuestions)}
+                        className="mt-3 w-full rounded-[1.35rem] border border-slate-200 bg-white px-4 py-3 text-sm leading-relaxed text-slate-700 placeholder:text-slate-400 focus:border-sky-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-70"
+                      />
+                    </div>
+                  </div>
+                ) : (
+                  renderInterruptActions('light')
+                )}
                 <div className="mt-6 flex items-center justify-between gap-4">
                   <button
                     type="button"
@@ -764,8 +1168,8 @@ export default function ChatMessageBubble({
                     onClick={() => setClarificationDismissed(true)}
                     className={`rounded-full px-4 py-2 text-sm font-medium transition-all duration-200 ${
                       allowDismiss
-                        ? 'text-white/70 hover:bg-white/[0.06] hover:text-white'
-                        : 'cursor-not-allowed text-white/25'
+                        ? 'text-slate-500 hover:bg-slate-100 hover:text-slate-700'
+                        : 'cursor-not-allowed text-slate-300'
                     }`}
                   >
                     {pendingInterrupt.responseSpec?.dismissLabel || 'Dismiss'}

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -9,7 +9,25 @@ import type { RenderableInterruptAction } from './interruptActions';
 import { buildApprovalReview } from './approvalReview';
 
 const THOUGHT_PREVIEW_LIMIT = 320;
-const THINKING_PLACEHOLDER = 'Formulating a research plan based on your prompt and available context.';
+const DEFAULT_THINKING_PLACEHOLDER = 'Working through your request based on the current workspace context.';
+
+const getThinkingPlaceholder = (
+  metadata?: ConversationMessageMetadata,
+  toolEvents: ConversationMessage['toolEvents'] = [],
+): string => {
+  const activeSkill = metadata?.runPolicy?.skill?.trim().toLowerCase();
+  if (activeSkill === 'frontend-slides') {
+    return 'Preparing the presentation workflow from your prompt and workspace content.';
+  }
+  const toolNames = new Set((toolEvents || []).map((event) => event.name?.trim().toLowerCase()).filter(Boolean));
+  if (toolNames.has('request_clarification')) {
+    return 'Waiting for the presentation details needed to continue.';
+  }
+  if (activeSkill === 'research' || toolNames.has('google_search') || toolNames.has('google_grounded_search')) {
+    return 'Formulating a research plan based on your prompt and available context.';
+  }
+  return DEFAULT_THINKING_PLACEHOLDER;
+};
 
 const formatInterruptValue = (value: unknown): string => {
   if (typeof value === 'string') {
@@ -164,7 +182,9 @@ export default function ChatMessageBubble({
   const isThinkingExpanded = expandedThinkingMessages.has(message.id);
   const rawThinkingText = message.thinkingText?.trim() || '';
   const isSystemThinking = /available skills/i.test(rawThinkingText);
-  const displayThinkingText = isSystemThinking ? THINKING_PLACEHOLDER : rawThinkingText;
+  const displayThinkingText = isSystemThinking
+    ? getThinkingPlaceholder(messageMetadata, toolEvents)
+    : rawThinkingText;
   const showThinkingToggle = !isSystemThinking && displayThinkingText.length > THOUGHT_PREVIEW_LIMIT;
   const isThinkingCollapsed = showThinkingToggle && !isThinkingExpanded;
   const sanitizedAgentText = (() => {

--- a/frontend/src/components/chat/ChatMessageList.tsx
+++ b/frontend/src/components/chat/ChatMessageList.tsx
@@ -15,6 +15,7 @@ export default function ChatMessageList({
   expandedThinkingMessages,
   copiedMessageId,
   interruptInputByMessageId,
+  interruptSelectedChoicesByMessageId,
   interruptSubmittingByMessageId,
   interruptErrorByMessageId,
   interruptFieldKey,
@@ -25,6 +26,7 @@ export default function ChatMessageList({
   getPrimaryInterruptAction,
   isPlanApprovalInterrupt,
   setInterruptInputByMessageId,
+  toggleInterruptSelectedChoice,
   workspaceSkipPlanApprovals,
   workspaceSettingsBusy,
   toggleThinkingVisibility,
@@ -45,6 +47,7 @@ export default function ChatMessageList({
   expandedThinkingMessages: Set<ConversationMessage['id']>;
   copiedMessageId: ConversationMessage['id'] | null;
   interruptInputByMessageId: Record<string, string>;
+  interruptSelectedChoicesByMessageId: Record<string, string[]>;
   interruptSubmittingByMessageId: Record<string, boolean>;
   interruptErrorByMessageId: Record<string, string>;
   interruptFieldKey: (
@@ -64,6 +67,7 @@ export default function ChatMessageList({
   ) => { name?: string; args?: Record<string, unknown> } | undefined;
   isPlanApprovalInterrupt: (pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt']) => boolean;
   setInterruptInputByMessageId: Dispatch<SetStateAction<Record<string, string>>>;
+  toggleInterruptSelectedChoice: (messageKey: string, choiceId: string, multiple: boolean) => void;
   workspaceSkipPlanApprovals: boolean;
   workspaceSettingsBusy: boolean;
   toggleThinkingVisibility: (messageId: ConversationMessage['id']) => void;
@@ -148,6 +152,7 @@ export default function ChatMessageList({
           expandedThinkingMessages={expandedThinkingMessages}
           copiedMessageId={copiedMessageId}
           interruptInputByMessageId={interruptInputByMessageId}
+          interruptSelectedChoicesByMessageId={interruptSelectedChoicesByMessageId}
           interruptSubmittingByMessageId={interruptSubmittingByMessageId}
           interruptErrorByMessageId={interruptErrorByMessageId}
           interruptFieldKey={interruptFieldKey}
@@ -158,6 +163,7 @@ export default function ChatMessageList({
           getPrimaryInterruptAction={getPrimaryInterruptAction}
           isPlanApprovalInterrupt={isPlanApprovalInterrupt}
           setInterruptInputByMessageId={setInterruptInputByMessageId}
+          toggleInterruptSelectedChoice={toggleInterruptSelectedChoice}
           workspaceSkipPlanApprovals={workspaceSkipPlanApprovals}
           workspaceSettingsBusy={workspaceSettingsBusy}
           toggleThinkingVisibility={toggleThinkingVisibility}
@@ -177,6 +183,7 @@ export default function ChatMessageList({
     interruptFieldKey,
     interruptActionFieldKey,
     interruptInputByMessageId,
+    interruptSelectedChoicesByMessageId,
     interruptSubmittingByMessageId,
     interruptErrorByMessageId,
     copiedMessageId,
@@ -198,6 +205,7 @@ export default function ChatMessageList({
     messages,
     personaDisplayName,
     setInterruptInputByMessageId,
+    toggleInterruptSelectedChoice,
     toggleThinkingVisibility,
     toggleToolActivityVisibility,
     workspaceId,

--- a/frontend/src/components/chat/interruptActions.ts
+++ b/frontend/src/components/chat/interruptActions.ts
@@ -2,6 +2,7 @@ import type { InterruptAction } from '../../types';
 
 export type RenderableInterruptAction = InterruptAction & {
   source: 'dynamic' | 'approval' | 'clarification-choice' | 'clarification-text';
+  description?: string;
   legacyDecision?: 'approve' | 'edit' | 'reject';
   choiceId?: string;
 };

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -254,6 +254,14 @@ const loadActiveRunsFromStorage = (): Record<string, ActiveRunInfo> => {
   return {};
 };
 
+type PersistProgressRequest = {
+  runInfo: ActiveRunInfo;
+  statusOverride?: AgentRunStatus;
+  options?: {
+    metadataOverride?: Partial<ConversationMessageMetadata>;
+  };
+};
+
 export default function WorkspacePage() {
   const navigate = useNavigate();
   const { signOut } = useAuth();
@@ -319,6 +327,7 @@ export default function WorkspacePage() {
   const lastPersistedStatusRef = useRef<Record<string, AgentRunStatus | undefined>>({});
   const lastPersistedMetadataRef = useRef<Record<string, string | undefined>>({});
   const persistInFlightRef = useRef<Set<string>>(new Set());
+  const pendingPersistRef = useRef<Record<string, PersistProgressRequest>>({});
   const stopRequestedRef = useRef(false);
   const chatInputRef = useRef<HTMLTextAreaElement | null>(null);
   const attachmentInputRef = useRef<HTMLInputElement | null>(null);
@@ -2198,6 +2207,7 @@ export default function WorkspacePage() {
     ) => {
       const { runId, conversationId, turnId, placeholderId } = runInfo;
       if (persistInFlightRef.current.has(runId)) {
+        pendingPersistRef.current[runId] = { runInfo, statusOverride, options };
         return;
       }
       const message = findAgentMessageForRun(conversationId, placeholderId, turnId);
@@ -2247,6 +2257,11 @@ export default function WorkspacePage() {
         console.error('Failed to persist agent progress', error);
       } finally {
         persistInFlightRef.current.delete(runId);
+        const pending = pendingPersistRef.current[runId];
+        if (pending) {
+          delete pendingPersistRef.current[runId];
+          void persistAgentProgress(pending.runInfo, pending.statusOverride, pending.options);
+        }
       }
     },
     [getBufferedAgentText, findAgentMessageForRun, upsertPersistedAgentMessage],
@@ -2295,9 +2310,42 @@ export default function WorkspacePage() {
 
   const getInterruptKind = useCallback((
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
-  ): 'approval' | 'clarification' => (
-    pendingInterrupt?.kind === 'clarification' ? 'clarification' : 'approval'
-  ), []);
+  ): 'approval' | 'clarification' => {
+    if (pendingInterrupt?.kind === 'clarification') {
+      return 'clarification';
+    }
+
+    const responseSpec =
+      pendingInterrupt?.responseSpec && typeof pendingInterrupt.responseSpec === 'object'
+        ? pendingInterrupt.responseSpec
+        : undefined;
+    if (responseSpec) {
+      return 'clarification';
+    }
+
+    const actions = Array.isArray(pendingInterrupt?.actions) ? pendingInterrupt.actions : [];
+    const actionRequests = Array.isArray(pendingInterrupt?.actionRequests) ? pendingInterrupt.actionRequests : [];
+    const reviewConfigs = Array.isArray(pendingInterrupt?.reviewConfigs) ? pendingInterrupt.reviewConfigs : [];
+    const hasApprovalConfig = actionRequests.length > 0 || reviewConfigs.length > 0;
+    const hasClarificationAction = actions.some((action) => {
+      if (!action || typeof action !== 'object') {
+        return false;
+      }
+      if (action.id === 'clarification-text') {
+        return true;
+      }
+      if (action.payload && typeof action.payload === 'object' && 'selectedChoiceId' in action.payload) {
+        return true;
+      }
+      return false;
+    });
+
+    if (hasClarificationAction && !hasApprovalConfig) {
+      return 'clarification';
+    }
+
+    return 'approval';
+  }, []);
 
   const isPlanApprovalInterrupt = useCallback((
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -402,10 +402,31 @@ export default function WorkspacePage() {
     }
   }, []);
 
+  const removeConflictingRuns = useCallback((runs: Record<string, ActiveRunInfo>, runInfo: ActiveRunInfo) => {
+    const next = { ...runs };
+    Object.entries(next).forEach(([candidateRunId, candidate]) => {
+      if (candidateRunId === runInfo.runId) {
+        return;
+      }
+      if (candidate.conversationId === runInfo.conversationId && candidate.turnId === runInfo.turnId) {
+        delete next[candidateRunId];
+        delete lastPersistedAgentTextRef.current[candidateRunId];
+        delete lastPersistedStatusRef.current[candidateRunId];
+        delete lastPersistedMetadataRef.current[candidateRunId];
+        resumeInFlightRef.current.delete(candidateRunId);
+        resumeAttemptedRef.current.delete(candidateRunId);
+      }
+    });
+    return next;
+  }, []);
+
   const registerActiveRun = useCallback((runInfo: ActiveRunInfo) => {
-    const next = { ...activeRunsRef.current, [runInfo.runId]: runInfo };
+    const next = {
+      ...removeConflictingRuns(activeRunsRef.current, runInfo),
+      [runInfo.runId]: runInfo,
+    };
     persistActiveRuns(next);
-  }, [persistActiveRuns]);
+  }, [persistActiveRuns, removeConflictingRuns]);
 
   const removeActiveRun = useCallback((runId: string) => {
     if (!activeRunsRef.current[runId]) return;
@@ -417,6 +438,31 @@ export default function WorkspacePage() {
     delete lastPersistedMetadataRef.current[runId];
     resumeInFlightRef.current.delete(runId);
     resumeAttemptedRef.current.delete(runId);
+  }, [persistActiveRuns]);
+
+  const removeActiveRunsForTurn = useCallback((conversationId: string, turnId?: string, keepRunId?: string) => {
+    if (!turnId) {
+      return;
+    }
+    const next = { ...activeRunsRef.current };
+    let changed = false;
+    Object.entries(next).forEach(([candidateRunId, candidate]) => {
+      if (candidateRunId === keepRunId) {
+        return;
+      }
+      if (candidate.conversationId === conversationId && candidate.turnId === turnId) {
+        delete next[candidateRunId];
+        delete lastPersistedAgentTextRef.current[candidateRunId];
+        delete lastPersistedStatusRef.current[candidateRunId];
+        delete lastPersistedMetadataRef.current[candidateRunId];
+        resumeInFlightRef.current.delete(candidateRunId);
+        resumeAttemptedRef.current.delete(candidateRunId);
+        changed = true;
+      }
+    });
+    if (changed) {
+      persistActiveRuns(next);
+    }
   }, [persistActiveRuns]);
 
   const getActiveRunForConversation = useCallback((conversationId: string | null) => {
@@ -2097,6 +2143,10 @@ export default function WorkspacePage() {
     if (!message || message.sender !== 'agent') {
       return true;
     }
+    const metadata = (message.metadata as ConversationMessageMetadata | undefined) || undefined;
+    if (metadata?.pendingInterrupt || metadata?.status === 'awaiting_approval') {
+      return false;
+    }
     return !message.text && !message.thinkingText && !message.toolEvents?.length;
   }, []);
 
@@ -2450,8 +2500,14 @@ export default function WorkspacePage() {
         )
       : [];
     if (interruptActions.length) {
+      const responseSpec = pendingInterrupt?.responseSpec;
+      const clarificationChoices = Array.isArray(responseSpec?.choices) ? responseSpec.choices : [];
       return interruptActions.map((action) => ({
         ...action,
+        description:
+          typeof action.payload?.selectedChoiceId === 'string'
+            ? clarificationChoices.find((choice) => choice.id === action.payload?.selectedChoiceId)?.description
+            : clarificationChoices.find((choice) => choice.id === action.id)?.description,
         source: 'dynamic',
       }));
     }
@@ -2462,6 +2518,7 @@ export default function WorkspacePage() {
       const derivedActions: RenderableInterruptAction[] = clarificationChoices.map((choice) => ({
         id: `choice:${choice.id}`,
         label: choice.label,
+        description: choice.description,
         style: 'secondary',
         inputMode: 'none',
         value: choice.value,
@@ -2879,6 +2936,7 @@ export default function WorkspacePage() {
           registerActiveRun({ ...runInfo, status: finalStatus });
         } else {
           removeActiveRun(runId);
+          removeActiveRunsForTurn(conversationId, turnId);
           const workspaceId = selectedWorkspace?.id;
           if (workspaceId) {
             loadFilesForWorkspace(workspaceId);
@@ -2897,6 +2955,7 @@ export default function WorkspacePage() {
       getRunStatus,
       addLocalSystemMessage,
       removeActiveRun,
+      removeActiveRunsForTurn,
       selectedWorkspace?.id,
       loadFilesForWorkspace,
     ],
@@ -3211,7 +3270,7 @@ export default function WorkspacePage() {
         return;
       }
 
-      if (action.source === 'clarification-text') {
+      if (getInterruptKind(pendingInterrupt) === 'clarification' && action.inputMode === 'text') {
         await handleClarificationResponse(message, pendingInterrupt);
         return;
       }
@@ -3424,25 +3483,29 @@ export default function WorkspacePage() {
               .finally(() => {
                 resumeInFlightRef.current.delete(activeRun.runId);
               });
-          } else if (needsRecovery) {
-            streamRunForConversation({ ...activeRun, status: status.status }, true)
-              .catch((error) => {
-                console.error('Failed to recover agent stream', error);
-                removeActiveRun(activeRun.runId);
-              })
-              .finally(() => {
-                resumeInFlightRef.current.delete(activeRun.runId);
-              });
           } else if (status.status === 'awaiting_approval') {
             const targetMessage = findAgentMessageForRun(
               activeRun.conversationId,
               activeRun.placeholderId,
               activeRun.turnId
             );
-            if (targetMessage?.metadata?.runId || status.pendingInterrupt) {
+            if (!targetMessage && status.pendingInterrupt) {
+              ensureAgentPlaceholder(
+                activeRun.conversationId,
+                activeRun.placeholderId,
+                activeRun.turnId,
+                true,
+              );
+            }
+            const resolvedTargetMessage = findAgentMessageForRun(
+              activeRun.conversationId,
+              activeRun.placeholderId,
+              activeRun.turnId
+            );
+            if (resolvedTargetMessage?.metadata?.runId || status.pendingInterrupt) {
               updateMessagesForConversation(activeRun.conversationId, (prev) => {
                 const updated = [...prev];
-                const idx = updated.findIndex((message) => message.id === targetMessage?.id);
+                const idx = updated.findIndex((message) => message.id === resolvedTargetMessage?.id);
                 if (idx === -1) {
                   return updated;
                 }
@@ -3458,6 +3521,15 @@ export default function WorkspacePage() {
               });
             }
             resumeInFlightRef.current.delete(activeRun.runId);
+          } else if (needsRecovery) {
+            streamRunForConversation({ ...activeRun, status: status.status }, true)
+              .catch((error) => {
+                console.error('Failed to recover agent stream', error);
+                removeActiveRun(activeRun.runId);
+              })
+              .finally(() => {
+                resumeInFlightRef.current.delete(activeRun.runId);
+              });
           } else {
             resumeInFlightRef.current.delete(activeRun.runId);
             const staleMessage = findAgentMessageForRun(

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -1064,6 +1064,33 @@ export default function WorkspacePage() {
     stopRequestedRef.current = true;
     const activeRun = getActiveRunForConversation(activeConversationId);
     if (activeRun) {
+      updateMessagesForConversation(activeRun.conversationId, (prev) =>
+        prev.map((message) => {
+          if (message.sender !== 'agent') {
+            return message;
+          }
+          const metadata = (message.metadata as ConversationMessageMetadata | undefined) || undefined;
+          const matchesRun =
+            metadata?.runId === activeRun.runId ||
+            message.id === activeRun.placeholderId ||
+            (activeRun.turnId && message.turnId === activeRun.turnId);
+          if (!matchesRun) {
+            return message;
+          }
+          return {
+            ...message,
+            metadata: {
+              ...(metadata || {}),
+              runId: metadata?.runId || activeRun.runId,
+              status: 'cancelled',
+              pendingInterrupt: undefined,
+            },
+          };
+        }),
+      );
+      removeActiveRun(activeRun.runId);
+      resumeInFlightRef.current.delete(activeRun.runId);
+      resumeAttemptedRef.current.add(activeRun.runId);
       cancelRun(activeRun.runId).catch((error) => {
         console.error('Failed to cancel run', error);
       });

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -2393,6 +2393,15 @@ export default function WorkspacePage() {
         source: 'clarification-choice',
         choiceId: choice.id,
       }));
+      if (responseSpec?.multiple && derivedActions.length) {
+        derivedActions.push({
+          id: 'clarification-submit',
+          label: responseSpec?.submitLabel || 'Continue',
+          style: 'primary',
+          inputMode: 'none',
+          source: 'clarification-text',
+        });
+      }
       const inputMode = responseSpec?.inputMode || 'text';
       if (inputMode === 'text' || inputMode === 'text_or_choice' || !derivedActions.length) {
         derivedActions.push({
@@ -3099,6 +3108,35 @@ export default function WorkspacePage() {
     ],
   );
 
+  const toggleInterruptSelectedChoice = useCallback((messageKey: string, choiceId: string, multiple: boolean) => {
+    setInterruptSelectedChoicesByMessageId((prev) => {
+      const current = prev[messageKey] || [];
+      let nextChoices: string[];
+      if (multiple) {
+        nextChoices = current.includes(choiceId)
+          ? current.filter((id) => id !== choiceId)
+          : [...current, choiceId];
+      } else {
+        nextChoices = current.length === 1 && current[0] === choiceId ? [] : [choiceId];
+      }
+      if (!nextChoices.length) {
+        const next = { ...prev };
+        delete next[messageKey];
+        return next;
+      }
+      return {
+        ...prev,
+        [messageKey]: nextChoices,
+      };
+    });
+    setInterruptErrorByMessageId((prev) => {
+      if (!prev[messageKey]) return prev;
+      const next = { ...prev };
+      delete next[messageKey];
+      return next;
+    });
+  }, []);
+
   const handleInterruptAction = useCallback(
     async (
       message: ConversationMessage,
@@ -3126,6 +3164,10 @@ export default function WorkspacePage() {
       const actionText = (interruptInputByMessageId[actionTextKey] || '').trim();
 
       if (action.source === 'clarification-choice') {
+        if (pendingInterrupt?.responseSpec?.multiple && action.choiceId) {
+          toggleInterruptSelectedChoice(messageKey, action.choiceId, true);
+          return;
+        }
         setInterruptSubmittingByMessageId((prev) => ({ ...prev, [messageKey]: true }));
         setInterruptErrorByMessageId((prev) => {
           if (!prev[messageKey]) return prev;
@@ -3262,6 +3304,7 @@ export default function WorkspacePage() {
       registerActiveRun,
       submitInterruptWithRetry,
       streamRunForConversation,
+      toggleInterruptSelectedChoice,
     ],
   );
 
@@ -4707,6 +4750,7 @@ export default function WorkspacePage() {
               expandedThinkingMessages={expandedThinkingMessages}
               copiedMessageId={copiedMessageId}
               interruptInputByMessageId={interruptInputByMessageId}
+              interruptSelectedChoicesByMessageId={interruptSelectedChoicesByMessageId}
               interruptSubmittingByMessageId={interruptSubmittingByMessageId}
               interruptErrorByMessageId={interruptErrorByMessageId}
               chatMessage={chatMessage}
@@ -4731,6 +4775,7 @@ export default function WorkspacePage() {
               getPrimaryInterruptAction={getPrimaryInterruptAction}
               isPlanApprovalInterrupt={isPlanApprovalInterrupt}
               setInterruptInputByMessageId={setInterruptInputByMessageId}
+              toggleInterruptSelectedChoice={toggleInterruptSelectedChoice}
               workspaceSkipPlanApprovals={Boolean(selectedWorkspace?.skipPlanApprovals)}
               workspaceSettingsBusy={workspaceSettingsBusy}
               onToggleAgentPaneVisibility={() => setIsAgentPaneVisible((prev) => !prev)}

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -2596,6 +2596,19 @@ export default function WorkspacePage() {
     chunk: AgentStreamChunk,
     runId?: string,
   ) => {
+    const preserveInterruptState = (
+      metadata: ConversationMessageMetadata | undefined,
+    ): ConversationMessageMetadata => {
+      const nextMetadata = { ...(metadata || {}) };
+      const hasPendingInterrupt = Boolean(nextMetadata.pendingInterrupt);
+      if (runId) {
+        nextMetadata.runId = runId;
+      }
+      nextMetadata.status = hasPendingInterrupt ? 'awaiting_approval' : 'running';
+      nextMetadata.pendingInterrupt = hasPendingInterrupt ? nextMetadata.pendingInterrupt : undefined;
+      return nextMetadata;
+    };
+
     if (chunk.type === 'keepalive') {
       setStreamingForConversation(conversationId, true);
       return;
@@ -2619,45 +2632,25 @@ export default function WorkspacePage() {
     }
 
     if (chunk.type === 'thought') {
-      updateMessageMetadataAtIndex(conversationId, agentMessageIndex, (metadata) => ({
-        ...metadata,
-        ...(runId ? { runId } : {}),
-        status: 'running',
-        pendingInterrupt: undefined,
-      }));
+      updateMessageMetadataAtIndex(conversationId, agentMessageIndex, preserveInterruptState);
       appendAgentThought(conversationId, agentMessageIndex, chunk.content || '');
       return;
     }
 
     if (chunk.type === 'tool_start') {
-      updateMessageMetadataAtIndex(conversationId, agentMessageIndex, (metadata) => ({
-        ...metadata,
-        ...(runId ? { runId } : {}),
-        status: 'running',
-        pendingInterrupt: undefined,
-      }));
+      updateMessageMetadataAtIndex(conversationId, agentMessageIndex, preserveInterruptState);
       appendToolStart(conversationId, agentMessageIndex, chunk);
       return;
     }
 
     if (chunk.type === 'tool_end') {
-      updateMessageMetadataAtIndex(conversationId, agentMessageIndex, (metadata) => ({
-        ...metadata,
-        ...(runId ? { runId } : {}),
-        status: 'running',
-        pendingInterrupt: undefined,
-      }));
+      updateMessageMetadataAtIndex(conversationId, agentMessageIndex, preserveInterruptState);
       appendToolEnd(conversationId, agentMessageIndex, chunk);
       return;
     }
 
     if (chunk.type === 'tool_error') {
-      updateMessageMetadataAtIndex(conversationId, agentMessageIndex, (metadata) => ({
-        ...metadata,
-        ...(runId ? { runId } : {}),
-        status: 'running',
-        pendingInterrupt: undefined,
-      }));
+      updateMessageMetadataAtIndex(conversationId, agentMessageIndex, preserveInterruptState);
       appendToolEnd(conversationId, agentMessageIndex, chunk, 'error');
       return;
     }
@@ -2685,12 +2678,7 @@ export default function WorkspacePage() {
     }
 
     if (chunk.type === 'token' || chunk.type === 'chunk') {
-      updateMessageMetadataAtIndex(conversationId, agentMessageIndex, (metadata) => ({
-        ...metadata,
-        ...(runId ? { runId } : {}),
-        status: 'running',
-        pendingInterrupt: undefined,
-      }));
+      updateMessageMetadataAtIndex(conversationId, agentMessageIndex, preserveInterruptState);
       if (chunk.role && chunk.role !== 'assistant') {
         return;
       }

--- a/packages/shared/src/services/agentStream.ts
+++ b/packages/shared/src/services/agentStream.ts
@@ -42,6 +42,12 @@ export type AgentStreamChunk =
         allowDismiss?: boolean;
         dismissLabel?: string;
         choices?: Array<{ id: string; label: string; description?: string; value: string }>;
+        questions?: Array<{
+          id: string;
+          header: string;
+          question: string;
+          options?: Array<{ id: string; label: string; description?: string; value: string }>;
+        }>;
       };
       displayPayload?: Record<string, unknown>;
     }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -54,6 +54,20 @@ export interface InterruptChoice {
   value: string;
 }
 
+export interface InterruptQuestionOption {
+  id: string;
+  label: string;
+  description?: string;
+  value: string;
+}
+
+export interface InterruptQuestion {
+  id: string;
+  header: string;
+  question: string;
+  options?: InterruptQuestionOption[];
+}
+
 export interface InterruptAction {
   id: string;
   label: string;
@@ -74,6 +88,7 @@ export interface InterruptResponseSpec {
   allowDismiss?: boolean;
   dismissLabel?: string;
   choices?: InterruptChoice[];
+  questions?: InterruptQuestion[];
 }
 
 export interface PendingInterrupt {

--- a/skills/frontend-slides/SKILL.md
+++ b/skills/frontend-slides/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: frontend-slides
 description: Create stunning, animation-rich HTML presentations from scratch or by converting PowerPoint files. Use when the user wants to build a presentation, convert a PPT/PPTX to web, or create slides for a talk/pitch. Helps non-designers discover their aesthetic through visual exploration rather than abstract choices.
+requires_hitl_plan: false
 ---
 
 # Frontend Slides Skill


### PR DESCRIPTION
## Summary
- fix dynamic HITL approval/action resume flow across frontend, backend, and agent runtime
- redesign plan approvals into a structured review card with trusted workspace mode
- harden live chat stream persistence, duplicate-bubble cleanup, and resumed-stream rendering

## Included
- additive v2 interrupt actions model with `/act` support
- approval/clarification rendering cleanup and scoped interrupt inputs
- restart-safe run resume context and approval persistence fixes
- approval review card UX improvements and editor-assisted plan edit flow
- workspace drawer/footer layout fixes and active-run/stream reconnection fixes
- debug note for observed HITL production symptoms

## Validation
- `python3 -m py_compile agent/helpudoc_agent/app.py agent/helpudoc_agent/tools_and_schemas.py agent/helpudoc_agent/graph.py`
- `npm exec -- tsc -p tsconfig.json --noEmit --pretty false` in `backend`
- `npm exec -- tsc -b --pretty false` in `frontend`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run build` in `frontend`
- live deploy and Playwright QC on `lc-demo.com`

## Notes
- This PR does not include the unrelated untracked `docs/current-architecture.md` file.
