### PR TITLE
Fix rich markdown editor parity

### DIFF
--- a/agent/config/runtime.yaml
+++ b/agent/config/runtime.yaml
@@ -62,6 +62,9 @@ tools:
   - name: request_clarification
     kind: builtin
     description: Pause the run and ask the human for clarification with optional choices
+  - name: request_human_action
+    kind: builtin
+    description: Pause the run and ask the human to choose from arbitrary actions
 
 mcp_servers:
   - name: toolbox-bq-demo

--- a/agent/helpudoc_agent/app.py
+++ b/agent/helpudoc_agent/app.py
@@ -896,6 +896,21 @@ def create_app() -> FastAPI:
                 missing.append(item)
         return missing
 
+    def _reset_turn_context(runtime: AgentRuntimeState) -> None:
+        context = runtime.workspace_state.context or {}
+        skip_plan_approvals = bool(context.get("skip_plan_approvals"))
+        # Skill execution state is per top-level user task. Resumes should preserve it,
+        # but a fresh user turn should not inherit approval or active-skill state.
+        context.pop("active_skill", None)
+        context.pop("active_skill_policy", None)
+        context.pop("last_plan_feedback", None)
+        context.pop("last_plan_file_path", None)
+        context.pop("tagged_files", None)
+        context.pop("tagged_rag_context", None)
+        context["tagged_files_only"] = False
+        context["plan_approved"] = skip_plan_approvals
+        context["pre_plan_search_count"] = 0
+
     _ASSISTANT_ROLES = {"assistant", "ai", "aimessagechunk"}
     _TOOL_ROLES = {"tool"}
 
@@ -931,6 +946,7 @@ def create_app() -> FastAPI:
 
         payload = _prepare_payload(message)
         if resume_decisions is None and resume_value is None:
+            _reset_turn_context(runtime)
             tagged_files = _extract_tagged_files(message.message)
             runtime.workspace_state.context["tagged_files"] = tagged_files
             # Historical behavior forced "RAG-only" when any tagged files were present, which breaks

--- a/agent/helpudoc_agent/app.py
+++ b/agent/helpudoc_agent/app.py
@@ -387,6 +387,8 @@ def create_app() -> FastAPI:
             context["mcp_auth_fingerprint"] = mcp_auth_fingerprint.strip()
         if allow_script_runner:
             context["allow_script_runner"] = True
+        if isinstance(payload.get("skipPlanApprovals"), bool):
+            context["skip_plan_approvals"] = payload["skipPlanApprovals"]
         return context
 
 

--- a/agent/helpudoc_agent/app.py
+++ b/agent/helpudoc_agent/app.py
@@ -73,6 +73,17 @@ class InterruptResponseRequest(BaseModel):
     selectedValues: List[str] = Field(default_factory=list)
 
 
+class InterruptAction(BaseModel):
+    id: str
+    value: Optional[str] = None
+    payload: Dict[str, Any] = Field(default_factory=dict)
+    text: Optional[str] = None
+
+
+class InterruptActionRequest(BaseModel):
+    action: InterruptAction
+
+
 class RagQueryRequest(BaseModel):
     query: str
     mode: str = "local"
@@ -803,6 +814,7 @@ def create_app() -> FastAPI:
 
         action_requests = interrupt_value.get("action_requests")
         review_configs = interrupt_value.get("review_configs")
+        actions = interrupt_value.get("actions")
         payload = {
             "type": "interrupt",
             "kind": interrupt_value.get("kind"),
@@ -810,6 +822,7 @@ def create_app() -> FastAPI:
             "description": interrupt_value.get("description"),
             "stepIndex": interrupt_value.get("step_index"),
             "stepCount": interrupt_value.get("step_count"),
+            "actions": actions if isinstance(actions, list) else [],
             "actionRequests": action_requests if isinstance(action_requests, list) else [],
             "reviewConfigs": review_configs if isinstance(review_configs, list) else [],
         }
@@ -1118,6 +1131,27 @@ def create_app() -> FastAPI:
             response_payload = response_request.dict(exclude_none=True)  # type: ignore[attr-defined]
         placeholder = ChatRequest(message="", history=None, forceReset=False)
         stream = _stream_agent_response(runtime, placeholder, resume_value=response_payload)
+        return StreamingResponse(stream, media_type="application/jsonl")
+
+    @app.post("/agents/{agent_name}/workspace/{workspace_id}/chat/stream/act")
+    async def chat_stream_act(
+        agent_name: str,
+        workspace_id: str,
+        action_request: InterruptActionRequest,
+        request: Request,
+    ):
+        try:
+            initial_context = _extract_request_context(request)
+            runtime = await registry.get_or_create(agent_name, workspace_id, initial_context=initial_context)
+        except ValueError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        if hasattr(action_request, "model_dump"):
+            action_payload = action_request.model_dump(exclude_none=True)  # type: ignore[attr-defined]
+        else:
+            action_payload = action_request.dict(exclude_none=True)  # type: ignore[attr-defined]
+        placeholder = ChatRequest(message="", history=None, forceReset=False)
+        stream = _stream_agent_response(runtime, placeholder, resume_value=action_payload)
         return StreamingResponse(stream, media_type="application/jsonl")
 
     return app

--- a/agent/helpudoc_agent/graph.py
+++ b/agent/helpudoc_agent/graph.py
@@ -30,6 +30,7 @@ GENERAL_SYSTEM_PROMPT = (
     "the proposal to workspace markdown files using write_file (and append_to_report if needed). "
     "Before executing a multi-step skill-driven plan, first call request_plan_approval with a concise plan and checklist. "
     "If execution is blocked on missing user intent or an unresolved choice, call request_clarification instead of guessing. "
+    "If you need the human to choose from arbitrary next-step actions, call request_human_action. "
     "Only proceed with side-effecting tools after approval (or after applying user edits). "
     "Reply in chat with brief status updates, not full sections. "
     "If no skill applies, proceed with best-effort behavior."

--- a/agent/helpudoc_agent/graph.py
+++ b/agent/helpudoc_agent/graph.py
@@ -28,7 +28,7 @@ GENERAL_SYSTEM_PROMPT = (
     "Do not assume skills are copied into the workspace. "
     "For proposal/SOW/RFP requests, always load the proposal-writing skill and write "
     "the proposal to workspace markdown files using write_file (and append_to_report if needed). "
-    "Before executing a multi-step skill-driven plan, first call request_plan_approval with a concise plan and checklist. "
+    "Before executing a multi-step skill-driven plan, first call request_plan_approval with a concise plan, markdown summary, step list, tool/file impact, and target plan file path when possible. "
     "If execution is blocked on missing user intent or an unresolved choice, call request_clarification instead of guessing. "
     "If you need the human to choose from arbitrary next-step actions, call request_human_action. "
     "Only proceed with side-effecting tools after approval (or after applying user edits). "
@@ -97,8 +97,9 @@ class AgentRegistry:
         policy_key = json.dumps(context_payload.get("mcp_policy", {}) or {}, sort_keys=True, default=str)
         mcp_auth_fingerprint = str(context_payload.get("mcp_auth_fingerprint") or "")
         user_key = str(context_payload.get("user_id") or "")
-        cache_scope_prefix = f"{user_key}:{policy_key}:"
-        key = (resolved_name, workspace_id, f"{user_key}:{policy_key}:{mcp_auth_fingerprint}")
+        trusted_plan_key = "trusted" if bool(context_payload.get("skip_plan_approvals") or context_payload.get("skipPlanApprovals")) else "reviewed"
+        cache_scope_prefix = f"{user_key}:{policy_key}:{trusted_plan_key}:"
+        key = (resolved_name, workspace_id, f"{user_key}:{policy_key}:{trusted_plan_key}:{mcp_auth_fingerprint}")
         if key in self._cache:
             return self._cache[key]
         # Prevent unbounded growth when delegated auth fingerprints rotate over time.
@@ -154,6 +155,10 @@ class AgentRegistry:
         )
 
         model = self._get_model(model_name)
+        interrupt_on = dict(self.settings.backend.interrupt_on or {})
+        if bool(context_payload.get("skip_plan_approvals") or context_payload.get("skipPlanApprovals")):
+            interrupt_on.pop("request_plan_approval", None)
+
         middleware = [
             TodoListMiddleware(),
             FilesystemMiddleware(backend=backend),
@@ -164,8 +169,8 @@ class AgentRegistry:
             ),
             PatchToolCallsMiddleware(),
         ]
-        if self.settings.backend.interrupt_on:
-            middleware.append(HumanInTheLoopMiddleware(interrupt_on=self.settings.backend.interrupt_on))
+        if interrupt_on:
+            middleware.append(HumanInTheLoopMiddleware(interrupt_on=interrupt_on))
 
         full_prompt = system_prompt + "\n\n" + BASE_AGENT_PROMPT if system_prompt else BASE_AGENT_PROMPT
         agent = create_agent(

--- a/agent/helpudoc_agent/tools_and_schemas.py
+++ b/agent/helpudoc_agent/tools_and_schemas.py
@@ -55,6 +55,8 @@ def _get_active_skill_policy(workspace_state: WorkspaceState) -> SkillPolicy:
 
 
 def _is_plan_approved(workspace_state: WorkspaceState) -> bool:
+    if workspace_state.context.get("skip_plan_approvals"):
+        return True
     return bool(workspace_state.context.get("plan_approved"))
 
 
@@ -334,8 +336,11 @@ class ToolFactory:
                         "required_artifacts": skill.policy.required_artifacts or [],
                         "pre_plan_search_limit": max(0, int(skill.policy.pre_plan_search_limit or 0)),
                     }
-                    # Reset plan approval each time a new skill is loaded.
-                    workspace_state.context["plan_approved"] = False
+                    # Reset plan approval each time a new skill is loaded unless the
+                    # workspace is explicitly trusted to auto-approve plan reviews.
+                    workspace_state.context["plan_approved"] = bool(
+                        workspace_state.context.get("skip_plan_approvals")
+                    )
                     workspace_state.context["pre_plan_search_count"] = 0
                     return f"Loaded skill: {skill.skill_id}\n\n{content}"
             available = ", ".join(sorted({skill.skill_id for skill in skills}))
@@ -351,10 +356,17 @@ class ToolFactory:
         @tool
         def request_plan_approval(
             plan_title: str,
-            plan_summary: str,
-            execution_checklist: str,
+            plan_summary: str = "",
+            execution_checklist: str = "",
+            plan_summary_markdown: str = "",
+            steps: Optional[List[Dict[str, Any]]] = None,
+            plan_file_path: str = "",
+            status_label: str = "Pending Approval",
+            step_index: int = 0,
+            step_count: int = 1,
             risky_actions: str = "None",
             reviewer_feedback: str = "",
+            edited_plan_content: str = "",
         ) -> str:
             """Request human approval/edit/rejection for a proposed execution plan."""
             if workspace_state.context.get("tagged_files_only"):
@@ -362,18 +374,37 @@ class ToolFactory:
 
             title = (plan_title or "").strip()
             summary = (plan_summary or "").strip()
+            summary_markdown = (plan_summary_markdown or "").strip()
             checklist = (execution_checklist or "").strip()
+            normalized_steps = steps if isinstance(steps, list) else []
+            plan_path = (plan_file_path or "").strip() or "research_plan.md"
+            status = (status_label or "").strip() or "Pending Approval"
             risks = (risky_actions or "").strip()
             feedback = (reviewer_feedback or "").strip()
+            draft_content = (edited_plan_content or "").strip()
 
             if not title:
                 return "Plan approval blocked: plan_title is required."
-            if not summary:
-                return "Plan approval blocked: plan_summary is required."
-            if not checklist:
-                return "Plan approval blocked: execution_checklist is required."
+            if not summary_markdown and not summary:
+                return "Plan approval blocked: plan_summary_markdown or plan_summary is required."
+            if not normalized_steps and not checklist:
+                return "Plan approval blocked: steps or execution_checklist is required."
 
             workspace_state.context["last_plan_feedback"] = feedback
+            workspace_state.context["last_plan_file_path"] = plan_path
+
+            if workspace_state.context.get("skip_plan_approvals"):
+                workspace_state.context["plan_approved"] = True
+                return (
+                    "PLAN_APPROVAL_SKIPPED_TRUSTED_MODE\n"
+                    f"Title: {title}\n"
+                    f"Summary: {summary_markdown or summary}\n"
+                    f"Execution checklist: {checklist or json.dumps(normalized_steps, ensure_ascii=False)}\n"
+                    f"Plan file path: {plan_path}\n"
+                    f"Status label: {status}\n"
+                    f"Risky actions: {risks}\n"
+                    "Workspace trusted mode is enabled, so plan approval was skipped. Continue executing the plan."
+                )
 
             # If a reviewer provides edit feedback, require one more approval round.
             # This prevents immediate continuation after edit and enforces explicit
@@ -383,10 +414,13 @@ class ToolFactory:
                 return (
                     "PLAN_EDIT_FEEDBACK_RECORDED\n"
                     f"Title: {title}\n"
-                    f"Summary: {summary}\n"
-                    f"Execution checklist: {checklist}\n"
+                    f"Summary: {summary_markdown or summary}\n"
+                    f"Execution checklist: {checklist or json.dumps(normalized_steps, ensure_ascii=False)}\n"
+                    f"Plan file path: {plan_path}\n"
+                    f"Status label: {status}\n"
                     f"Risky actions: {risks}\n"
                     f"Reviewer feedback: {feedback}\n"
+                    f"Edited draft included: {'yes' if draft_content else 'no'}\n"
                     "Do not execute yet. Revise the plan and call request_plan_approval again for final approval."
                 )
 
@@ -395,8 +429,10 @@ class ToolFactory:
             return (
                 "PLAN_APPROVAL_RECORDED\n"
                 f"Title: {title}\n"
-                f"Summary: {summary}\n"
-                f"Execution checklist: {checklist}\n"
+                f"Summary: {summary_markdown or summary}\n"
+                f"Execution checklist: {checklist or json.dumps(normalized_steps, ensure_ascii=False)}\n"
+                f"Plan file path: {plan_path}\n"
+                f"Status label: {status}\n"
                 f"Risky actions: {risks}\n"
                 "Reviewer feedback: None\n"
                 "Plan decision has been applied. Continue executing the approved plan."

--- a/agent/helpudoc_agent/tools_and_schemas.py
+++ b/agent/helpudoc_agent/tools_and_schemas.py
@@ -10,7 +10,7 @@ import time
 from importlib import import_module
 from io import BytesIO
 from pathlib import Path
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 from uuid import uuid4
 
 from langchain_core.tools import tool
@@ -221,6 +221,7 @@ class ToolFactory:
             "load_skill": self._build_load_skill_tool,
             "request_plan_approval": self._build_request_plan_approval_tool,
             "request_clarification": self._build_request_clarification_tool,
+            "request_human_action": self._build_request_human_action_tool,
         }
 
     def build_tools(self, tool_names: List[str], workspace_state: WorkspaceState) -> List[Tool]:
@@ -486,6 +487,31 @@ class ToolFactory:
                     "description": prompt_description,
                     "step_index": max(0, int(step_index or 0)),
                     "step_count": max(1, int(step_count or 1)),
+                    "actions": [
+                        {
+                            "id": choice["id"],
+                            "label": choice["label"],
+                            "style": "secondary",
+                            "inputMode": "none",
+                            "value": choice["value"],
+                            **({"payload": {"selectedChoiceId": choice["id"]}} if choice.get("id") else {}),
+                        }
+                        for choice in parsed_choices
+                    ]
+                    + (
+                        [
+                            {
+                                "id": "clarification-text",
+                                "label": (submit_label or "Continue").strip() or "Continue",
+                                "style": "primary",
+                                "inputMode": "text",
+                                "placeholder": (placeholder or "").strip(),
+                                "submitLabel": (submit_label or "Continue").strip() or "Continue",
+                            }
+                        ]
+                        if allow_freeform or not parsed_choices
+                        else []
+                    ),
                     "response_spec": {
                         "inputMode": input_mode,
                         "multiple": bool(multi_select),
@@ -506,6 +532,103 @@ class ToolFactory:
             "Use options_json for clickable choices and allow_freeform for typed input."
         )
         return request_clarification
+
+    def _build_request_human_action_tool(self, workspace_state: WorkspaceState) -> Tool:
+        """Pause execution and ask the human to choose from arbitrary actions."""
+
+        @tool
+        def request_human_action(
+            title: str,
+            description: str = "",
+            actions_json: str = "[]",
+            kind: str = "approval",
+            step_index: int = 0,
+            step_count: int = 1,
+            context_json: str = "{}",
+        ) -> str:
+            """Ask the human to choose an action, optionally with scoped text input."""
+            if workspace_state.context.get("tagged_files_only"):
+                return "Tool disabled: tagged files were provided, use rag_query only."
+
+            prompt_title = (title or "").strip()
+            prompt_description = (description or "").strip()
+            interrupt_kind = (kind or "approval").strip().lower()
+            if interrupt_kind not in {"approval", "clarification"}:
+                interrupt_kind = "approval"
+            if not prompt_title:
+                return "Human action request blocked: title is required."
+
+            parsed_actions: List[Dict[str, Any]] = []
+            try:
+                raw_actions = json.loads(actions_json or "[]")
+            except json.JSONDecodeError:
+                raw_actions = []
+
+            if isinstance(raw_actions, list):
+                for index, item in enumerate(raw_actions):
+                    if not isinstance(item, dict):
+                        continue
+                    action_id = str(item.get("id") or f"action-{index + 1}").strip()
+                    label = str(item.get("label") or "").strip()
+                    if not action_id or not label:
+                        continue
+                    style = str(item.get("style") or "secondary").strip().lower()
+                    if style not in {"primary", "secondary", "danger"}:
+                        style = "secondary"
+                    input_mode = str(item.get("inputMode") or "none").strip().lower()
+                    if input_mode not in {"none", "text"}:
+                        input_mode = "none"
+                    action_payload = item.get("payload")
+                    action: Dict[str, Any] = {
+                        "id": action_id,
+                        "label": label,
+                        "style": style,
+                        "inputMode": input_mode,
+                    }
+                    if isinstance(item.get("placeholder"), str) and item["placeholder"].strip():
+                        action["placeholder"] = item["placeholder"].strip()
+                    if isinstance(item.get("submitLabel"), str) and item["submitLabel"].strip():
+                        action["submitLabel"] = item["submitLabel"].strip()
+                    if isinstance(item.get("confirm"), bool):
+                        action["confirm"] = item["confirm"]
+                    if isinstance(item.get("value"), str) and item["value"].strip():
+                        action["value"] = item["value"].strip()
+                    if isinstance(action_payload, dict):
+                        action["payload"] = action_payload
+                    parsed_actions.append(action)
+
+            if not parsed_actions:
+                return "Human action request blocked: provide at least one valid action in actions_json."
+
+            display_payload: Dict[str, Any] = {}
+            try:
+                parsed_context = json.loads(context_json or "{}")
+                if isinstance(parsed_context, dict):
+                    display_payload = parsed_context
+            except json.JSONDecodeError:
+                display_payload = {}
+
+            response = interrupt(
+                {
+                    "kind": interrupt_kind,
+                    "title": prompt_title,
+                    "description": prompt_description,
+                    "step_index": max(0, int(step_index or 0)),
+                    "step_count": max(1, int(step_count or 1)),
+                    "actions": parsed_actions,
+                    "display_payload": display_payload,
+                }
+            )
+            if isinstance(response, dict):
+                return json.dumps(response, ensure_ascii=False)
+            return str(response)
+
+        request_human_action.name = "request_human_action"
+        request_human_action.description = (
+            "Pause execution and ask the human to choose from arbitrary actions. "
+            "Each action can be button-only or require scoped text input."
+        )
+        return request_human_action
 
     def _build_append_to_report_tool(self, workspace_state: WorkspaceState) -> Tool:
         """Append a section file to the stitched proposal inside the workspace."""

--- a/backend/src/api/agent.ts
+++ b/backend/src/api/agent.ts
@@ -159,11 +159,13 @@ export default function(
       mcpServerAllowIds: string[];
       mcpServerDenyIds: string[];
     };
+    skipPlanApprovals?: boolean;
   }): Promise<string | null> => {
     const payload: Record<string, unknown> = {
       sub: input.userId,
       userId: input.userId,
       workspaceId: input.workspaceId,
+      skipPlanApprovals: Boolean(input.skipPlanApprovals),
       ...input.policy,
     };
 
@@ -337,11 +339,13 @@ export default function(
       const user = requireUserContext(req);
       const { persona, prompt, workspaceId, history, forceReset } = runAgentSchema.parse(req.body);
       const policy = await workspaceService.getMcpServerPolicy(workspaceId, user.userId, { requireEdit: true });
+      const settings = await workspaceService.getWorkspaceSettings(workspaceId, user.userId, { requireEdit: true });
       const enrichedPrompt = await injectTaggedFileUrls(prompt, workspaceId, user.userId);
       const authToken = await buildAgentAuthToken({
         userId: user.userId,
         workspaceId,
         policy,
+        skipPlanApprovals: settings.skipPlanApprovals,
       });
       const response = await runAgent(persona, workspaceId, enrichedPrompt, history, { forceReset, authToken: authToken || undefined });
       res.json(response);
@@ -380,11 +384,13 @@ export default function(
       const user = requireUserContext(req);
       const { persona, prompt, workspaceId, history, forceReset } = runAgentSchema.parse(req.body);
       const policy = await workspaceService.getMcpServerPolicy(workspaceId, user.userId, { requireEdit: true });
+      const settings = await workspaceService.getWorkspaceSettings(workspaceId, user.userId, { requireEdit: true });
       const enrichedPrompt = await injectTaggedFileUrls(prompt, workspaceId, user.userId);
       const authToken = await buildAgentAuthToken({
         userId: user.userId,
         workspaceId,
         policy,
+        skipPlanApprovals: settings.skipPlanApprovals,
       });
       streamResponse = await runAgentStream(persona, workspaceId, enrichedPrompt, history, {
         forceReset,
@@ -435,11 +441,13 @@ export default function(
       const { persona, prompt, workspaceId, history, forceReset, turnId } = runAgentSchema.parse(req.body);
       await workspaceService.ensureMembership(workspaceId, user.userId, { requireEdit: true });
       const policy = await workspaceService.getMcpServerPolicy(workspaceId, user.userId, { requireEdit: true });
+      const settings = await workspaceService.getWorkspaceSettings(workspaceId, user.userId, { requireEdit: true });
       const enrichedPrompt = await injectTaggedFileUrls(prompt, workspaceId, user.userId);
       const authToken = await buildAgentAuthToken({
         userId: user.userId,
         workspaceId,
         policy,
+        skipPlanApprovals: settings.skipPlanApprovals,
       });
       const { runId, status } = await startAgentRun({
         persona,
@@ -498,10 +506,12 @@ export default function(
       }
       await workspaceService.ensureMembership(meta.workspaceId, user.userId, { requireEdit: true });
       const policy = await workspaceService.getMcpServerPolicy(meta.workspaceId, user.userId, { requireEdit: true });
+      const settings = await workspaceService.getWorkspaceSettings(meta.workspaceId, user.userId, { requireEdit: true });
       const authToken = await buildAgentAuthToken({
         userId: user.userId,
         workspaceId: meta.workspaceId,
         policy,
+        skipPlanApprovals: settings.skipPlanApprovals,
       });
       if (meta.status !== 'awaiting_approval') {
         return res.status(409).json({ error: 'Run is not awaiting approval' });
@@ -552,10 +562,12 @@ export default function(
       }
       await workspaceService.ensureMembership(meta.workspaceId, user.userId, { requireEdit: true });
       const policy = await workspaceService.getMcpServerPolicy(meta.workspaceId, user.userId, { requireEdit: true });
+      const settings = await workspaceService.getWorkspaceSettings(meta.workspaceId, user.userId, { requireEdit: true });
       const authToken = await buildAgentAuthToken({
         userId: user.userId,
         workspaceId: meta.workspaceId,
         policy,
+        skipPlanApprovals: settings.skipPlanApprovals,
       });
       if (meta.status !== 'awaiting_approval') {
         return res.status(409).json({ error: 'Run is not awaiting input' });
@@ -594,10 +606,12 @@ export default function(
       }
       await workspaceService.ensureMembership(meta.workspaceId, user.userId, { requireEdit: true });
       const policy = await workspaceService.getMcpServerPolicy(meta.workspaceId, user.userId, { requireEdit: true });
+      const settings = await workspaceService.getWorkspaceSettings(meta.workspaceId, user.userId, { requireEdit: true });
       const authToken = await buildAgentAuthToken({
         userId: user.userId,
         workspaceId: meta.workspaceId,
         policy,
+        skipPlanApprovals: settings.skipPlanApprovals,
       });
       if (meta.status !== 'awaiting_approval') {
         return res.status(409).json({ error: 'Run is not awaiting human input' });

--- a/backend/src/api/agent.ts
+++ b/backend/src/api/agent.ts
@@ -18,6 +18,7 @@ import {
   getRunMeta,
   getRunStreamKey,
   resumeAgentRun,
+  resumeAgentRunWithAction,
   resumeAgentRunWithResponse,
   startAgentRun,
 } from '../services/agentRunService';
@@ -118,6 +119,10 @@ export default function(
     message: z.string().optional(),
     selectedChoiceIds: z.array(z.string().min(1)).optional(),
     selectedValues: z.array(z.string()).optional(),
+  });
+  const runActionSchema = z.object({
+    actionId: z.string().min(1),
+    text: z.string().optional(),
   });
 
   const requireUserContext = (req: Request) => {
@@ -492,6 +497,12 @@ export default function(
         return res.status(404).json({ error: 'Run not found' });
       }
       await workspaceService.ensureMembership(meta.workspaceId, user.userId, { requireEdit: true });
+      const policy = await workspaceService.getMcpServerPolicy(meta.workspaceId, user.userId, { requireEdit: true });
+      const authToken = await buildAgentAuthToken({
+        userId: user.userId,
+        workspaceId: meta.workspaceId,
+        policy,
+      });
       if (meta.status !== 'awaiting_approval') {
         return res.status(409).json({ error: 'Run is not awaiting approval' });
       }
@@ -519,7 +530,9 @@ export default function(
             ? { type: 'reject' as const, message: payload.message || 'Rejected by user' }
             : { type: 'approve' as const },
       ];
-      const result = await resumeAgentRun(runId, decisions);
+      const result = await resumeAgentRun(runId, decisions, {
+        authToken: authToken || undefined,
+      });
       res.json(result);
     } catch (error: any) {
       if (error instanceof z.ZodError) {
@@ -538,6 +551,12 @@ export default function(
         return res.status(404).json({ error: 'Run not found' });
       }
       await workspaceService.ensureMembership(meta.workspaceId, user.userId, { requireEdit: true });
+      const policy = await workspaceService.getMcpServerPolicy(meta.workspaceId, user.userId, { requireEdit: true });
+      const authToken = await buildAgentAuthToken({
+        userId: user.userId,
+        workspaceId: meta.workspaceId,
+        policy,
+      });
       if (meta.status !== 'awaiting_approval') {
         return res.status(409).json({ error: 'Run is not awaiting input' });
       }
@@ -553,6 +572,8 @@ export default function(
         message: payload.message,
         selectedChoiceIds: payload.selectedChoiceIds,
         selectedValues: payload.selectedValues,
+      }, {
+        authToken: authToken || undefined,
       });
       res.json(result);
     } catch (error: any) {
@@ -560,6 +581,58 @@ export default function(
         return res.status(400).json({ error: 'Invalid input' });
       }
       handleError(res, error, 'Failed to submit clarification response');
+    }
+  });
+
+  router.post('/runs/:runId/act', async (req, res) => {
+    try {
+      const user = requireUserContext(req);
+      const { runId } = req.params;
+      const meta = await getRunMeta(runId);
+      if (!meta) {
+        return res.status(404).json({ error: 'Run not found' });
+      }
+      await workspaceService.ensureMembership(meta.workspaceId, user.userId, { requireEdit: true });
+      const policy = await workspaceService.getMcpServerPolicy(meta.workspaceId, user.userId, { requireEdit: true });
+      const authToken = await buildAgentAuthToken({
+        userId: user.userId,
+        workspaceId: meta.workspaceId,
+        policy,
+      });
+      if (meta.status !== 'awaiting_approval') {
+        return res.status(409).json({ error: 'Run is not awaiting human input' });
+      }
+      const payload = runActionSchema.parse(req.body);
+      const interruptActions = Array.isArray(meta.pendingInterrupt?.actions) ? meta.pendingInterrupt.actions : [];
+      const action = interruptActions.find((item) => item.id === payload.actionId);
+      if (!action) {
+        return res.status(404).json({ error: `Interrupt action "${payload.actionId}" was not found` });
+      }
+      if (action.inputMode === 'text' && !payload.text?.trim()) {
+        return res.status(400).json({ error: 'This action requires text input' });
+      }
+      const result = await resumeAgentRunWithAction(
+        runId,
+        {
+          action: {
+            id: action.id,
+            ...(typeof action.value === 'string' ? { value: action.value } : {}),
+            ...(action.payload && typeof action.payload === 'object' && !Array.isArray(action.payload)
+              ? { payload: action.payload }
+              : {}),
+            ...(payload.text?.trim() ? { text: payload.text.trim() } : {}),
+          },
+        },
+        {
+          authToken: authToken || undefined,
+        },
+      );
+      res.json(result);
+    } catch (error: any) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: 'Invalid interrupt action payload' });
+      }
+      handleError(res, error, 'Failed to submit interrupt action');
     }
   });
 

--- a/backend/src/api/conversations.ts
+++ b/backend/src/api/conversations.ts
@@ -96,6 +96,17 @@ export default function conversationRoutes(conversationService: ConversationServ
         description: z.string().optional(),
         stepIndex: z.number().int().nonnegative().optional(),
         stepCount: z.number().int().positive().optional(),
+        actions: z.array(z.object({
+          id: z.string(),
+          label: z.string(),
+          style: z.enum(['primary', 'secondary', 'danger']).optional(),
+          inputMode: z.enum(['none', 'text']).optional(),
+          placeholder: z.string().optional(),
+          submitLabel: z.string().optional(),
+          confirm: z.boolean().optional(),
+          value: z.string().optional(),
+          payload: z.record(z.string(), z.unknown()).optional(),
+        }).passthrough()).optional(),
         actionRequests: z.array(z.object({
           name: z.string().optional(),
           args: z.record(z.string(), z.unknown()).optional(),

--- a/backend/src/api/files.ts
+++ b/backend/src/api/files.ts
@@ -14,6 +14,12 @@ export default function(fileService: FileService) {
     version: z.number().int().positive().optional(),
   });
 
+  const createTextFileSchema = z.object({
+    name: z.string().min(1),
+    content: z.string(),
+    mimeType: z.string().min(1).optional(),
+  });
+
   const renameFileSchema = z.object({
     name: z.string().min(1),
     version: z.number().int().positive().optional(),
@@ -114,6 +120,27 @@ export default function(fileService: FileService) {
       }
     },
   );
+
+  router.post('/text', async (req: Request<{ workspaceId: string }>, res: Response) => {
+    try {
+      const { workspaceId } = req.params;
+      const user = requireUserContext(req);
+      const payload = createTextFileSchema.parse(req.body);
+      const created = await fileService.createTextFile(
+        workspaceId,
+        payload.name,
+        payload.content,
+        user.userId,
+        payload.mimeType,
+      );
+      res.status(201).json(created);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: 'Invalid text file payload' });
+      }
+      handleError(res, error, 'Failed to create text file');
+    }
+  });
 
   router.put('/:fileId/content', async (req: Request<{ fileId: string }>, res: Response) => {
     try {

--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -14,6 +14,10 @@ const collaboratorSchema = z.object({
   role: z.enum(['editor', 'viewer']),
 });
 
+const workspaceSettingsSchema = z.object({
+  skipPlanApprovals: z.boolean(),
+});
+
 export default function workspaceRoutes(workspaceService: WorkspaceService, userService: UserService) {
   const router = Router();
 
@@ -63,6 +67,30 @@ export default function workspaceRoutes(workspaceService: WorkspaceService, user
       res.json(workspace);
     } catch (error) {
       handleError(res, error, 'Failed to load workspace');
+    }
+  });
+
+  router.get('/:workspaceId/settings', async (req, res) => {
+    try {
+      const user = requireUserContext(req);
+      const settings = await workspaceService.getWorkspaceSettings(req.params.workspaceId, user.userId);
+      res.json(settings);
+    } catch (error) {
+      handleError(res, error, 'Failed to load workspace settings');
+    }
+  });
+
+  router.patch('/:workspaceId/settings', async (req, res) => {
+    try {
+      const user = requireUserContext(req);
+      const payload = workspaceSettingsSchema.parse(req.body);
+      const settings = await workspaceService.updateWorkspaceSettings(req.params.workspaceId, user.userId, payload);
+      res.json(settings);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: 'Invalid workspace settings payload' });
+      }
+      handleError(res, error, 'Failed to update workspace settings');
     }
   });
 

--- a/backend/src/services/agentRunService.ts
+++ b/backend/src/services/agentRunService.ts
@@ -4,8 +4,10 @@ import { redisClient } from './redisService';
 import {
   runAgentStream,
   resumeAgentStream,
+  resumeAgentActionStream,
   resumeAgentResponseStream,
   type AgentDecision,
+  type AgentInterruptActionResponse,
   type AgentInterruptResponse,
   type AgentHistoryEntry,
 } from './agentService';
@@ -35,6 +37,17 @@ type RunPendingInterrupt = {
   description?: string;
   stepIndex?: number;
   stepCount?: number;
+  actions?: Array<{
+    id: string;
+    label: string;
+    style?: 'primary' | 'secondary' | 'danger';
+    inputMode?: 'none' | 'text';
+    placeholder?: string;
+    submitLabel?: string;
+    confirm?: boolean;
+    value?: string;
+    payload?: Record<string, unknown>;
+  }>;
   actionRequests?: Array<{ name?: string; args?: Record<string, unknown> }>;
   reviewConfigs?: Array<{ action_name?: string; allowed_decisions?: string[] }>;
   responseSpec?: {
@@ -65,12 +78,23 @@ type RunContext = {
   params: StartRunParams;
 };
 
+type PersistedRunContext = {
+  workspaceId: string;
+  persona: string;
+  prompt: string;
+  history?: AgentHistoryEntry[];
+  forceReset?: boolean;
+  turnId?: string;
+};
+
 type ResumePayload =
   | { decisions: AgentDecision[]; response?: never }
-  | { response: AgentInterruptResponse; decisions?: never };
+  | { response: AgentInterruptResponse; decisions?: never }
+  | { action: AgentInterruptActionResponse; decisions?: never; response?: never };
 
 type PersistedRunMeta = Omit<RunMeta, 'pendingInterrupt'> & {
   pendingInterrupt?: string;
+  runContext?: string;
 };
 
 const STREAM_TTL_SECONDS = 60 * 60 * 24; // 24h
@@ -151,6 +175,18 @@ const parsePendingInterrupt = (raw: string | undefined): RunPendingInterrupt | u
       description: typeof payload.description === 'string' ? payload.description : undefined,
       stepIndex: typeof payload.stepIndex === 'number' ? payload.stepIndex : undefined,
       stepCount: typeof payload.stepCount === 'number' ? payload.stepCount : undefined,
+      actions: Array.isArray(payload.actions)
+        ? payload.actions.filter(
+            (
+              item,
+            ): item is NonNullable<RunPendingInterrupt['actions']>[number] =>
+              Boolean(item) &&
+              typeof item === 'object' &&
+              !Array.isArray(item) &&
+              typeof (item as { id?: unknown }).id === 'string' &&
+              typeof (item as { label?: unknown }).label === 'string',
+          )
+        : undefined,
       actionRequests: Array.isArray(payload.actionRequests)
         ? payload.actionRequests.filter(
             (item): item is { name?: string; args?: Record<string, unknown> } =>
@@ -177,6 +213,61 @@ const parsePendingInterrupt = (raw: string | undefined): RunPendingInterrupt | u
   }
 };
 
+const serializeRunContext = (params: StartRunParams): string =>
+  JSON.stringify({
+    workspaceId: params.workspaceId,
+    persona: params.persona,
+    prompt: params.prompt,
+    history: params.history,
+    forceReset: params.forceReset,
+    turnId: params.turnId,
+  } satisfies PersistedRunContext);
+
+const parseRunContext = (raw: string | undefined): RunContext | undefined => {
+  if (!raw || !raw.trim()) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(raw) as PersistedRunContext;
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed) ||
+      typeof parsed.workspaceId !== 'string' ||
+      typeof parsed.persona !== 'string' ||
+      typeof parsed.prompt !== 'string'
+    ) {
+      return undefined;
+    }
+    return {
+      params: {
+        workspaceId: parsed.workspaceId,
+        persona: parsed.persona,
+        prompt: parsed.prompt,
+        history: Array.isArray(parsed.history) ? parsed.history : undefined,
+        forceReset: typeof parsed.forceReset === 'boolean' ? parsed.forceReset : undefined,
+        turnId: typeof parsed.turnId === 'string' ? parsed.turnId : undefined,
+      },
+    };
+  } catch {
+    return undefined;
+  }
+};
+
+const loadRunContext = async (runId: string): Promise<RunContext | undefined> => {
+  const inMemory = runContexts.get(runId);
+  if (inMemory) {
+    return inMemory;
+  }
+  const metaKey = buildMetaKey(runId);
+  const persisted = await redisClient.hGet(metaKey, 'runContext');
+  const parsed = parseRunContext(persisted ?? undefined);
+  if (parsed) {
+    runContexts.set(runId, parsed);
+  }
+  return parsed;
+};
+
 const cleanupRun = (runId: string, upstream?: IncomingMessage) => {
   const controller = runAbortControllers.get(runId);
   if (controller) {
@@ -194,6 +285,7 @@ const markRunFinished = async (runId: string, status: AgentRunStatus, error?: st
     completedAt,
     error,
     pendingInterrupt: '',
+    runContext: '',
   });
   if (status === 'completed' || status === 'failed' || status === 'cancelled') {
     runContexts.delete(runId);
@@ -222,6 +314,7 @@ export async function startAgentRun(params: StartRunParams): Promise<{ runId: st
     createdAt: new Date().toISOString(),
     turnId: params.turnId,
     pendingInterrupt: '',
+    runContext: serializeRunContext(params),
   });
   runContexts.set(runId, { params });
 
@@ -252,6 +345,7 @@ async function runAgentRunWorker(runId: string, params: StartRunParams, resumePa
       hasHistory: Boolean(params.history?.length),
       resumeDecisions: Boolean(resumePayload && 'decisions' in resumePayload && resumePayload.decisions?.length),
       resumeResponse: Boolean(resumePayload && 'response' in resumePayload),
+      resumeAction: Boolean(resumePayload && 'action' in resumePayload && resumePayload.action),
     });
   }
 
@@ -332,6 +426,11 @@ async function runAgentRunWorker(runId: string, params: StartRunParams, resumePa
           signal: controller.signal,
           authToken: params.authToken,
         })
+      : resumePayload && 'action' in resumePayload && resumePayload.action
+      ? await resumeAgentActionStream(params.persona, params.workspaceId, resumePayload.action, {
+          signal: controller.signal,
+          authToken: params.authToken,
+        })
       : await runAgentStream(params.persona, params.workspaceId, params.prompt, params.history, {
           forceReset: params.forceReset,
           signal: controller.signal,
@@ -399,36 +498,63 @@ async function runAgentRunWorker(runId: string, params: StartRunParams, resumePa
 export async function resumeAgentRun(
   runId: string,
   decisions: AgentDecision[],
+  options?: { authToken?: string },
 ): Promise<{ runId: string; status: AgentRunStatus }> {
-  const context = runContexts.get(runId);
+  const context = await loadRunContext(runId);
   if (!context) {
     throw new Error('Run context not found. Start a new run.');
   }
+  const nextParams = options?.authToken ? { ...context.params, authToken: options.authToken } : context.params;
+  runContexts.set(runId, { params: nextParams });
   await persistMeta(runId, {
     status: 'queued',
     startedAt: new Date().toISOString(),
     error: '',
     pendingInterrupt: '',
   });
-  void runAgentRunWorker(runId, context.params, { decisions });
+  void runAgentRunWorker(runId, nextParams, { decisions });
   return { runId, status: 'queued' };
 }
 
 export async function resumeAgentRunWithResponse(
   runId: string,
   response: AgentInterruptResponse,
+  options?: { authToken?: string },
 ): Promise<{ runId: string; status: AgentRunStatus }> {
-  const context = runContexts.get(runId);
+  const context = await loadRunContext(runId);
   if (!context) {
     throw new Error('Run context not found. Start a new run.');
   }
+  const nextParams = options?.authToken ? { ...context.params, authToken: options.authToken } : context.params;
+  runContexts.set(runId, { params: nextParams });
   await persistMeta(runId, {
     status: 'queued',
     startedAt: new Date().toISOString(),
     error: '',
     pendingInterrupt: '',
   });
-  void runAgentRunWorker(runId, context.params, { response });
+  void runAgentRunWorker(runId, nextParams, { response });
+  return { runId, status: 'queued' };
+}
+
+export async function resumeAgentRunWithAction(
+  runId: string,
+  action: AgentInterruptActionResponse,
+  options?: { authToken?: string },
+): Promise<{ runId: string; status: AgentRunStatus }> {
+  const context = await loadRunContext(runId);
+  if (!context) {
+    throw new Error('Run context not found. Start a new run.');
+  }
+  const nextParams = options?.authToken ? { ...context.params, authToken: options.authToken } : context.params;
+  runContexts.set(runId, { params: nextParams });
+  await persistMeta(runId, {
+    status: 'queued',
+    startedAt: new Date().toISOString(),
+    error: '',
+    pendingInterrupt: '',
+  });
+  void runAgentRunWorker(runId, nextParams, { action });
   return { runId, status: 'queued' };
 }
 

--- a/backend/src/services/agentService.ts
+++ b/backend/src/services/agentService.ts
@@ -35,6 +35,17 @@ export type AgentInterruptResponse = {
   selectedValues?: string[];
 };
 
+export type AgentInterruptAction = {
+  id: string;
+  value?: string;
+  payload?: Record<string, unknown>;
+  text?: string;
+};
+
+export type AgentInterruptActionResponse = {
+  action: AgentInterruptAction;
+};
+
 type RunAgentOptions = {
   forceReset?: boolean;
   signal?: AbortSignal;
@@ -128,6 +139,27 @@ export async function resumeAgentResponseStream(
   return client.post(
     `/agents/${persona}/workspace/${workspaceId}/chat/stream/respond`,
     response,
+    {
+      responseType: "stream",
+      signal: options?.signal,
+      headers,
+    }
+  );
+}
+
+export async function resumeAgentActionStream(
+  persona: string,
+  workspaceId: string,
+  actionResponse: AgentInterruptActionResponse,
+  options?: RunAgentOptions
+): Promise<AxiosResponse<IncomingMessage>> {
+  const headers: Record<string, string> = {};
+  if (options?.authToken) {
+    headers.Authorization = `Bearer ${options.authToken}`;
+  }
+  return client.post(
+    `/agents/${persona}/workspace/${workspaceId}/chat/stream/act`,
+    actionResponse,
     {
       responseType: "stream",
       signal: options?.signal,

--- a/backend/src/services/databaseService.ts
+++ b/backend/src/services/databaseService.ts
@@ -179,6 +179,7 @@ export class DatabaseService {
         table.string('slug').notNullable().unique();
         table.uuid('ownerId').notNullable().references('id').inTable('users').onDelete('CASCADE');
         table.uuid('lastModifiedBy').references('id').inTable('users');
+        table.boolean('skipPlanApprovals').notNullable().defaultTo(false);
         table.timestamp('createdAt').notNullable().defaultTo(this.db.fn.now());
         table.timestamp('updatedAt').notNullable().defaultTo(this.db.fn.now());
       });
@@ -187,6 +188,7 @@ export class DatabaseService {
       await this.ensureColumn('workspaces', 'slug', (table) => table.string('slug').notNullable().defaultTo(this.db.raw('md5(random()::text)')));
       await this.ensureColumn('workspaces', 'ownerId', (table) => table.uuid('ownerId'));
       await this.ensureColumn('workspaces', 'lastModifiedBy', (table) => table.uuid('lastModifiedBy'));
+      await this.ensureColumn('workspaces', 'skipPlanApprovals', (table) => table.boolean('skipPlanApprovals').notNullable().defaultTo(false));
     }
   }
 

--- a/backend/src/services/fileService.ts
+++ b/backend/src/services/fileService.ts
@@ -245,6 +245,23 @@ export class FileService {
     return newFile;
   }
 
+  async createTextFile(
+    workspaceId: string,
+    fileName: string,
+    content: string,
+    userId: string,
+    mimeType = 'text/markdown',
+  ) {
+    return this.createFile(
+      workspaceId,
+      fileName,
+      Buffer.from(content, 'utf-8'),
+      mimeType,
+      userId,
+      { forceLocal: true },
+    );
+  }
+
   async getFileContent(fileId: number, userId: string) {
     const file = await this.db('files').where({ id: fileId }).first();
     if (!file) {

--- a/backend/src/services/workspaceService.ts
+++ b/backend/src/services/workspaceService.ts
@@ -20,6 +20,7 @@ export interface WorkspaceRecord {
   slug: string;
   ownerId: string;
   lastModifiedBy?: string | null;
+  skipPlanApprovals?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -80,6 +81,7 @@ export class WorkspaceService {
       slug: row.slug,
       ownerId: row.ownerId,
       lastModifiedBy: row.lastModifiedBy,
+      skipPlanApprovals: Boolean(row.skipPlanApprovals),
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
       role: row.role as WorkspaceRole,
@@ -97,6 +99,7 @@ export class WorkspaceService {
         slug,
         ownerId: user.userId,
         lastModifiedBy: user.userId,
+        skipPlanApprovals: false,
       })
       .returning('*');
 
@@ -116,6 +119,36 @@ export class WorkspaceService {
     return this.ensureMembership(workspaceId, userId);
   }
 
+  async getWorkspaceSettings(
+    workspaceId: string,
+    userId: string,
+    options: MembershipCheckOptions = {},
+  ): Promise<{ skipPlanApprovals: boolean }> {
+    const { workspace } = await this.ensureMembership(workspaceId, userId, options);
+    return {
+      skipPlanApprovals: Boolean(workspace.skipPlanApprovals),
+    };
+  }
+
+  async updateWorkspaceSettings(
+    workspaceId: string,
+    userId: string,
+    settings: { skipPlanApprovals?: boolean },
+  ): Promise<{ skipPlanApprovals: boolean }> {
+    await this.ensureMembership(workspaceId, userId, { requireEdit: true });
+    const updates: Record<string, unknown> = {
+      updatedAt: this.db.fn.now(),
+      lastModifiedBy: userId,
+    };
+    if (typeof settings.skipPlanApprovals === 'boolean') {
+      updates.skipPlanApprovals = settings.skipPlanApprovals;
+    }
+    await this.db<WorkspaceRecord>('workspaces')
+      .where({ id: workspaceId })
+      .update(updates);
+    return this.getWorkspaceSettings(workspaceId, userId, { requireEdit: true });
+  }
+
   async ensureMembership(
     workspaceId: string,
     userId: string,
@@ -125,6 +158,10 @@ export class WorkspaceService {
     if (!workspace) {
       throw new NotFoundError('Workspace not found');
     }
+    const normalizedWorkspace: WorkspaceRecord = {
+      ...workspace,
+      skipPlanApprovals: Boolean(workspace.skipPlanApprovals),
+    };
 
     const membership = await this.db<WorkspaceMembershipRecord>('workspace_members')
       .where({ workspaceId, userId })
@@ -143,7 +180,7 @@ export class WorkspaceService {
       throw new AccessDeniedError('Workspace is read-only for this user');
     }
 
-    return { workspace, membership: normalizedMembership };
+    return { workspace: normalizedWorkspace, membership: normalizedMembership };
   }
 
   async getMcpServerPolicy(

--- a/docs/hitl-decision-debug-note.md
+++ b/docs/hitl-decision-debug-note.md
@@ -1,0 +1,37 @@
+# HITL Decision Debug Note
+
+## Summary
+
+Observed against `https://www.lc-demo.com` in the live `research_3` workspace after Google sign-in with a real browser session.
+
+## Confirmed Behaviors
+
+- Google login works and returns to the app.
+- Workspace selection in `research_3` succeeds in the live UI.
+- The approval card renders with `Approve`, `Edit`, and `Reject`.
+- Clarification-style prompting is visible in the chat area, but approval actions still drive the active blocked flow.
+
+## Observed Failures
+
+- `Edit` opens the edit state, but `Save Changes` fails with `Failed to submit run decision`.
+- `Reject` opens the confirmation state, but `Confirm Rejection` fails with `Failed to submit run decision`.
+- `Approve` also fails to clear the approval card and does not cleanly advance the run.
+- Edit feedback can appear as a normal chat message while the approval card remains open.
+- A revised approval card can appear underneath the stale approval state, proving frontend run/interruption desync.
+
+## Likely Root Causes
+
+- Paused-run resume depended on in-memory backend context (`runContexts`), so approval decisions failed after backend restart while Redis still preserved the pending interrupt.
+- Resume auth depended on a short-lived agent JWT, so delayed approval actions were vulnerable to token expiry.
+- Approval bubble state and decision errors were not scoped tightly enough to the interrupt card, which made failed actions look like normal chat/system flow.
+
+## Playwright Artifacts
+
+- `output/playwright/hitl-edit-test.json`
+- `output/playwright/hitl-edit-result.json`
+- `output/playwright/hitl-edit-save-changes.json`
+- `output/playwright/hitl-reject-test.json`
+- `output/playwright/hitl-reject-confirm.json`
+- `output/playwright/hitl-approve-test.json`
+- `output/playwright/lc-demo-google-live-final-report.json`
+

--- a/frontend/src/components/CollapsibleDrawer.tsx
+++ b/frontend/src/components/CollapsibleDrawer.tsx
@@ -19,6 +19,8 @@ interface CollapsibleDrawerProps {
   colorMode: PaletteMode;
   onToggleColorMode: () => void;
   onSignOut?: () => void;
+  onToggleSkipPlanApprovals?: (checked: boolean) => void;
+  workspaceSettingsBusy?: boolean;
 }
 
 const drawerWidth = 280;
@@ -37,6 +39,8 @@ const CollapsibleDrawer: React.FC<CollapsibleDrawerProps> = ({
   colorMode,
   onToggleColorMode,
   onSignOut,
+  onToggleSkipPlanApprovals,
+  workspaceSettingsBusy = false,
 }) => {
   const handleOpenSettingsClick = () => {
     handleDrawerClose();
@@ -161,6 +165,40 @@ const CollapsibleDrawer: React.FC<CollapsibleDrawerProps> = ({
             >
               Agent Settings
             </Button>
+            {selectedWorkspace ? (
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  p: 1.5,
+                  borderRadius: 2,
+                  border: (theme) => `1px solid ${theme.palette.divider}`,
+                  backgroundColor: (theme) =>
+                    theme.palette.mode === 'light'
+                      ? 'rgba(15, 23, 42, 0.03)'
+                      : 'rgba(148, 163, 184, 0.08)',
+                }}
+              >
+                <Box sx={{ pr: 1.5 }}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+                    Plan approvals
+                  </Typography>
+                  <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.2 }}>
+                    {selectedWorkspace.skipPlanApprovals
+                      ? 'Trusted mode is on for this workspace.'
+                      : 'Review research plans before they run.'}
+                  </Typography>
+                </Box>
+                <Switch
+                  size="small"
+                  checked={Boolean(selectedWorkspace.skipPlanApprovals)}
+                  disabled={!onToggleSkipPlanApprovals || workspaceSettingsBusy}
+                  onChange={(event) => onToggleSkipPlanApprovals?.(event.target.checked)}
+                  inputProps={{ 'aria-label': 'Toggle workspace plan approvals' }}
+                />
+              </Box>
+            ) : null}
             <Typography variant="body2" sx={{ color: 'text.secondary', mt: 1 }}>
               Manage skills and tools.
             </Typography>

--- a/frontend/src/components/CollapsibleDrawer.tsx
+++ b/frontend/src/components/CollapsibleDrawer.tsx
@@ -63,8 +63,18 @@ const CollapsibleDrawer: React.FC<CollapsibleDrawerProps> = ({
       anchor="left"
       open={open}
     >
-      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', p: 2.5, gap: 2 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          minHeight: 0,
+          overflow: 'hidden',
+          p: 2.5,
+          gap: 2,
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
           <Typography variant="h6" sx={{ fontWeight: 600 }}>
             Workspaces
           </Typography>
@@ -77,7 +87,7 @@ const CollapsibleDrawer: React.FC<CollapsibleDrawerProps> = ({
           </IconButton>
         </Box>
 
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, flexShrink: 0 }}>
           <TextField
             placeholder="New workspace"
             variant="outlined"
@@ -104,8 +114,25 @@ const CollapsibleDrawer: React.FC<CollapsibleDrawerProps> = ({
           </Button>
         </Box>
 
-        <Box sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
-          <Box sx={{ flexGrow: 1, overflowY: 'auto', pr: 1 }}>
+        <Box
+          sx={{
+            flex: '1 1 0%',
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+            overflow: 'hidden',
+          }}
+        >
+          <Box
+            sx={{
+              flex: '1 1 auto',
+              minHeight: 0,
+              overflowY: 'auto',
+              overflowX: 'hidden',
+              pr: 1,
+              pb: 1,
+            }}
+          >
             <WorkspaceList
               workspaces={workspaces}
               selectedWorkspace={selectedWorkspace}
@@ -115,6 +142,7 @@ const CollapsibleDrawer: React.FC<CollapsibleDrawerProps> = ({
           </Box>
           <Box
             sx={{
+              flexShrink: 0,
               borderTop: (theme) => `1px solid ${theme.palette.divider}`,
               pt: 2,
               mt: 2,

--- a/frontend/src/components/FileEditor.tsx
+++ b/frontend/src/components/FileEditor.tsx
@@ -117,6 +117,7 @@ const FileEditor: React.FC<FileEditorProps> = ({
 }) => {
   const fileId = file?.id ? String(file.id) : null;
   const fileName = file?.name ?? '';
+  const isDraftFile = Boolean(fileId && fileId.startsWith('draft:'));
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const mdxEditorRef = useRef<MDXEditorMethods | null>(null);
   const collabSessionRef = useRef<ReturnType<typeof createCollabSession> | null>(null);
@@ -294,7 +295,7 @@ const FileEditor: React.FC<FileEditorProps> = ({
   }, [fileContent]);
 
   useEffect(() => {
-    if (!fileId) {
+    if (!fileId || isDraftFile) {
       setCollabReady(false);
       setPresenceUsers([]);
       setConnectionStatus('disconnected');
@@ -380,11 +381,11 @@ const FileEditor: React.FC<FileEditorProps> = ({
       setPresenceUsers([]);
       setConnectionStatus('disconnected');
     };
-  }, [fileId, fileName, workspaceId, onContentChange, bindMonaco, ensurePresenceStyles]);
+  }, [fileId, fileName, isDraftFile, workspaceId, onContentChange, bindMonaco, ensurePresenceStyles]);
 
   useEffect(() => {
     const session = collabSessionRef.current;
-    if (!session || !fileId || hasSeededRef.current) return;
+    if (!session || !fileId || isDraftFile || hasSeededRef.current) return;
 
     if (session.yText.length > 0) {
       hasSeededRef.current = true;
@@ -397,7 +398,7 @@ const FileEditor: React.FC<FileEditorProps> = ({
       session.yText.insert(0, fileContent);
     }, syncOriginRef.current);
     hasSeededRef.current = true;
-  }, [fileContent, fileId]);
+  }, [fileContent, fileId, isDraftFile]);
 
   if (!file) {
     return null;

--- a/frontend/src/components/FileEditor.tsx
+++ b/frontend/src/components/FileEditor.tsx
@@ -1,19 +1,29 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Editor, { type OnMount } from '@monaco-editor/react';
-import type { File } from '../types';
+import type { File as WorkspaceFile } from '../types';
 import { editor } from 'monaco-editor';
 import { Eye, EyeOff } from 'lucide-react';
 import {
   MDXEditor,
+  type CodeBlockEditorDescriptor,
   type MDXEditorMethods,
+  useCodeBlockEditorContext,
   headingsPlugin,
+  imagePlugin,
+  linkDialogPlugin,
+  linkPlugin,
   listsPlugin,
+  markdownShortcutPlugin,
   quotePlugin,
+  tablePlugin,
   thematicBreakPlugin,
   toolbarPlugin,
+  codeBlockPlugin,
+  codeMirrorPlugin,
   UndoRedo,
   BoldItalicUnderlineToggles,
   BlockTypeSelect,
+  InsertCodeBlock,
   CodeToggle,
   CreateLink,
   InsertImage,
@@ -25,6 +35,8 @@ import '@mdxeditor/editor/style.css';
 import { MonacoBinding } from 'y-monaco';
 import { createCollabSession } from '../services/collabClient';
 import { getAuthUser } from '../auth/authStore';
+import { createFile } from '../services/fileApi';
+import { MermaidDiagram, useMermaidColorMode } from './markdown/MarkdownShared';
 
 const COLLAB_COLORS = [
   '#0ea5e9',
@@ -101,12 +113,106 @@ const getLanguage = (fileName: string) => {
 };
 
 interface FileEditorProps {
-  file: File | null;
+  file: WorkspaceFile | null;
   fileContent: string;
   onContentChange: (content: string) => void;
   workspaceId: string;
   colorMode: 'light' | 'dark';
 }
+
+const CODE_BLOCK_LANGUAGES: Record<string, string> = {
+  '': 'Plain text',
+  js: 'JavaScript',
+  ts: 'TypeScript',
+  jsx: 'JSX',
+  tsx: 'TSX',
+  json: 'JSON',
+  css: 'CSS',
+  html: 'HTML',
+  md: 'Markdown',
+  bash: 'Bash',
+  shell: 'Shell',
+  python: 'Python',
+  sql: 'SQL',
+  yaml: 'YAML',
+  mermaid: 'Mermaid',
+};
+
+const MermaidCodeBlockEditor = ({
+  code,
+  focusEmitter,
+}: {
+  code: string;
+  focusEmitter: { subscribe: (cb: () => void) => void };
+}) => {
+  const { lexicalNode, parentEditor, setCode } = useCodeBlockEditorContext();
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [draft, setDraft] = useState(code);
+  const mermaidColorMode = useMermaidColorMode();
+
+  useEffect(() => {
+    setDraft(code);
+  }, [code]);
+
+  useEffect(() => {
+    focusEmitter.subscribe(() => {
+      textareaRef.current?.focus();
+    });
+  }, [focusEmitter]);
+
+  return (
+    <div className="helpudoc-mermaid-editor not-prose my-4 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <div className="flex items-center justify-between border-b border-slate-200 bg-slate-50 px-4 py-2">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Mermaid</p>
+          <p className="text-xs text-slate-500">Edit the diagram source and preview it live.</p>
+        </div>
+        <button
+          type="button"
+          className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-600 hover:bg-slate-100"
+          onClick={() => {
+            parentEditor.update(() => {
+              lexicalNode.remove();
+            });
+          }}
+        >
+          Remove
+        </button>
+      </div>
+      <div className="grid gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <label className="flex min-h-[260px] flex-col gap-2">
+          <span className="text-xs font-medium text-slate-600">Source</span>
+          <textarea
+            ref={textareaRef}
+            value={draft}
+            onChange={(event) => {
+              const nextValue = event.target.value;
+              setDraft(nextValue);
+              setCode(nextValue);
+            }}
+            spellCheck={false}
+            className="min-h-[240px] w-full resize-y rounded-xl border border-slate-200 bg-slate-950 p-4 font-mono text-sm leading-relaxed text-slate-100 focus:border-blue-400 focus:outline-none"
+          />
+        </label>
+        <div className="flex min-h-[260px] flex-col gap-2">
+          <span className="text-xs font-medium text-slate-600">Preview</span>
+          <MermaidDiagram
+            chart={draft}
+            colorMode={mermaidColorMode}
+            className={`mermaid-container h-full min-h-[240px] overflow-auto rounded-xl border p-4 ${mermaidColorMode === 'dark' ? 'border-slate-700 bg-slate-950' : 'border-slate-200 bg-white'}`}
+            fallbackClassName="h-full min-h-[240px]"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const mermaidCodeBlockDescriptor: CodeBlockEditorDescriptor = {
+  priority: 100,
+  match: (language) => language === 'mermaid',
+  Editor: MermaidCodeBlockEditor,
+};
 
 const FileEditor: React.FC<FileEditorProps> = ({
   file,
@@ -132,8 +238,57 @@ const FileEditor: React.FC<FileEditorProps> = ({
   const [connectionStatus, setConnectionStatus] = useState('connecting');
   const [presenceUsers, setPresenceUsers] = useState<Array<{ clientId: number; name: string; color: string }>>([]);
   const [isRawView, setIsRawView] = useState(false);
+  const [mdxError, setMdxError] = useState<string | null>(null);
   const isDarkMode = colorMode === 'dark';
   const monacoTheme = isDarkMode ? 'helpudoc-nord' : 'vs';
+
+  const handleImageUpload = useCallback(async (image: File) => {
+    const created = await createFile(workspaceId, image);
+    if (!created?.publicUrl) {
+      throw new Error('Image upload did not return a public URL.');
+    }
+    return created.publicUrl;
+  }, [workspaceId]);
+
+  const mdxPlugins = useMemo(
+    () => [
+      headingsPlugin(),
+      listsPlugin(),
+      quotePlugin(),
+      thematicBreakPlugin(),
+      linkPlugin(),
+      linkDialogPlugin(),
+      tablePlugin(),
+      imagePlugin({ imageUploadHandler: handleImageUpload }),
+      codeBlockPlugin({
+        codeBlockEditorDescriptors: [mermaidCodeBlockDescriptor],
+      }),
+      codeMirrorPlugin({
+        codeBlockLanguages: CODE_BLOCK_LANGUAGES,
+      }),
+      markdownShortcutPlugin(),
+      toolbarPlugin({
+        toolbarContents: () => (
+          <>
+            <UndoRedo />
+            <Separator />
+            <BoldItalicUnderlineToggles />
+            <CodeToggle />
+            <Separator />
+            <ListsToggle />
+            <Separator />
+            <BlockTypeSelect />
+            <Separator />
+            <CreateLink />
+            <InsertImage />
+            <InsertTable />
+            <InsertCodeBlock />
+          </>
+        ),
+      }),
+    ],
+    [handleImageUpload]
+  );
 
   useEffect(() => {
     if (isDarkMode) {
@@ -293,6 +448,10 @@ const FileEditor: React.FC<FileEditorProps> = ({
   useEffect(() => {
     lastContentRef.current = fileContent;
   }, [fileContent]);
+
+  useEffect(() => {
+    setMdxError(null);
+  }, [fileId, isRawView]);
 
   useEffect(() => {
     if (!fileId || isDraftFile) {
@@ -479,7 +638,7 @@ const FileEditor: React.FC<FileEditorProps> = ({
       )}
       <div className="flex-grow overflow-auto">
         {isMarkdown ? (
-          <div className="mdxeditor-root h-full overflow-y-auto flex flex-col" style={{ maxHeight: 'calc(100vh - 200px)' }}>
+          <div className="helpudoc-mdxeditor-shell h-full overflow-y-auto flex flex-col" style={{ maxHeight: 'calc(100vh - 200px)' }}>
             {/* Raw/Rendered Toggle Toolbar */}
             <div className="flex items-center justify-between px-3 py-2 border-b border-gray-200 bg-gray-50">
               <span className="text-xs font-medium text-gray-500">
@@ -522,39 +681,29 @@ const FileEditor: React.FC<FileEditorProps> = ({
                 spellCheck={false}
               />
             ) : (
-              <MDXEditor
-                ref={mdxEditorRef}
-                markdown={fileContent}
-                onChange={(value) => {
-                  if (isApplyingRemoteRef.current) return;
-                  applyTextUpdate(value);
-                }}
-                plugins={[
-                  headingsPlugin(),
-                  listsPlugin(),
-                  quotePlugin(),
-                  thematicBreakPlugin(),
-                  toolbarPlugin({
-                    toolbarContents: () => (
-                      <>
-                        <UndoRedo />
-                        <Separator />
-                        <BoldItalicUnderlineToggles />
-                        <Separator />
-                        <ListsToggle />
-                        <Separator />
-                        <BlockTypeSelect />
-                        <Separator />
-                        <CreateLink />
-                        <InsertImage />
-                        <InsertTable />
-                        <Separator />
-                        <CodeToggle />
-                      </>
-                    ),
-                  }),
-                ]}
-              />
+              <>
+                {mdxError && (
+                  <div className="border-b border-rose-200 bg-rose-50 px-4 py-2 text-sm text-rose-700">
+                    {mdxError}
+                  </div>
+                )}
+                <MDXEditor
+                  ref={mdxEditorRef}
+                  markdown={fileContent}
+                  className="mdxeditor helpudoc-mdxeditor flex-1"
+                  contentEditableClassName="prose prose-slate max-w-none helpudoc-markdown helpudoc-markdown-editor mdxeditor-root-contenteditable"
+                  onChange={(value) => {
+                    if (isApplyingRemoteRef.current) return;
+                    setMdxError(null);
+                    applyTextUpdate(value);
+                  }}
+                  onError={({ error, source }) => {
+                    console.error('MDXEditor markdown processing error:', { error, source });
+                    setMdxError(error);
+                  }}
+                  plugins={mdxPlugins}
+                />
+              </>
             )}
           </div>
         ) : (

--- a/frontend/src/components/FileRenderer.tsx
+++ b/frontend/src/components/FileRenderer.tsx
@@ -5,150 +5,24 @@ import remarkGfm from 'remark-gfm';
 import Papa from 'papaparse';
 import PlotlyChart, { type PlotlySpec } from './PlotlyChart';
 import type { File } from '../types';
+import {
+  configureMermaid,
+  createMarkdownComponents,
+  useMermaidColorMode,
+} from './markdown/MarkdownShared';
 
 interface FileRendererProps {
   file: File | null;
   fileContent: string;
   disableInternalScroll?: boolean;
+  workspaceId?: string;
 }
-
-type MermaidColorMode = 'light' | 'dark';
-
-const getColorMode = (): MermaidColorMode => {
-  if (typeof document === 'undefined') {
-    return 'light';
-  }
-  const mode = document.documentElement.getAttribute('data-theme');
-  if (mode === 'dark' || mode === 'light') {
-    return mode;
-  }
-  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-};
-
-const configureMermaid = (mode: MermaidColorMode) => {
-  mermaid.initialize({
-    startOnLoad: false,
-    securityLevel: 'loose',
-    theme: 'base',
-    themeVariables: mode === 'dark'
-      ? {
-          background: '#0f172a',
-          primaryColor: '#818cf8',
-          primaryBorderColor: '#6366f1',
-          primaryTextColor: '#e2e8f0',
-          secondaryColor: '#1e293b',
-          secondaryBorderColor: '#334155',
-          secondaryTextColor: '#cbd5e1',
-          tertiaryColor: '#111827',
-          tertiaryBorderColor: '#374151',
-          tertiaryTextColor: '#cbd5e1',
-          lineColor: '#94a3b8',
-          textColor: '#e2e8f0',
-          mainBkg: '#0b1220',
-          edgeLabelBackground: '#0b1220',
-          actorBorder: '#6366f1',
-          actorBkg: '#1e293b',
-          actorTextColor: '#e2e8f0',
-          labelBoxBkgColor: '#1e293b',
-          labelBoxBorderColor: '#334155',
-          gridColor: '#334155',
-          section0: '#1e293b',
-          section1: '#1f2937',
-          section2: '#0f172a',
-          sectionBkgColor: '#111827',
-          cScale0: '#818cf8',
-          cScale1: '#60a5fa',
-          cScale2: '#34d399',
-        }
-      : {
-          background: '#ffffff',
-          primaryColor: '#4f46e5',
-          primaryBorderColor: '#3730a3',
-          primaryTextColor: '#0f172a',
-          secondaryColor: '#dbeafe',
-          secondaryBorderColor: '#93c5fd',
-          secondaryTextColor: '#0f172a',
-          tertiaryColor: '#eef2ff',
-          tertiaryBorderColor: '#a5b4fc',
-          tertiaryTextColor: '#0f172a',
-          lineColor: '#334155',
-          textColor: '#0f172a',
-          mainBkg: '#ffffff',
-          edgeLabelBackground: '#f8fafc',
-          actorBorder: '#3730a3',
-          actorBkg: '#c7d2fe',
-          actorTextColor: '#0f172a',
-          labelBoxBkgColor: '#f8fafc',
-          labelBoxBorderColor: '#94a3b8',
-          gridColor: '#cbd5e1',
-          section0: '#e0e7ff',
-          section1: '#f1f5f9',
-          section2: '#e2e8f0',
-          sectionBkgColor: '#f8fafc',
-          cScale0: '#3730a3',
-          cScale1: '#1d4ed8',
-          cScale2: '#0f766e',
-        },
-    fontFamily: 'Inter, "Segoe UI", Arial, sans-serif',
-  });
-};
-
-const MermaidDiagram: React.FC<{ chart: string; colorMode: MermaidColorMode }> = ({ chart, colorMode }) => {
-  const diagramRef = useRef<HTMLDivElement>(null);
-  const idRef = useRef(`mermaid-md-${Math.random().toString(36).slice(2, 11)}`);
-  const [hasError, setHasError] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const renderDiagram = async () => {
-      if (!diagramRef.current) {
-        return;
-      }
-      try {
-        setHasError(false);
-        diagramRef.current.innerHTML = '';
-        configureMermaid(colorMode);
-        // Validate syntax first to avoid mermaid's inline error SVG
-        mermaid.parse(chart);
-        const renderId = `${idRef.current}-${Date.now()}`;
-        const { svg } = await mermaid.render(renderId, chart);
-        if (!cancelled && diagramRef.current) {
-          diagramRef.current.innerHTML = svg;
-        }
-      } catch (error) {
-        console.error('Mermaid markdown rendering error:', error);
-        if (!cancelled && diagramRef.current) {
-          setHasError(true);
-          diagramRef.current.textContent = chart;
-        }
-      }
-    };
-
-    renderDiagram();
-    return () => {
-      cancelled = true;
-    };
-  }, [chart, colorMode]);
-
-  return (
-    <div
-      ref={diagramRef}
-      className={`mermaid-container my-4 overflow-auto rounded-xl border p-4 ${colorMode === 'dark' ? 'border-slate-700 bg-slate-950' : 'border-gray-200 bg-white'}`}
-    >
-      {hasError && (
-        <p className="mb-2 text-sm text-red-600">
-          Unable to render diagram, showing source instead.
-        </p>
-      )}
-    </div>
-  );
-};
 
 const FileRenderer: React.FC<FileRendererProps> = ({
   file,
   fileContent,
   disableInternalScroll = false,
+  workspaceId,
 }) => {
   const mermaidRef = useRef<HTMLDivElement>(null);
   const mermaidIdRef = useRef(`mermaid-graph-${Math.random().toString(36).slice(2, 11)}`);
@@ -156,21 +30,7 @@ const FileRenderer: React.FC<FileRendererProps> = ({
   const [mermaidError, setMermaidError] = useState<string | null>(null);
   const [copyStatus, setCopyStatus] = useState<string | null>(null);
   const [copiedUrl, setCopiedUrl] = useState(false);
-  const [colorMode, setColorMode] = useState<MermaidColorMode>(() => getColorMode());
-
-  useEffect(() => {
-    if (typeof document === 'undefined') {
-      return undefined;
-    }
-    const root = document.documentElement;
-    const observer = new MutationObserver(() => {
-      setColorMode(getColorMode());
-    });
-    observer.observe(root, { attributes: true, attributeFilter: ['data-theme'] });
-    return () => {
-      observer.disconnect();
-    };
-  }, []);
+  const colorMode = useMermaidColorMode();
 
   useEffect(() => {
     if (!copyStatus) return;
@@ -235,6 +95,15 @@ const FileRenderer: React.FC<FileRendererProps> = ({
       cancelled = true;
     };
   }, [colorMode, fileContent, isMermaidFile]);
+
+  const markdownComponents = useMemo(
+    () => createMarkdownComponents({
+      workspaceId,
+      colorMode,
+      paragraphClassName: 'mb-4 last:mb-0',
+    }),
+    [workspaceId, colorMode]
+  );
 
   if (!file) {
     return (
@@ -301,77 +170,8 @@ const FileRenderer: React.FC<FileRendererProps> = ({
       ].join(' ');
 
       return (
-        <div className={markdownContainerClassName}>
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            components={{
-              p: ({ children }) => <div className="mb-4 last:mb-0">{children}</div>,
-              img: (props) => (
-                <img
-                  className="max-w-full h-auto rounded-lg shadow-md"
-                  loading="lazy"
-                  {...props}
-                  src={props.src || undefined}
-                />
-              ),
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              code: ({ inline, className, children, ...props }: any) => {
-                const language = /language-(\w+)/.exec(className || '');
-                const codeContent = (
-                  Array.isArray(children) ? children.join('') : String(children ?? '')
-                ).replace(/\n$/, '');
-                const isInlineLike =
-                  inline ||
-                  (!language?.[1] && !codeContent.includes('\n'));
-
-                if (!inline && language?.[1] === 'mermaid') {
-                  return <MermaidDiagram chart={codeContent} colorMode={colorMode} />;
-                }
-
-                if (!inline && language?.[1] === 'plotly') {
-                  try {
-                    const spec = JSON.parse(codeContent) as PlotlySpec;
-                    if (!spec || typeof spec !== 'object') {
-                      throw new Error('Plotly spec must be a JSON object.');
-                    }
-                    if (!Array.isArray(spec.data)) {
-                      throw new Error('Plotly spec must include a top-level "data" array.');
-                    }
-                    return (
-                      <div className="my-4 overflow-hidden rounded-xl border border-gray-200 bg-white p-2">
-                        <PlotlyChart spec={spec} minHeight={360} />
-                      </div>
-                    );
-                  } catch (error) {
-                    return (
-                      <pre className="my-4 overflow-x-auto rounded-xl bg-red-50 p-4 text-sm text-red-700">
-                        Invalid Plotly JSON: {error instanceof Error ? error.message : 'Unknown error'}
-                      </pre>
-                    );
-                  }
-                }
-
-                if (isInlineLike) {
-                  return (
-                    <code
-                      className={`inline-code rounded-md px-1.5 py-0.5 font-mono text-xs ${className || ''}`}
-                      {...props}
-                    >
-                      {children}
-                    </code>
-                  );
-                }
-
-                return (
-                  <pre className="my-4 overflow-x-auto rounded-xl bg-gray-900 p-4 text-sm text-gray-100">
-                    <code className={`font-mono ${className || ''}`} {...props}>
-                      {children}
-                    </code>
-                  </pre>
-                );
-              },
-            }}
-          >
+        <div className={`${markdownContainerClassName} helpudoc-markdown`}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
             {fileContent}
           </ReactMarkdown>
         </div>

--- a/frontend/src/components/UIBlockRenderer.tsx
+++ b/frontend/src/components/UIBlockRenderer.tsx
@@ -16,6 +16,7 @@ interface UIBlockRendererProps {
   blocks: UIBlock[];
   className?: string;
   emptyState?: React.ReactNode;
+  workspaceId?: string;
 }
 
 const createVirtualFile = (name: string, id?: BlockId): File => ({
@@ -26,7 +27,7 @@ const createVirtualFile = (name: string, id?: BlockId): File => ({
 const getBlockKey = (block: UIBlock, index: number) =>
   block.id ? String(block.id) : `${block.kind}-${index}`;
 
-const UIBlockRenderer: React.FC<UIBlockRendererProps> = ({ blocks, className, emptyState }) => {
+const UIBlockRenderer: React.FC<UIBlockRendererProps> = ({ blocks, className, emptyState, workspaceId }) => {
   const containerClassName = [className ?? 'h-full w-full', blocks.length > 1 ? 'space-y-4' : '']
     .filter(Boolean)
     .join(' ');
@@ -47,6 +48,7 @@ const UIBlockRenderer: React.FC<UIBlockRendererProps> = ({ blocks, className, em
                   file={block.file}
                   fileContent={block.content}
                   disableInternalScroll
+                  workspaceId={workspaceId}
                 />
               </div>
             );
@@ -57,6 +59,7 @@ const UIBlockRenderer: React.FC<UIBlockRendererProps> = ({ blocks, className, em
                   file={createVirtualFile(block.name ?? 'block.md', block.id)}
                   fileContent={block.content}
                   disableInternalScroll
+                  workspaceId={workspaceId}
                 />
               </div>
             );
@@ -66,6 +69,7 @@ const UIBlockRenderer: React.FC<UIBlockRendererProps> = ({ blocks, className, em
                 <FileRenderer
                   file={createVirtualFile(block.name ?? 'block.html', block.id)}
                   fileContent={block.content}
+                  workspaceId={workspaceId}
                 />
               </div>
             );

--- a/frontend/src/components/chat/AgentChatPane.tsx
+++ b/frontend/src/components/chat/AgentChatPane.tsx
@@ -73,6 +73,8 @@ export default function AgentChatPane({
   getPrimaryInterruptAction,
   isPlanApprovalInterrupt,
   setInterruptInputByMessageId,
+  workspaceSkipPlanApprovals,
+  workspaceSettingsBusy,
   onToggleAgentPaneVisibility,
   onModeChange,
   onToggleHistory,
@@ -85,7 +87,9 @@ export default function AgentChatPane({
   onToggleToolActivityVisibility,
   onCopyMessageText,
   onRerunMessage,
+  onPrepareInterruptAction,
   onInterruptAction,
+  onEnableTrustedPlanMode,
   onChatInputChange,
   onChatInputKeyDown,
   onChatInputKeyUp,
@@ -152,6 +156,8 @@ export default function AgentChatPane({
   ) => { name?: string; args?: Record<string, unknown> } | undefined;
   isPlanApprovalInterrupt: (pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt']) => boolean;
   setInterruptInputByMessageId: Dispatch<SetStateAction<Record<string, string>>>;
+  workspaceSkipPlanApprovals: boolean;
+  workspaceSettingsBusy: boolean;
   onToggleAgentPaneVisibility: () => void;
   onModeChange: (event: ChangeEvent<HTMLSelectElement>) => void;
   onToggleHistory: () => void;
@@ -164,11 +170,17 @@ export default function AgentChatPane({
   onToggleToolActivityVisibility: (messageId: ConversationMessage['id']) => void;
   onCopyMessageText: (message: ConversationMessage) => void;
   onRerunMessage: (messageId: ConversationMessage['id']) => void;
+  onPrepareInterruptAction: (
+    message: ConversationMessage,
+    action: RenderableInterruptAction,
+    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  ) => void;
   onInterruptAction: (
     message: ConversationMessage,
     action: RenderableInterruptAction,
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => void;
+  onEnableTrustedPlanMode: () => Promise<boolean> | boolean;
   onChatInputChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
   onChatInputKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
   onChatInputKeyUp: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
@@ -234,11 +246,15 @@ export default function AgentChatPane({
           getPrimaryInterruptAction={getPrimaryInterruptAction}
           isPlanApprovalInterrupt={isPlanApprovalInterrupt}
           setInterruptInputByMessageId={setInterruptInputByMessageId}
+          workspaceSkipPlanApprovals={workspaceSkipPlanApprovals}
+          workspaceSettingsBusy={workspaceSettingsBusy}
           toggleThinkingVisibility={onToggleThinkingVisibility}
           toggleToolActivityVisibility={onToggleToolActivityVisibility}
           handleCopyMessageText={onCopyMessageText}
           handleRerunMessage={onRerunMessage}
+          handlePrepareInterruptAction={onPrepareInterruptAction}
           handleInterruptAction={onInterruptAction}
+          enableTrustedPlanMode={onEnableTrustedPlanMode}
           workspaceId={workspaceId}
         />
         <ChatInputArea

--- a/frontend/src/components/chat/AgentChatPane.tsx
+++ b/frontend/src/components/chat/AgentChatPane.tsx
@@ -19,6 +19,7 @@ import ChatHeader from './ChatHeader';
 import ChatHistoryPanel from './ChatHistoryPanel';
 import ChatInputArea from './ChatInputArea';
 import ChatMessageList from './ChatMessageList';
+import type { RenderableInterruptAction } from './interruptActions';
 
 type CommandSuggestion = {
   id: string;
@@ -48,8 +49,8 @@ export default function AgentChatPane({
   expandedThinkingMessages,
   copiedMessageId,
   interruptInputByMessageId,
-  interruptSelectedChoicesByMessageId,
   interruptSubmittingByMessageId,
+  interruptErrorByMessageId,
   chatMessage,
   chatAttachments,
   showPaper2SlidesControls,
@@ -66,12 +67,12 @@ export default function AgentChatPane({
   workspaceId,
   formatMessageTimestamp,
   interruptFieldKey,
+  interruptActionFieldKey,
   getInterruptKind,
-  getAllowedDecisions,
+  getInterruptActions,
   getPrimaryInterruptAction,
   isPlanApprovalInterrupt,
   setInterruptInputByMessageId,
-  setInterruptSelectedChoicesByMessageId,
   onToggleAgentPaneVisibility,
   onModeChange,
   onToggleHistory,
@@ -84,8 +85,7 @@ export default function AgentChatPane({
   onToggleToolActivityVisibility,
   onCopyMessageText,
   onRerunMessage,
-  onInterruptDecision,
-  onClarificationResponse,
+  onInterruptAction,
   onChatInputChange,
   onChatInputKeyDown,
   onChatInputKeyUp,
@@ -119,8 +119,8 @@ export default function AgentChatPane({
   expandedThinkingMessages: Set<ConversationMessage['id']>;
   copiedMessageId: ConversationMessage['id'] | null;
   interruptInputByMessageId: Record<string, string>;
-  interruptSelectedChoicesByMessageId: Record<string, string[]>;
   interruptSubmittingByMessageId: Record<string, boolean>;
+  interruptErrorByMessageId: Record<string, string>;
   chatMessage: string;
   chatAttachments: File[];
   showPaper2SlidesControls: boolean;
@@ -140,18 +140,18 @@ export default function AgentChatPane({
     messageKey: string,
     field: 'feedback' | 'edit-json' | 'reject-note' | 'clarification-text',
   ) => string;
+  interruptActionFieldKey: (messageKey: string, actionId: string) => string;
   getInterruptKind: (
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => 'approval' | 'clarification';
-  getAllowedDecisions: (
+  getInterruptActions: (
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
-  ) => Array<'approve' | 'edit' | 'reject'>;
+  ) => RenderableInterruptAction[];
   getPrimaryInterruptAction: (
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => { name?: string; args?: Record<string, unknown> } | undefined;
   isPlanApprovalInterrupt: (pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt']) => boolean;
   setInterruptInputByMessageId: Dispatch<SetStateAction<Record<string, string>>>;
-  setInterruptSelectedChoicesByMessageId: Dispatch<SetStateAction<Record<string, string[]>>>;
   onToggleAgentPaneVisibility: () => void;
   onModeChange: (event: ChangeEvent<HTMLSelectElement>) => void;
   onToggleHistory: () => void;
@@ -164,13 +164,9 @@ export default function AgentChatPane({
   onToggleToolActivityVisibility: (messageId: ConversationMessage['id']) => void;
   onCopyMessageText: (message: ConversationMessage) => void;
   onRerunMessage: (messageId: ConversationMessage['id']) => void;
-  onInterruptDecision: (
+  onInterruptAction: (
     message: ConversationMessage,
-    decision: 'approve' | 'edit' | 'reject',
-    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
-  ) => void;
-  onClarificationResponse: (
-    message: ConversationMessage,
+    action: RenderableInterruptAction,
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => void;
   onChatInputChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
@@ -228,22 +224,21 @@ export default function AgentChatPane({
           expandedThinkingMessages={expandedThinkingMessages}
           copiedMessageId={copiedMessageId}
           interruptInputByMessageId={interruptInputByMessageId}
-          interruptSelectedChoicesByMessageId={interruptSelectedChoicesByMessageId}
           interruptSubmittingByMessageId={interruptSubmittingByMessageId}
+          interruptErrorByMessageId={interruptErrorByMessageId}
           interruptFieldKey={interruptFieldKey}
+          interruptActionFieldKey={interruptActionFieldKey}
           getInterruptKind={getInterruptKind}
           formatMessageTimestamp={formatMessageTimestamp}
-          getAllowedDecisions={getAllowedDecisions}
+          getInterruptActions={getInterruptActions}
           getPrimaryInterruptAction={getPrimaryInterruptAction}
           isPlanApprovalInterrupt={isPlanApprovalInterrupt}
           setInterruptInputByMessageId={setInterruptInputByMessageId}
-          setInterruptSelectedChoicesByMessageId={setInterruptSelectedChoicesByMessageId}
           toggleThinkingVisibility={onToggleThinkingVisibility}
           toggleToolActivityVisibility={onToggleToolActivityVisibility}
           handleCopyMessageText={onCopyMessageText}
           handleRerunMessage={onRerunMessage}
-          handleInterruptDecision={onInterruptDecision}
-          handleClarificationResponse={onClarificationResponse}
+          handleInterruptAction={onInterruptAction}
           workspaceId={workspaceId}
         />
         <ChatInputArea

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -1,4 +1,4 @@
-import { Copy, Loader2, RotateCcw } from 'lucide-react';
+import { CheckCircle2, Copy, FilePenLine, Loader2, RotateCcw, ShieldCheck } from 'lucide-react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from
 import type { ConversationMessage, ConversationMessageMetadata } from '../../types';
 import ToolOutputFilePreview from './ToolOutputFilePreview';
 import type { RenderableInterruptAction } from './interruptActions';
+import { buildApprovalReview } from './approvalReview';
 
 const THOUGHT_PREVIEW_LIMIT = 320;
 const THINKING_PLACEHOLDER = 'Formulating a research plan based on your prompt and available context.';
@@ -79,11 +80,15 @@ export default function ChatMessageBubble({
   getPrimaryInterruptAction,
   isPlanApprovalInterrupt,
   setInterruptInputByMessageId,
+  workspaceSkipPlanApprovals,
+  workspaceSettingsBusy,
   toggleThinkingVisibility,
   toggleToolActivityVisibility,
   handleCopyMessageText,
   handleRerunMessage,
+  handlePrepareInterruptAction,
   handleInterruptAction,
+  enableTrustedPlanMode,
   isStreaming,
   workspaceId,
 }: {
@@ -114,15 +119,23 @@ export default function ChatMessageBubble({
   ) => { name?: string; args?: Record<string, unknown> } | undefined;
   isPlanApprovalInterrupt: (pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt']) => boolean;
   setInterruptInputByMessageId: Dispatch<SetStateAction<Record<string, string>>>;
+  workspaceSkipPlanApprovals: boolean;
+  workspaceSettingsBusy: boolean;
   toggleThinkingVisibility: (messageId: ConversationMessage['id']) => void;
   toggleToolActivityVisibility: (messageId: ConversationMessage['id']) => void;
   handleCopyMessageText: (message: ConversationMessage) => void;
   handleRerunMessage: (messageId: ConversationMessage['id']) => void;
+  handlePrepareInterruptAction: (
+    message: ConversationMessage,
+    action: RenderableInterruptAction,
+    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  ) => void;
   handleInterruptAction: (
     message: ConversationMessage,
     action: RenderableInterruptAction,
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => void;
+  enableTrustedPlanMode: () => Promise<boolean> | boolean;
   isStreaming: boolean;
   workspaceId?: string;
 }) {
@@ -200,6 +213,10 @@ export default function ChatMessageBubble({
     }
     return JSON.stringify(args, null, 2);
   }, [primaryInterruptAction?.args]);
+  const approvalReview = useMemo(
+    () => buildApprovalReview(pendingInterrupt, primaryInterruptAction),
+    [pendingInterrupt, primaryInterruptAction],
+  );
 
   useEffect(() => {
     if (!pendingInterrupt) {
@@ -237,6 +254,7 @@ export default function ChatMessageBubble({
     if (interruptControlsDisabled) {
       return;
     }
+    handlePrepareInterruptAction(message, action, pendingInterrupt);
     if (action.inputMode === 'text') {
       setActiveTextActionId(action.id);
       if (action.confirm) {
@@ -259,7 +277,9 @@ export default function ChatMessageBubble({
   };
 
   const clarificationDisplayPayload = renderDisplayPayload(pendingInterrupt?.displayPayload, 'Context', 'dark');
-  const approvalDisplayPayload = renderDisplayPayload(pendingInterrupt?.displayPayload, 'Plan details', 'light');
+  const approvalDisplayPayload = approvalReview
+    ? null
+    : renderDisplayPayload(pendingInterrupt?.displayPayload, 'Plan details', 'light');
   const isDynamicActionInterrupt = Boolean(pendingInterrupt?.actions?.length);
 
   const getActionButtonClass = (action: RenderableInterruptAction, tone: 'light' | 'dark'): string => {
@@ -418,6 +438,20 @@ export default function ChatMessageBubble({
     );
   };
 
+  const approvalCreateImpacts = approvalReview
+    ? approvalReview.steps.flatMap((step) => step.fileImpacts.filter((impact) => impact.action === 'create'))
+    : [];
+  const approvalUpdateImpacts = approvalReview
+    ? approvalReview.steps.flatMap((step) => step.fileImpacts.filter((impact) => impact.action === 'update'))
+    : [];
+
+  const handleEnableTrustedMode = async () => {
+    if (workspaceSkipPlanApprovals || workspaceSettingsBusy) {
+      return;
+    }
+    await Promise.resolve(enableTrustedPlanMode());
+  };
+
   return (
     <div className={`group flex items-start gap-3 motion-safe:animate-[chat-pane-message-in_220ms_ease-out] ${isAgentMessage ? '' : 'justify-end'}`}>
       <div style={{ width: '100%', maxWidth: messageBubbleMaxWidth }} className="relative flex-1 md:flex-initial">
@@ -469,27 +503,187 @@ export default function ChatMessageBubble({
             {pendingInterrupt && !isClarificationInterrupt ? (
               <div className="relative mt-4 pl-4 before:absolute before:-bottom-2 before:left-1 before:top-2 before:w-px before:bg-slate-200">
                 <span className="absolute left-0 top-3 h-2.5 w-2.5 rounded-full border border-indigo-300 bg-indigo-100" />
-                <div className="rounded-2xl border border-sky-200/70 bg-gradient-to-br from-white/75 via-sky-50/70 to-indigo-100/60 p-4 shadow-[0_18px_40px_-28px_rgba(30,64,175,0.75)] backdrop-blur-md">
-                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-700">
-                    {pendingInterrupt.title || 'Approval Required'}
-                  </p>
-                  <p className="mt-1 text-sm text-slate-700">
-                    {pendingInterrupt.description || 'Please review the proposed plan below before continuing.'}
-                  </p>
-                  <div className="mt-3 grid gap-2">
-                    {approvalDisplayPayload}
-                    {isPlanApprovalRequest || planText ? (
-                      <div className="max-h-48 overflow-y-auto rounded-xl border border-slate-200/70 bg-white/60 p-3 text-sm whitespace-pre-wrap text-slate-700">
-                        {planText || 'No plan details were provided.'}
+                <div className="rounded-[1.9rem] border border-amber-200/75 bg-[radial-gradient(circle_at_top_left,_rgba(251,191,36,0.12),_transparent_38%),linear-gradient(160deg,rgba(255,255,255,0.98),rgba(248,250,252,0.95))] p-5 shadow-[0_24px_60px_-34px_rgba(120,53,15,0.45)] backdrop-blur-md">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                          {approvalReview?.cardTitle || pendingInterrupt.title || 'Review Research Strategy'}
+                        </p>
+                        <span className="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-700">
+                          <CheckCircle2 size={12} />
+                          {approvalReview?.badgeLabel || 'Pending Approval'}
+                        </span>
+                      </div>
+                      <p className="mt-3 text-xl font-semibold tracking-tight text-slate-900">
+                        {approvalReview?.planTitle || 'Proposed plan'}
+                      </p>
+                      <p className="mt-1 text-sm leading-relaxed text-slate-600">
+                        {approvalReview?.description || pendingInterrupt.description || 'Review the proposed research strategy before execution continues.'}
+                      </p>
+                    </div>
+                    {approvalReview?.stepCount && approvalReview.stepCount > 1 ? (
+                      <div className="rounded-full border border-slate-200 bg-white/80 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500">
+                        Step {typeof approvalReview.stepIndex === 'number' ? approvalReview.stepIndex + 1 : 1} of {approvalReview.stepCount}
                       </div>
                     ) : null}
-                    {interruptError ? (
-                      <div className="rounded-xl border border-rose-200/90 bg-rose-50 px-3 py-2 text-xs font-medium text-rose-700">
-                        {interruptError}
-                      </div>
-                    ) : null}
-                    {renderInterruptActions('light')}
                   </div>
+
+                  {approvalReview ? (
+                    <div className="mt-4 space-y-4">
+                      <div className="rounded-[1.4rem] border border-slate-200/80 bg-white/80 p-4 shadow-sm">
+                        <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                          <span>Plan File</span>
+                          <span className="rounded-full bg-slate-100 px-2.5 py-1 font-mono text-[10px] normal-case tracking-normal text-slate-700">
+                            {approvalReview.planFilePath}
+                          </span>
+                        </div>
+                        {approvalReview.summaryMarkdown ? (
+                          <div className="agent-markdown mt-3 text-sm text-slate-700">
+                            <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                              {approvalReview.summaryMarkdown}
+                            </ReactMarkdown>
+                          </div>
+                        ) : null}
+                      </div>
+
+                      {approvalReview.steps.length ? (
+                        <div className="rounded-[1.4rem] border border-slate-200/80 bg-white/72 p-4 shadow-sm">
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                            Execution Map
+                          </p>
+                          <div className="mt-3 space-y-3">
+                            {approvalReview.steps.map((step, index) => (
+                              <div key={`${step.title}-${index}`} className="rounded-[1.2rem] border border-slate-200/80 bg-slate-50/80 p-3">
+                                <div className="flex items-start gap-3">
+                                  <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-slate-900 text-[11px] font-semibold text-white">
+                                    {index + 1}
+                                  </span>
+                                  <div className="min-w-0">
+                                    <p className="text-sm font-semibold text-slate-900">{step.title}</p>
+                                    {step.detail ? (
+                                      <p className="mt-1 text-sm leading-relaxed text-slate-600">{step.detail}</p>
+                                    ) : null}
+                                    {step.toolNames.length ? (
+                                      <div className="mt-3 flex flex-wrap gap-2">
+                                        {step.toolNames.map((toolName) => (
+                                          <span
+                                            key={`${step.title}-${toolName}`}
+                                            className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-semibold text-slate-700 shadow-sm"
+                                          >
+                                            {toolName}
+                                          </span>
+                                        ))}
+                                      </div>
+                                    ) : null}
+                                    {step.fileImpacts.length ? (
+                                      <div className="mt-3 flex flex-wrap gap-2">
+                                        {step.fileImpacts.map((impact) => (
+                                          <span
+                                            key={`${step.title}-${impact.action}-${impact.path}`}
+                                            className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${
+                                              impact.action === 'create'
+                                                ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
+                                                : 'bg-blue-50 text-blue-700 ring-1 ring-blue-200'
+                                            }`}
+                                          >
+                                            {impact.action === 'create' ? 'Create' : 'Update'}: {impact.path}
+                                          </span>
+                                        ))}
+                                      </div>
+                                    ) : null}
+                                  </div>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      ) : null}
+
+                      {approvalCreateImpacts.length || approvalUpdateImpacts.length ? (
+                        <div className="grid gap-3 md:grid-cols-2">
+                          <div className="rounded-[1.3rem] border border-emerald-200/80 bg-emerald-50/70 p-4">
+                            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-700">Create</p>
+                            <div className="mt-2 space-y-1.5 text-sm text-emerald-900">
+                              {approvalCreateImpacts.length ? approvalCreateImpacts.map((impact, index) => (
+                                <p key={`${impact.path}-${index}`}>{impact.path}</p>
+                              )) : <p className="text-emerald-800/70">No new files.</p>}
+                            </div>
+                          </div>
+                          <div className="rounded-[1.3rem] border border-blue-200/80 bg-blue-50/75 p-4">
+                            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-700">Update</p>
+                            <div className="mt-2 space-y-1.5 text-sm text-blue-900">
+                              {approvalUpdateImpacts.length ? approvalUpdateImpacts.map((impact, index) => (
+                                <p key={`${impact.path}-${index}`}>{impact.path}</p>
+                              )) : <p className="text-blue-800/70">No existing files updated.</p>}
+                            </div>
+                          </div>
+                        </div>
+                      ) : null}
+
+                      {approvalReview.riskyActions ? (
+                        <div className="rounded-[1.3rem] border border-rose-200/80 bg-rose-50/70 p-4">
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-700">Risk Notes</p>
+                          <p className="mt-2 text-sm leading-relaxed text-rose-900">{approvalReview.riskyActions}</p>
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : (
+                    <div className="mt-3 grid gap-2">
+                      {approvalDisplayPayload}
+                      {isPlanApprovalRequest || planText ? (
+                        <div className="max-h-48 overflow-y-auto rounded-xl border border-slate-200/70 bg-white/60 p-3 text-sm whitespace-pre-wrap text-slate-700">
+                          {planText || 'No plan details were provided.'}
+                        </div>
+                      ) : null}
+                    </div>
+                  )}
+
+                  {isPlanApprovalRequest ? (
+                    <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-[1.2rem] border border-slate-200/80 bg-white/75 px-4 py-3">
+                      <label className="flex min-w-0 items-center gap-3 text-sm text-slate-600">
+                        <input
+                          type="checkbox"
+                          checked={workspaceSkipPlanApprovals}
+                          disabled={workspaceSkipPlanApprovals || workspaceSettingsBusy}
+                          onChange={() => { void handleEnableTrustedMode(); }}
+                          className="h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
+                        />
+                        <span className="min-w-0">
+                          <span className="font-medium text-slate-700">Don’t ask me again for this workspace</span>
+                          <span className="block text-xs text-slate-500">
+                            Future plan reviews will auto-approve until you switch approvals back on in the sidebar.
+                          </span>
+                        </span>
+                      </label>
+                      {workspaceSkipPlanApprovals ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold text-emerald-700 ring-1 ring-emerald-200">
+                          <ShieldCheck size={12} />
+                          Trusted mode enabled
+                        </span>
+                      ) : null}
+                    </div>
+                  ) : null}
+
+                  {interruptError ? (
+                    <div className="mt-4 rounded-xl border border-rose-200/90 bg-rose-50 px-3 py-2 text-xs font-medium text-rose-700">
+                      {interruptError}
+                    </div>
+                  ) : null}
+
+                  {isPlanApprovalRequest ? (
+                    <div className="mt-3 rounded-[1.2rem] border border-slate-200/80 bg-white/70 px-4 py-3 text-xs text-slate-500">
+                      <div className="flex items-center gap-2 font-semibold uppercase tracking-[0.16em] text-slate-500">
+                        <FilePenLine size={13} />
+                        Edit Behavior
+                      </div>
+                      <p className="mt-2 leading-relaxed text-slate-600">
+                        Selecting <span className="font-semibold text-slate-700">Edit</span> opens the plan file in the editor so you can revise the draft before resubmitting feedback.
+                      </p>
+                    </div>
+                  ) : null}
+
+                  <div className="mt-3">{renderInterruptActions('light')}</div>
                 </div>
               </div>
             ) : null}

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -1,10 +1,11 @@
 import { Copy, Loader2, RotateCcw } from 'lucide-react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { useEffect, useMemo, useState, type Dispatch, type KeyboardEvent, type SetStateAction } from 'react';
+import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
 
-import type { ConversationMessage, ConversationMessageMetadata, PendingInterrupt } from '../../types';
+import type { ConversationMessage, ConversationMessageMetadata } from '../../types';
 import ToolOutputFilePreview from './ToolOutputFilePreview';
+import type { RenderableInterruptAction } from './interruptActions';
 
 const THOUGHT_PREVIEW_LIMIT = 320;
 const THINKING_PLACEHOLDER = 'Formulating a research plan based on your prompt and available context.';
@@ -59,9 +60,6 @@ const renderDisplayPayload = (
   );
 };
 
-const getClarificationInputMode = (pendingInterrupt?: PendingInterrupt): 'none' | 'text' | 'choice' | 'text_or_choice' =>
-  pendingInterrupt?.responseSpec?.inputMode || 'text';
-
 export default function ChatMessageBubble({
   message,
   personaDisplayName,
@@ -71,22 +69,21 @@ export default function ChatMessageBubble({
   expandedThinkingMessages,
   copiedMessageId,
   interruptInputByMessageId,
-  interruptSelectedChoicesByMessageId,
   interruptSubmittingByMessageId,
+  interruptErrorByMessageId,
   interruptFieldKey,
+  interruptActionFieldKey,
   formatMessageTimestamp,
   getInterruptKind,
-  getAllowedDecisions,
+  getInterruptActions,
   getPrimaryInterruptAction,
   isPlanApprovalInterrupt,
   setInterruptInputByMessageId,
-  setInterruptSelectedChoicesByMessageId,
   toggleThinkingVisibility,
   toggleToolActivityVisibility,
   handleCopyMessageText,
   handleRerunMessage,
-  handleInterruptDecision,
-  handleClarificationResponse,
+  handleInterruptAction,
   isStreaming,
   workspaceId,
 }: {
@@ -98,36 +95,32 @@ export default function ChatMessageBubble({
   expandedThinkingMessages: Set<ConversationMessage['id']>;
   copiedMessageId: ConversationMessage['id'] | null;
   interruptInputByMessageId: Record<string, string>;
-  interruptSelectedChoicesByMessageId: Record<string, string[]>;
   interruptSubmittingByMessageId: Record<string, boolean>;
+  interruptErrorByMessageId: Record<string, string>;
   interruptFieldKey: (
     messageKey: string,
     field: 'feedback' | 'edit-json' | 'reject-note' | 'clarification-text',
   ) => string;
+  interruptActionFieldKey: (messageKey: string, actionId: string) => string;
   formatMessageTimestamp: (value?: string) => string;
   getInterruptKind: (
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => 'approval' | 'clarification';
-  getAllowedDecisions: (
+  getInterruptActions: (
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
-  ) => Array<'approve' | 'edit' | 'reject'>;
+  ) => RenderableInterruptAction[];
   getPrimaryInterruptAction: (
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => { name?: string; args?: Record<string, unknown> } | undefined;
   isPlanApprovalInterrupt: (pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt']) => boolean;
   setInterruptInputByMessageId: Dispatch<SetStateAction<Record<string, string>>>;
-  setInterruptSelectedChoicesByMessageId: Dispatch<SetStateAction<Record<string, string[]>>>;
   toggleThinkingVisibility: (messageId: ConversationMessage['id']) => void;
   toggleToolActivityVisibility: (messageId: ConversationMessage['id']) => void;
   handleCopyMessageText: (message: ConversationMessage) => void;
   handleRerunMessage: (messageId: ConversationMessage['id']) => void;
-  handleInterruptDecision: (
+  handleInterruptAction: (
     message: ConversationMessage,
-    decision: 'approve' | 'edit' | 'reject',
-    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
-  ) => void;
-  handleClarificationResponse: (
-    message: ConversationMessage,
+    action: RenderableInterruptAction,
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => void;
   isStreaming: boolean;
@@ -141,12 +134,13 @@ export default function ChatMessageBubble({
   const pendingInterrupt = messageMetadata?.pendingInterrupt;
   const interruptKind = getInterruptKind(pendingInterrupt);
   const isClarificationInterrupt = Boolean(pendingInterrupt && interruptKind === 'clarification');
-  const allowedInterruptDecisions = getAllowedDecisions(pendingInterrupt);
+  const interruptActions = getInterruptActions(pendingInterrupt);
   const primaryInterruptAction = getPrimaryInterruptAction(pendingInterrupt);
   const isPlanApprovalRequest = isPlanApprovalInterrupt(pendingInterrupt);
   const messageKey = String(message.id);
   const interruptBusy = Boolean(interruptSubmittingByMessageId[messageKey]);
-  const [interruptMode, setInterruptMode] = useState<'review' | 'editing' | 'rejecting'>('review');
+  const [activeTextActionId, setActiveTextActionId] = useState<string | null>(null);
+  const [confirmActionId, setConfirmActionId] = useState<string | null>(null);
   const [clarificationDismissed, setClarificationDismissed] = useState(false);
   const isToolActivityExpanded = expandedToolMessages.has(message.id);
   const isThinkingExpanded = expandedThinkingMessages.has(message.id);
@@ -183,12 +177,7 @@ export default function ChatMessageBubble({
   const genericEditKey = interruptFieldKey(messageKey, 'edit-json');
   const rejectNoteKey = interruptFieldKey(messageKey, 'reject-note');
   const clarificationTextKey = interruptFieldKey(messageKey, 'clarification-text');
-  const clarificationInputMode = getClarificationInputMode(pendingInterrupt);
-  const clarificationAllowsChoices = clarificationInputMode === 'choice' || clarificationInputMode === 'text_or_choice';
-  const clarificationAllowsText = clarificationInputMode === 'text' || clarificationInputMode === 'text_or_choice';
-  const clarificationChoices = pendingInterrupt?.responseSpec?.choices || [];
-  const selectedChoiceIds = interruptSelectedChoicesByMessageId[messageKey] || [];
-  const clarificationValue = interruptInputByMessageId[clarificationTextKey] || '';
+  const interruptError = interruptErrorByMessageId[messageKey] || '';
   const allowDismiss = Boolean(pendingInterrupt?.responseSpec?.allowDismiss);
 
   const planText = useMemo(() => {
@@ -213,10 +202,13 @@ export default function ChatMessageBubble({
 
   useEffect(() => {
     if (!pendingInterrupt) {
-      setInterruptMode('review');
+      setActiveTextActionId(null);
+      setConfirmActionId(null);
       setClarificationDismissed(false);
       return;
     }
+    setActiveTextActionId(null);
+    setConfirmActionId(null);
     setClarificationDismissed(false);
   }, [pendingInterrupt, messageKey]);
 
@@ -227,66 +219,203 @@ export default function ChatMessageBubble({
     }));
   };
 
-  const setSelectedChoices = (nextChoices: string[]) => {
-    setInterruptSelectedChoicesByMessageId((prev) => ({
-      ...prev,
-      [messageKey]: nextChoices,
-    }));
-  };
-
-  const handleClarificationChoiceToggle = (choiceId: string, choiceValue: string) => {
-    const isMultiple = Boolean(pendingInterrupt?.responseSpec?.multiple);
-    const nextChoices = isMultiple
-      ? selectedChoiceIds.includes(choiceId)
-        ? selectedChoiceIds.filter((value) => value !== choiceId)
-        : [...selectedChoiceIds, choiceId]
-      : [choiceId];
-    setSelectedChoices(nextChoices);
-    if (clarificationInputMode === 'text_or_choice') {
-      setInterruptValue(clarificationTextKey, choiceValue);
+  const getActionInputKey = (action: RenderableInterruptAction): string => {
+    if (action.source === 'approval' && action.legacyDecision === 'edit') {
+      return isPlanApprovalRequest ? planFeedbackKey : genericEditKey;
     }
+    if (action.source === 'approval' && action.legacyDecision === 'reject') {
+      return rejectNoteKey;
+    }
+    if (action.source === 'clarification-text') {
+      return clarificationTextKey;
+    }
+    return interruptActionFieldKey(messageKey, action.id);
   };
 
-  const handleClarificationKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (!pendingInterrupt || clarificationDismissed) {
+  const handleActionTrigger = (action: RenderableInterruptAction) => {
+    if (interruptBusy) {
       return;
     }
-    const target = event.target as HTMLElement | null;
-    const isTextEntryTarget = target?.tagName === 'TEXTAREA' || target?.tagName === 'INPUT';
-    if (clarificationAllowsChoices && clarificationChoices.length) {
-      if (isTextEntryTarget) {
-        return;
+    if (action.inputMode === 'text') {
+      setActiveTextActionId(action.id);
+      if (action.confirm) {
+        setConfirmActionId(action.id);
+      } else {
+        setConfirmActionId(null);
       }
-      const currentIndex = selectedChoiceIds.length
-        ? clarificationChoices.findIndex((choice) => choice.id === selectedChoiceIds[0])
-        : -1;
-      if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        const nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % clarificationChoices.length;
-        const nextChoice = clarificationChoices[nextIndex];
-        handleClarificationChoiceToggle(nextChoice.id, nextChoice.value);
-        return;
-      }
-      if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        const nextIndex = currentIndex <= 0 ? clarificationChoices.length - 1 : currentIndex - 1;
-        const nextChoice = clarificationChoices[nextIndex];
-        handleClarificationChoiceToggle(nextChoice.id, nextChoice.value);
-        return;
-      }
+      return;
     }
-    const hasValidResponse =
-      clarificationValue.trim().length > 0 ||
-      selectedChoiceIds.length > 0 ||
-      clarificationInputMode === 'none';
-    if (event.key === 'Enter' && !event.shiftKey && hasValidResponse && !interruptBusy) {
-      event.preventDefault();
-      handleClarificationResponse(message, pendingInterrupt);
+    if (action.confirm && confirmActionId !== action.id) {
+      setConfirmActionId(action.id);
+      return;
     }
+    void handleInterruptAction(message, action, pendingInterrupt);
+  };
+
+  const handleActionCancel = () => {
+    setActiveTextActionId(null);
+    setConfirmActionId(null);
   };
 
   const clarificationDisplayPayload = renderDisplayPayload(pendingInterrupt?.displayPayload, 'Context', 'dark');
   const approvalDisplayPayload = renderDisplayPayload(pendingInterrupt?.displayPayload, 'Plan details', 'light');
+  const isDynamicActionInterrupt = Boolean(pendingInterrupt?.actions?.length);
+
+  const getActionButtonClass = (action: RenderableInterruptAction, tone: 'light' | 'dark'): string => {
+    const isPrimary = action.style === 'primary';
+    const isDanger = action.style === 'danger';
+    if (tone === 'dark') {
+      if (isPrimary) {
+        return 'rounded-[1.2rem] border border-[#94c5f8]/70 bg-[#94c5f8] px-4 py-3 text-sm font-semibold text-slate-900 transition-all duration-200 hover:bg-[#a8d2fb] disabled:cursor-not-allowed disabled:opacity-40';
+      }
+      if (isDanger) {
+        return 'rounded-[1.2rem] border border-rose-400/35 bg-rose-500/10 px-4 py-3 text-sm font-semibold text-rose-100 transition-all duration-200 hover:bg-rose-500/15 disabled:cursor-not-allowed disabled:opacity-40';
+      }
+      return 'rounded-[1.2rem] border border-white/10 bg-white/[0.03] px-4 py-3 text-sm font-semibold text-white/92 transition-all duration-200 hover:border-white/25 hover:bg-white/[0.07] disabled:cursor-not-allowed disabled:opacity-40';
+    }
+    if (isPrimary) {
+      return 'rounded-xl border border-emerald-300/80 bg-emerald-500/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-all duration-200 hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60';
+    }
+    if (isDanger) {
+      return 'rounded-xl border border-rose-200/90 bg-white px-3 py-1.5 text-xs font-semibold text-rose-700 transition-all duration-200 hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60';
+    }
+    return 'rounded-xl border border-blue-200/90 bg-white px-3 py-1.5 text-xs font-semibold text-blue-700 transition-all duration-200 hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60';
+  };
+
+  const renderInterruptActions = (tone: 'light' | 'dark') => {
+    if (!interruptActions.length) {
+      return null;
+    }
+
+    return (
+      <div className={tone === 'dark' ? 'mt-5 space-y-3' : 'mt-3 space-y-2'}>
+        {interruptActions.map((action, index) => {
+          const inputKey = getActionInputKey(action);
+          const inputValue = interruptInputByMessageId[inputKey] || '';
+          const isTextMode = activeTextActionId === action.id && action.inputMode === 'text';
+          const needsExplicitConfirm = Boolean(action.confirm && confirmActionId === action.id);
+          const showConfirmationOnly = needsExplicitConfirm && action.inputMode !== 'text';
+          const showPrimaryRow = !isTextMode && !showConfirmationOnly;
+          const numberedChoice = tone === 'dark' && action.source === 'clarification-choice';
+
+          return (
+            <div key={action.id} className={tone === 'dark' ? 'space-y-3' : 'space-y-2'}>
+              {showPrimaryRow ? (
+                <button
+                  type="button"
+                  disabled={interruptBusy}
+                  onClick={() => handleActionTrigger(action)}
+                  className={
+                    numberedChoice
+                      ? `flex w-full items-start justify-between rounded-[1.35rem] border px-5 py-4 text-left transition-all duration-200 ${
+                          action.style === 'primary'
+                            ? 'border-[#94c5f8]/55 bg-[#94c5f8]/10 text-white hover:bg-[#94c5f8]/15'
+                            : action.style === 'danger'
+                              ? 'border-rose-400/25 bg-rose-500/10 text-rose-100 hover:bg-rose-500/15'
+                              : 'border-white/10 bg-white/[0.03] text-white/92 hover:border-white/25 hover:bg-white/[0.07]'
+                        } ${interruptBusy ? 'cursor-not-allowed opacity-70' : ''}`
+                      : getActionButtonClass(action, tone)
+                  }
+                >
+                  {numberedChoice ? (
+                    <>
+                      <div className="min-w-0 pr-3">
+                        <div className="flex items-center gap-3">
+                          <span className="text-2xl font-semibold text-white/45">{index + 1}.</span>
+                          <span className="text-[18px] font-semibold leading-snug">{action.label}</span>
+                        </div>
+                      </div>
+                      <span className="mt-1 text-lg text-white/35">{needsExplicitConfirm ? '!' : ''}</span>
+                    </>
+                  ) : (
+                    action.label
+                  )}
+                </button>
+              ) : null}
+              {showConfirmationOnly ? (
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    disabled={interruptBusy}
+                    onClick={() => void handleInterruptAction(message, action, pendingInterrupt)}
+                    className={getActionButtonClass(
+                      {
+                        ...action,
+                        label: action.submitLabel || `Confirm ${action.label}`,
+                        style: action.style === 'danger' ? 'danger' : 'primary',
+                      },
+                      tone,
+                    )}
+                  >
+                    {action.submitLabel || `Confirm ${action.label}`}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={interruptBusy}
+                    onClick={handleActionCancel}
+                    className={tone === 'dark'
+                      ? 'rounded-full px-4 py-2 text-sm font-medium text-white/70 transition-all duration-200 hover:bg-white/[0.06] hover:text-white disabled:cursor-not-allowed disabled:opacity-40'
+                      : 'rounded-xl border border-slate-300/80 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition-all duration-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60'}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : null}
+              {isTextMode ? (
+                <div className={tone === 'dark' ? 'space-y-3' : 'space-y-2'}>
+                  <textarea
+                    value={inputValue}
+                    onChange={(event) => setInterruptValue(inputKey, event.target.value)}
+                    rows={tone === 'dark' ? 4 : 4}
+                    autoFocus
+                    disabled={interruptBusy}
+                    placeholder={action.placeholder || 'Enter your response'}
+                    className={tone === 'dark'
+                      ? 'w-full rounded-[1.35rem] border border-white/10 bg-white/[0.03] px-5 py-4 text-sm leading-relaxed text-white placeholder:text-white/32 focus:border-white/25 focus:outline-none disabled:cursor-not-allowed disabled:opacity-70'
+                      : 'w-full rounded-xl border border-slate-200/80 bg-white/85 p-3 text-sm text-slate-700 backdrop-blur-sm focus:border-sky-400 focus:outline-none'}
+                  />
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      disabled={interruptBusy}
+                      onClick={() => void handleInterruptAction(message, action, pendingInterrupt)}
+                      className={getActionButtonClass(
+                        {
+                          ...action,
+                          label: action.submitLabel || action.label,
+                          style: action.style === 'danger' ? 'danger' : 'primary',
+                        },
+                        tone,
+                      )}
+                    >
+                      {interruptBusy ? (
+                        <span className="inline-flex items-center gap-2">
+                          <Loader2 size={16} className="animate-spin" />
+                          {action.submitLabel || action.label}
+                        </span>
+                      ) : (
+                        action.submitLabel || action.label
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      disabled={interruptBusy}
+                      onClick={handleActionCancel}
+                      className={tone === 'dark'
+                        ? 'rounded-full px-4 py-2 text-sm font-medium text-white/70 transition-all duration-200 hover:bg-white/[0.06] hover:text-white disabled:cursor-not-allowed disabled:opacity-40'
+                        : 'rounded-xl border border-slate-300/80 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition-all duration-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60'}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
 
   return (
     <div className={`group flex items-start gap-3 motion-safe:animate-[chat-pane-message-in_220ms_ease-out] ${isAgentMessage ? '' : 'justify-end'}`}>
@@ -346,275 +475,62 @@ export default function ChatMessageBubble({
                   <p className="mt-1 text-sm text-slate-700">
                     {pendingInterrupt.description || 'Please review the proposed plan below before continuing.'}
                   </p>
-                  {isPlanApprovalRequest ? (
-                    <div className="mt-3 grid gap-2">
-                      {approvalDisplayPayload}
-                      {interruptMode === 'editing' ? (
-                        <textarea
-                          value={interruptInputByMessageId[planFeedbackKey] || ''}
-                          onChange={(event) => setInterruptValue(planFeedbackKey, event.target.value)}
-                          className="w-full rounded-xl border border-slate-200/80 bg-white/85 p-3 text-sm text-slate-700 backdrop-blur-sm focus:border-sky-400 focus:outline-none"
-                          rows={6}
-                          placeholder="Edit this plan before saving changes"
-                        />
-                      ) : (
-                        <div className="max-h-48 overflow-y-auto rounded-xl border border-slate-200/70 bg-white/60 p-3 text-sm text-slate-700 whitespace-pre-wrap">
-                          {planText || 'No plan details were provided.'}
-                        </div>
-                      )}
-                      {interruptMode === 'rejecting' ? (
-                        <input
-                          value={interruptInputByMessageId[rejectNoteKey] || ''}
-                          onChange={(event) => setInterruptValue(rejectNoteKey, event.target.value)}
-                          className="w-full rounded-xl border border-slate-200/80 bg-white/80 px-3 py-2 text-sm text-slate-700 backdrop-blur-sm focus:border-sky-400 focus:outline-none"
-                          placeholder="Reason for rejection (optional)"
-                        />
-                      ) : null}
-                      <div className="mt-1 flex flex-wrap gap-2">
-                        {interruptMode === 'editing' ? (
-                          <>
-                            <button
-                              type="button"
-                              disabled={interruptBusy}
-                              onClick={() => handleInterruptDecision(message, 'edit', pendingInterrupt)}
-                              className="rounded-xl border border-blue-300/80 bg-blue-500/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-all duration-200 hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
-                            >
-                              Save Changes
-                            </button>
-                            <button
-                              type="button"
-                              disabled={interruptBusy}
-                              onClick={() => setInterruptMode('review')}
-                              className="rounded-xl border border-slate-300/80 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition-all duration-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                            >
-                              Cancel
-                            </button>
-                          </>
-                        ) : interruptMode === 'rejecting' ? (
-                          <>
-                            <button
-                              type="button"
-                              disabled={interruptBusy}
-                              onClick={() => handleInterruptDecision(message, 'reject', pendingInterrupt)}
-                              className="rounded-xl border border-rose-300/80 bg-rose-500/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-all duration-200 hover:bg-rose-500 disabled:cursor-not-allowed disabled:opacity-60"
-                            >
-                              Confirm Rejection
-                            </button>
-                            <button
-                              type="button"
-                              disabled={interruptBusy}
-                              onClick={() => setInterruptMode('review')}
-                              className="rounded-xl border border-slate-300/80 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition-all duration-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                            >
-                              Cancel
-                            </button>
-                          </>
-                        ) : (
-                          <>
-                            {allowedInterruptDecisions.includes('approve') ? (
-                              <button
-                                type="button"
-                                disabled={interruptBusy}
-                                onClick={() => handleInterruptDecision(message, 'approve', pendingInterrupt)}
-                                className="rounded-xl border border-emerald-300/80 bg-emerald-500/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-all duration-200 hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
-                              >
-                                Approve
-                              </button>
-                            ) : null}
-                            {allowedInterruptDecisions.includes('edit') ? (
-                              <button
-                                type="button"
-                                disabled={interruptBusy}
-                                onClick={() => {
-                                  if (!(interruptInputByMessageId[planFeedbackKey] || '').trim()) {
-                                    setInterruptValue(planFeedbackKey, planText);
-                                  }
-                                  setInterruptMode('editing');
-                                }}
-                                className="rounded-xl border border-blue-200/90 bg-white px-3 py-1.5 text-xs font-semibold text-blue-700 transition-all duration-200 hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60"
-                              >
-                                Edit
-                              </button>
-                            ) : null}
-                            {allowedInterruptDecisions.includes('reject') ? (
-                              <button
-                                type="button"
-                                disabled={interruptBusy}
-                                onClick={() => setInterruptMode('rejecting')}
-                                className="rounded-xl border border-rose-200/90 bg-white px-3 py-1.5 text-xs font-semibold text-rose-700 transition-all duration-200 hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
-                              >
-                                Reject
-                              </button>
-                            ) : null}
-                          </>
-                        )}
+                  <div className="mt-3 grid gap-2">
+                    {approvalDisplayPayload}
+                    {isPlanApprovalRequest || planText ? (
+                      <div className="max-h-48 overflow-y-auto rounded-xl border border-slate-200/70 bg-white/60 p-3 text-sm whitespace-pre-wrap text-slate-700">
+                        {planText || 'No plan details were provided.'}
                       </div>
-                    </div>
-                  ) : (
-                    <div className="mt-2 grid gap-2">
-                      {approvalDisplayPayload}
-                      <textarea
-                        value={interruptInputByMessageId[genericEditKey] || ''}
-                        onChange={(event) => setInterruptValue(genericEditKey, event.target.value)}
-                        className="w-full rounded-xl border border-slate-200/80 bg-white/80 p-2 text-xs text-slate-700 backdrop-blur-sm focus:border-sky-400 focus:outline-none"
-                        rows={4}
-                        placeholder="Optional edit feedback or updated args JSON"
-                      />
-                      {interruptMode === 'rejecting' ? (
-                        <input
-                          value={interruptInputByMessageId[rejectNoteKey] || ''}
-                          onChange={(event) => setInterruptValue(rejectNoteKey, event.target.value)}
-                          className="w-full rounded-xl border border-slate-200/80 bg-white/80 px-2 py-1.5 text-xs text-slate-700 backdrop-blur-sm focus:border-sky-400 focus:outline-none"
-                          placeholder="Reason for rejection (optional)"
-                        />
-                      ) : null}
-                      <div className="mt-1 flex flex-wrap gap-2">
-                        {allowedInterruptDecisions.includes('approve') ? (
-                          <button
-                            type="button"
-                            disabled={interruptBusy}
-                            onClick={() => handleInterruptDecision(message, 'approve', pendingInterrupt)}
-                            className="rounded-xl border border-emerald-300/80 bg-emerald-500/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-all duration-200 hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
-                          >
-                            Approve
-                          </button>
-                        ) : null}
-                        {allowedInterruptDecisions.includes('edit') ? (
-                          <button
-                            type="button"
-                            disabled={interruptBusy}
-                            onClick={() => handleInterruptDecision(message, 'edit', pendingInterrupt)}
-                            className="rounded-xl border border-blue-200/90 bg-white px-3 py-1.5 text-xs font-semibold text-blue-700 transition-all duration-200 hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60"
-                          >
-                            Edit
-                          </button>
-                        ) : null}
-                        {allowedInterruptDecisions.includes('reject') ? (
-                          interruptMode === 'rejecting' ? (
-                            <>
-                              <button
-                                type="button"
-                                disabled={interruptBusy}
-                                onClick={() => handleInterruptDecision(message, 'reject', pendingInterrupt)}
-                                className="rounded-xl border border-rose-300/80 bg-rose-500/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-all duration-200 hover:bg-rose-500 disabled:cursor-not-allowed disabled:opacity-60"
-                              >
-                                Confirm Rejection
-                              </button>
-                              <button
-                                type="button"
-                                disabled={interruptBusy}
-                                onClick={() => setInterruptMode('review')}
-                                className="rounded-xl border border-slate-300/80 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition-all duration-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                              >
-                                Cancel
-                              </button>
-                            </>
-                          ) : (
-                            <button
-                              type="button"
-                              disabled={interruptBusy}
-                              onClick={() => setInterruptMode('rejecting')}
-                              className="rounded-xl border border-rose-200/90 bg-white px-3 py-1.5 text-xs font-semibold text-rose-700 transition-all duration-200 hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
-                            >
-                              Reject
-                            </button>
-                          )
-                        ) : null}
+                    ) : null}
+                    {interruptError ? (
+                      <div className="rounded-xl border border-rose-200/90 bg-rose-50 px-3 py-2 text-xs font-medium text-rose-700">
+                        {interruptError}
                       </div>
-                    </div>
-                  )}
+                    ) : null}
+                    {renderInterruptActions('light')}
+                  </div>
                 </div>
               </div>
             ) : null}
             {pendingInterrupt && isClarificationInterrupt && !clarificationDismissed ? (
               <div className="mt-5 rounded-[2rem] border border-white/10 bg-[#121212] p-5 text-white shadow-[0_26px_80px_-34px_rgba(0,0,0,0.95)] ring-1 ring-white/10">
-                <div
-                  className="outline-none"
-                  tabIndex={0}
-                  onKeyDown={handleClarificationKeyDown}
-                >
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <p className="text-[30px] font-semibold leading-tight tracking-tight text-white">
-                        {pendingInterrupt.title || 'The agent needs clarification'}
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <p className="text-[30px] font-semibold leading-tight tracking-tight text-white">
+                      {pendingInterrupt.title || (isDynamicActionInterrupt ? 'Select the next step' : 'The agent needs clarification')}
+                    </p>
+                    {pendingInterrupt.description ? (
+                      <p className="mt-3 max-w-2xl text-sm leading-relaxed text-white/70">
+                        {pendingInterrupt.description}
                       </p>
-                      {pendingInterrupt.description ? (
-                        <p className="mt-3 max-w-2xl text-sm leading-relaxed text-white/70">
-                          {pendingInterrupt.description}
-                        </p>
-                      ) : null}
-                    </div>
-                    {pendingInterrupt.stepCount && pendingInterrupt.stepCount > 1 ? (
-                      <div className="shrink-0 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/75">
-                        {typeof pendingInterrupt.stepIndex === 'number' ? pendingInterrupt.stepIndex + 1 : 1} of {pendingInterrupt.stepCount}
-                      </div>
                     ) : null}
                   </div>
-                  {clarificationDisplayPayload ? <div className="mt-5">{clarificationDisplayPayload}</div> : null}
-                  {clarificationAllowsChoices && clarificationChoices.length ? (
-                    <div className="mt-5 space-y-3">
-                      {clarificationChoices.map((choice, index) => {
-                        const selected = selectedChoiceIds.includes(choice.id);
-                        return (
-                          <button
-                            key={choice.id}
-                            type="button"
-                            disabled={interruptBusy}
-                            onClick={() => handleClarificationChoiceToggle(choice.id, choice.value)}
-                            className={`flex w-full items-start justify-between rounded-[1.35rem] border px-5 py-4 text-left transition-all duration-200 ${
-                              selected
-                                ? 'border-white/70 bg-white/14 text-white shadow-[0_12px_36px_-24px_rgba(255,255,255,0.65)]'
-                                : 'border-white/10 bg-white/[0.03] text-white/92 hover:border-white/25 hover:bg-white/[0.07]'
-                            } ${interruptBusy ? 'cursor-not-allowed opacity-70' : ''}`}
-                          >
-                            <div className="min-w-0 pr-3">
-                              <div className="flex items-center gap-3">
-                                <span className={`text-2xl font-semibold ${selected ? 'text-white' : 'text-white/45'}`}>{index + 1}.</span>
-                                <span className="text-[18px] font-semibold leading-snug">{choice.label}</span>
-                              </div>
-                              {choice.description ? (
-                                <p className="mt-2 pl-11 text-sm leading-relaxed text-white/62">{choice.description}</p>
-                              ) : null}
-                            </div>
-                            <span className={`mt-1 text-lg ${selected ? 'text-white' : 'text-white/35'}`}>{selected ? '↵' : ''}</span>
-                          </button>
-                        );
-                      })}
+                  {pendingInterrupt.stepCount && pendingInterrupt.stepCount > 1 ? (
+                    <div className="shrink-0 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/75">
+                      {typeof pendingInterrupt.stepIndex === 'number' ? pendingInterrupt.stepIndex + 1 : 1} of {pendingInterrupt.stepCount}
                     </div>
                   ) : null}
-                  {clarificationAllowsText ? (
-                    <textarea
-                      value={clarificationValue}
-                      onChange={(event) => setInterruptValue(clarificationTextKey, event.target.value)}
-                      rows={4}
-                      disabled={interruptBusy}
-                      placeholder={pendingInterrupt.responseSpec?.placeholder || 'Type your answer for the agent'}
-                      className="mt-5 w-full rounded-[1.35rem] border border-white/10 bg-white/[0.03] px-5 py-4 text-sm leading-relaxed text-white placeholder:text-white/32 focus:border-white/25 focus:outline-none disabled:cursor-not-allowed disabled:opacity-70"
-                    />
-                  ) : null}
-                  <div className="mt-6 flex items-center justify-between gap-4">
-                    <button
-                      type="button"
-                      disabled={!allowDismiss || interruptBusy}
-                      onClick={() => setClarificationDismissed(true)}
-                      className={`rounded-full px-4 py-2 text-sm font-medium transition-all duration-200 ${
-                        allowDismiss
-                          ? 'text-white/70 hover:bg-white/[0.06] hover:text-white'
-                          : 'cursor-not-allowed text-white/25'
-                      }`}
-                    >
-                      {pendingInterrupt.responseSpec?.dismissLabel || 'Dismiss'}
-                    </button>
-                    <button
-                      type="button"
-                      disabled={interruptBusy || (!clarificationValue.trim() && !selectedChoiceIds.length && clarificationInputMode !== 'none')}
-                      onClick={() => handleClarificationResponse(message, pendingInterrupt)}
-                      className="inline-flex items-center gap-2 rounded-full bg-[#94c5f8] px-5 py-3 text-sm font-semibold text-slate-900 transition-all duration-200 hover:bg-[#a8d2fb] disabled:cursor-not-allowed disabled:opacity-40"
-                    >
-                      {interruptBusy ? <Loader2 size={16} className="animate-spin" /> : null}
-                      <span>{pendingInterrupt.responseSpec?.submitLabel || 'Continue'}</span>
-                    </button>
+                </div>
+                {clarificationDisplayPayload ? <div className="mt-5">{clarificationDisplayPayload}</div> : null}
+                {interruptError ? (
+                  <div className="mt-4 rounded-[1.25rem] border border-rose-400/35 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+                    {interruptError}
                   </div>
+                ) : null}
+                {renderInterruptActions('dark')}
+                <div className="mt-6 flex items-center justify-between gap-4">
+                  <button
+                    type="button"
+                    disabled={!allowDismiss || interruptBusy}
+                    onClick={() => setClarificationDismissed(true)}
+                    className={`rounded-full px-4 py-2 text-sm font-medium transition-all duration-200 ${
+                      allowDismiss
+                        ? 'text-white/70 hover:bg-white/[0.06] hover:text-white'
+                        : 'cursor-not-allowed text-white/25'
+                    }`}
+                  >
+                    {pendingInterrupt.responseSpec?.dismissLabel || 'Dismiss'}
+                  </button>
                 </div>
               </div>
             ) : null}

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -139,6 +139,7 @@ export default function ChatMessageBubble({
   const isPlanApprovalRequest = isPlanApprovalInterrupt(pendingInterrupt);
   const messageKey = String(message.id);
   const interruptBusy = Boolean(interruptSubmittingByMessageId[messageKey]);
+  const interruptControlsDisabled = interruptBusy || (Boolean(pendingInterrupt) && isStreaming);
   const [activeTextActionId, setActiveTextActionId] = useState<string | null>(null);
   const [confirmActionId, setConfirmActionId] = useState<string | null>(null);
   const [clarificationDismissed, setClarificationDismissed] = useState(false);
@@ -233,7 +234,7 @@ export default function ChatMessageBubble({
   };
 
   const handleActionTrigger = (action: RenderableInterruptAction) => {
-    if (interruptBusy) {
+    if (interruptControlsDisabled) {
       return;
     }
     if (action.inputMode === 'text') {
@@ -303,7 +304,7 @@ export default function ChatMessageBubble({
               {showPrimaryRow ? (
                 <button
                   type="button"
-                  disabled={interruptBusy}
+                  disabled={interruptControlsDisabled}
                   onClick={() => handleActionTrigger(action)}
                   className={
                     numberedChoice
@@ -313,7 +314,7 @@ export default function ChatMessageBubble({
                             : action.style === 'danger'
                               ? 'border-rose-400/25 bg-rose-500/10 text-rose-100 hover:bg-rose-500/15'
                               : 'border-white/10 bg-white/[0.03] text-white/92 hover:border-white/25 hover:bg-white/[0.07]'
-                        } ${interruptBusy ? 'cursor-not-allowed opacity-70' : ''}`
+                        } ${interruptControlsDisabled ? 'cursor-not-allowed opacity-70' : ''}`
                       : getActionButtonClass(action, tone)
                   }
                 >
@@ -336,7 +337,7 @@ export default function ChatMessageBubble({
                 <div className="flex flex-wrap gap-2">
                   <button
                     type="button"
-                    disabled={interruptBusy}
+                    disabled={interruptControlsDisabled}
                     onClick={() => void handleInterruptAction(message, action, pendingInterrupt)}
                     className={getActionButtonClass(
                       {
@@ -351,7 +352,7 @@ export default function ChatMessageBubble({
                   </button>
                   <button
                     type="button"
-                    disabled={interruptBusy}
+                    disabled={interruptControlsDisabled}
                     onClick={handleActionCancel}
                     className={tone === 'dark'
                       ? 'rounded-full px-4 py-2 text-sm font-medium text-white/70 transition-all duration-200 hover:bg-white/[0.06] hover:text-white disabled:cursor-not-allowed disabled:opacity-40'
@@ -368,7 +369,7 @@ export default function ChatMessageBubble({
                     onChange={(event) => setInterruptValue(inputKey, event.target.value)}
                     rows={tone === 'dark' ? 4 : 4}
                     autoFocus
-                    disabled={interruptBusy}
+                    disabled={interruptControlsDisabled}
                     placeholder={action.placeholder || 'Enter your response'}
                     className={tone === 'dark'
                       ? 'w-full rounded-[1.35rem] border border-white/10 bg-white/[0.03] px-5 py-4 text-sm leading-relaxed text-white placeholder:text-white/32 focus:border-white/25 focus:outline-none disabled:cursor-not-allowed disabled:opacity-70'
@@ -377,7 +378,7 @@ export default function ChatMessageBubble({
                   <div className="flex flex-wrap gap-2">
                     <button
                       type="button"
-                      disabled={interruptBusy}
+                      disabled={interruptControlsDisabled}
                       onClick={() => void handleInterruptAction(message, action, pendingInterrupt)}
                       className={getActionButtonClass(
                         {
@@ -399,7 +400,7 @@ export default function ChatMessageBubble({
                     </button>
                     <button
                       type="button"
-                      disabled={interruptBusy}
+                      disabled={interruptControlsDisabled}
                       onClick={handleActionCancel}
                       className={tone === 'dark'
                         ? 'rounded-full px-4 py-2 text-sm font-medium text-white/70 transition-all duration-200 hover:bg-white/[0.06] hover:text-white disabled:cursor-not-allowed disabled:opacity-40'

--- a/frontend/src/components/chat/ChatMessageList.tsx
+++ b/frontend/src/components/chat/ChatMessageList.tsx
@@ -3,6 +3,7 @@ import { type Dispatch, type ReactNode, type SetStateAction, useEffect, useMemo,
 
 import type { ConversationMessage, ConversationMessageMetadata } from '../../types';
 import ChatMessageBubble from './ChatMessageBubble';
+import type { RenderableInterruptAction } from './interruptActions';
 
 export default function ChatMessageList({
   messages,
@@ -14,22 +15,21 @@ export default function ChatMessageList({
   expandedThinkingMessages,
   copiedMessageId,
   interruptInputByMessageId,
-  interruptSelectedChoicesByMessageId,
   interruptSubmittingByMessageId,
+  interruptErrorByMessageId,
   interruptFieldKey,
+  interruptActionFieldKey,
   formatMessageTimestamp,
   getInterruptKind,
-  getAllowedDecisions,
+  getInterruptActions,
   getPrimaryInterruptAction,
   isPlanApprovalInterrupt,
   setInterruptInputByMessageId,
-  setInterruptSelectedChoicesByMessageId,
   toggleThinkingVisibility,
   toggleToolActivityVisibility,
   handleCopyMessageText,
   handleRerunMessage,
-  handleInterruptDecision,
-  handleClarificationResponse,
+  handleInterruptAction,
   workspaceId,
 }: {
   messages: ConversationMessage[];
@@ -41,36 +41,32 @@ export default function ChatMessageList({
   expandedThinkingMessages: Set<ConversationMessage['id']>;
   copiedMessageId: ConversationMessage['id'] | null;
   interruptInputByMessageId: Record<string, string>;
-  interruptSelectedChoicesByMessageId: Record<string, string[]>;
   interruptSubmittingByMessageId: Record<string, boolean>;
+  interruptErrorByMessageId: Record<string, string>;
   interruptFieldKey: (
     messageKey: string,
     field: 'feedback' | 'edit-json' | 'reject-note' | 'clarification-text',
   ) => string;
+  interruptActionFieldKey: (messageKey: string, actionId: string) => string;
   formatMessageTimestamp: (value?: string) => string;
   getInterruptKind: (
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => 'approval' | 'clarification';
-  getAllowedDecisions: (
+  getInterruptActions: (
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
-  ) => Array<'approve' | 'edit' | 'reject'>;
+  ) => RenderableInterruptAction[];
   getPrimaryInterruptAction: (
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => { name?: string; args?: Record<string, unknown> } | undefined;
   isPlanApprovalInterrupt: (pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt']) => boolean;
   setInterruptInputByMessageId: Dispatch<SetStateAction<Record<string, string>>>;
-  setInterruptSelectedChoicesByMessageId: Dispatch<SetStateAction<Record<string, string[]>>>;
   toggleThinkingVisibility: (messageId: ConversationMessage['id']) => void;
   toggleToolActivityVisibility: (messageId: ConversationMessage['id']) => void;
   handleCopyMessageText: (message: ConversationMessage) => void;
   handleRerunMessage: (messageId: ConversationMessage['id']) => void;
-  handleInterruptDecision: (
+  handleInterruptAction: (
     message: ConversationMessage,
-    decision: 'approve' | 'edit' | 'reject',
-    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
-  ) => void;
-  handleClarificationResponse: (
-    message: ConversationMessage,
+    action: RenderableInterruptAction,
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => void;
   workspaceId?: string;
@@ -140,22 +136,21 @@ export default function ChatMessageList({
           expandedThinkingMessages={expandedThinkingMessages}
           copiedMessageId={copiedMessageId}
           interruptInputByMessageId={interruptInputByMessageId}
-          interruptSelectedChoicesByMessageId={interruptSelectedChoicesByMessageId}
           interruptSubmittingByMessageId={interruptSubmittingByMessageId}
+          interruptErrorByMessageId={interruptErrorByMessageId}
           interruptFieldKey={interruptFieldKey}
+          interruptActionFieldKey={interruptActionFieldKey}
           formatMessageTimestamp={formatMessageTimestamp}
           getInterruptKind={getInterruptKind}
-          getAllowedDecisions={getAllowedDecisions}
+          getInterruptActions={getInterruptActions}
           getPrimaryInterruptAction={getPrimaryInterruptAction}
           isPlanApprovalInterrupt={isPlanApprovalInterrupt}
           setInterruptInputByMessageId={setInterruptInputByMessageId}
-          setInterruptSelectedChoicesByMessageId={setInterruptSelectedChoicesByMessageId}
           toggleThinkingVisibility={toggleThinkingVisibility}
           toggleToolActivityVisibility={toggleToolActivityVisibility}
           handleCopyMessageText={handleCopyMessageText}
           handleRerunMessage={handleRerunMessage}
-          handleInterruptDecision={handleInterruptDecision}
-          handleClarificationResponse={handleClarificationResponse}
+          handleInterruptAction={handleInterruptAction}
           isStreaming={isStreaming}
           workspaceId={workspaceId}
         />,
@@ -164,19 +159,19 @@ export default function ChatMessageList({
     return nodes;
   }, [
     interruptFieldKey,
+    interruptActionFieldKey,
     interruptInputByMessageId,
-    interruptSelectedChoicesByMessageId,
     interruptSubmittingByMessageId,
+    interruptErrorByMessageId,
     copiedMessageId,
     expandedThinkingMessages,
     expandedToolMessages,
     formatMessageTimestamp,
     getInterruptKind,
-    getAllowedDecisions,
+    getInterruptActions,
     getPrimaryInterruptAction,
     handleCopyMessageText,
-    handleClarificationResponse,
-    handleInterruptDecision,
+    handleInterruptAction,
     handleRerunMessage,
     isPlanApprovalInterrupt,
     isStreaming,
@@ -185,7 +180,6 @@ export default function ChatMessageList({
     messages,
     personaDisplayName,
     setInterruptInputByMessageId,
-    setInterruptSelectedChoicesByMessageId,
     toggleThinkingVisibility,
     toggleToolActivityVisibility,
     workspaceId,

--- a/frontend/src/components/chat/ChatMessageList.tsx
+++ b/frontend/src/components/chat/ChatMessageList.tsx
@@ -25,11 +25,15 @@ export default function ChatMessageList({
   getPrimaryInterruptAction,
   isPlanApprovalInterrupt,
   setInterruptInputByMessageId,
+  workspaceSkipPlanApprovals,
+  workspaceSettingsBusy,
   toggleThinkingVisibility,
   toggleToolActivityVisibility,
   handleCopyMessageText,
   handleRerunMessage,
+  handlePrepareInterruptAction,
   handleInterruptAction,
+  enableTrustedPlanMode,
   workspaceId,
 }: {
   messages: ConversationMessage[];
@@ -60,15 +64,23 @@ export default function ChatMessageList({
   ) => { name?: string; args?: Record<string, unknown> } | undefined;
   isPlanApprovalInterrupt: (pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt']) => boolean;
   setInterruptInputByMessageId: Dispatch<SetStateAction<Record<string, string>>>;
+  workspaceSkipPlanApprovals: boolean;
+  workspaceSettingsBusy: boolean;
   toggleThinkingVisibility: (messageId: ConversationMessage['id']) => void;
   toggleToolActivityVisibility: (messageId: ConversationMessage['id']) => void;
   handleCopyMessageText: (message: ConversationMessage) => void;
   handleRerunMessage: (messageId: ConversationMessage['id']) => void;
+  handlePrepareInterruptAction: (
+    message: ConversationMessage,
+    action: RenderableInterruptAction,
+    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  ) => void;
   handleInterruptAction: (
     message: ConversationMessage,
     action: RenderableInterruptAction,
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ) => void;
+  enableTrustedPlanMode: () => Promise<boolean> | boolean;
   workspaceId?: string;
 }) {
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -146,11 +158,15 @@ export default function ChatMessageList({
           getPrimaryInterruptAction={getPrimaryInterruptAction}
           isPlanApprovalInterrupt={isPlanApprovalInterrupt}
           setInterruptInputByMessageId={setInterruptInputByMessageId}
+          workspaceSkipPlanApprovals={workspaceSkipPlanApprovals}
+          workspaceSettingsBusy={workspaceSettingsBusy}
           toggleThinkingVisibility={toggleThinkingVisibility}
           toggleToolActivityVisibility={toggleToolActivityVisibility}
           handleCopyMessageText={handleCopyMessageText}
           handleRerunMessage={handleRerunMessage}
+          handlePrepareInterruptAction={handlePrepareInterruptAction}
           handleInterruptAction={handleInterruptAction}
+          enableTrustedPlanMode={enableTrustedPlanMode}
           isStreaming={isStreaming}
           workspaceId={workspaceId}
         />,
@@ -175,6 +191,8 @@ export default function ChatMessageList({
     handleRerunMessage,
     isPlanApprovalInterrupt,
     isStreaming,
+    workspaceSkipPlanApprovals,
+    workspaceSettingsBusy,
     markdownComponents,
     messageBubbleMaxWidth,
     messages,
@@ -183,6 +201,8 @@ export default function ChatMessageList({
     toggleThinkingVisibility,
     toggleToolActivityVisibility,
     workspaceId,
+    handlePrepareInterruptAction,
+    enableTrustedPlanMode,
   ]);
 
   return (

--- a/frontend/src/components/chat/approvalReview.ts
+++ b/frontend/src/components/chat/approvalReview.ts
@@ -1,0 +1,194 @@
+import type { ConversationMessageMetadata } from '../../types';
+
+export type PlanFileImpact = {
+  path: string;
+  action: 'create' | 'update';
+};
+
+export type PlanReviewStep = {
+  title: string;
+  detail?: string;
+  toolNames: string[];
+  fileImpacts: PlanFileImpact[];
+};
+
+export type ApprovalReviewModel = {
+  cardTitle: string;
+  badgeLabel: string;
+  planTitle: string;
+  description?: string;
+  summaryMarkdown: string;
+  steps: PlanReviewStep[];
+  planFilePath: string;
+  stepIndex?: number;
+  stepCount?: number;
+  riskyActions?: string;
+  rawChecklist?: string;
+  hasStructuredContent: boolean;
+};
+
+type PrimaryInterruptAction = { name?: string; args?: Record<string, unknown> } | undefined;
+
+const DEFAULT_CARD_TITLE = 'Review Research Strategy';
+const DEFAULT_BADGE_LABEL = 'Pending Approval';
+const DEFAULT_PLAN_PATH = 'research_plan.md';
+
+const coerceString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
+
+const normalizePath = (value: string): string => value.replace(/^\/+/, '').trim();
+
+const coerceNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+};
+
+const parseSteps = (value: unknown): PlanReviewStep[] => {
+  const rawSteps = (() => {
+    if (Array.isArray(value)) {
+      return value;
+    }
+    if (typeof value === 'string' && value.trim()) {
+      try {
+        const parsed = JSON.parse(value);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch {
+        return [];
+      }
+    }
+    return [];
+  })();
+
+  return rawSteps.flatMap((item) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      return [];
+    }
+    const title = coerceString((item as Record<string, unknown>).title);
+    if (!title) {
+      return [];
+    }
+    const detail = coerceString((item as Record<string, unknown>).detail);
+    const toolNames = Array.isArray((item as Record<string, unknown>).toolNames)
+      ? ((item as Record<string, unknown>).toolNames as unknown[])
+          .map((tool) => coerceString(tool))
+          .filter(Boolean)
+      : [];
+    const fileImpactsRaw = Array.isArray((item as Record<string, unknown>).fileImpacts)
+      ? ((item as Record<string, unknown>).fileImpacts as unknown[])
+      : [];
+    const fileImpacts = fileImpactsRaw.flatMap((impact) => {
+      if (!impact || typeof impact !== 'object' || Array.isArray(impact)) {
+        return [];
+      }
+      const path = normalizePath(coerceString((impact as Record<string, unknown>).path));
+      const action = coerceString((impact as Record<string, unknown>).action).toLowerCase();
+      if (!path || (action !== 'create' && action !== 'update')) {
+        return [];
+      }
+      return [{ path, action: action as 'create' | 'update' }];
+    });
+    return [{ title, ...(detail ? { detail } : {}), toolNames, fileImpacts }];
+  });
+};
+
+const checklistToSteps = (checklist: string): PlanReviewStep[] =>
+  checklist
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/^[-*]\s+/, '').replace(/^\d+[\.\)]\s+/, '').trim())
+    .filter(Boolean)
+    .map((title) => ({
+      title,
+      toolNames: [],
+      fileImpacts: [],
+    }));
+
+const isGenericApprovalTitle = (value: string): boolean =>
+  /approval required/i.test(value) || /request_plan_approval/i.test(value);
+
+export const buildApprovalReview = (
+  pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  primaryAction?: PrimaryInterruptAction,
+): ApprovalReviewModel | null => {
+  const args =
+    primaryAction?.args && typeof primaryAction.args === 'object' && !Array.isArray(primaryAction.args)
+      ? primaryAction.args
+      : undefined;
+  if (!args) {
+    return null;
+  }
+
+  const planTitle = coerceString(args.plan_title) || coerceString(pendingInterrupt?.title);
+  const summaryMarkdown = coerceString(args.plan_summary_markdown) || coerceString(args.plan_summary);
+  const rawChecklist = coerceString(args.execution_checklist);
+  const steps = parseSteps(args.steps);
+  const fallbackSteps = steps.length ? steps : rawChecklist ? checklistToSteps(rawChecklist) : [];
+  const planFilePath = normalizePath(coerceString(args.plan_file_path) || DEFAULT_PLAN_PATH) || DEFAULT_PLAN_PATH;
+  const badgeLabel = coerceString(args.status_label) || DEFAULT_BADGE_LABEL;
+  const riskyActions = coerceString(args.risky_actions);
+  const description = coerceString(pendingInterrupt?.description);
+  const interruptTitle = coerceString(pendingInterrupt?.title);
+  const cardTitle = interruptTitle && !isGenericApprovalTitle(interruptTitle) ? interruptTitle : DEFAULT_CARD_TITLE;
+  const stepIndex = coerceNumber(pendingInterrupt?.stepIndex) ?? coerceNumber(args.step_index);
+  const stepCount = coerceNumber(pendingInterrupt?.stepCount) ?? coerceNumber(args.step_count);
+
+  if (!planTitle && !summaryMarkdown && !fallbackSteps.length && !rawChecklist) {
+    return null;
+  }
+
+  return {
+    cardTitle,
+    badgeLabel,
+    planTitle: planTitle || 'Proposed plan',
+    ...(description ? { description } : {}),
+    summaryMarkdown,
+    steps: fallbackSteps,
+    planFilePath,
+    ...(typeof stepIndex === 'number' ? { stepIndex } : {}),
+    ...(typeof stepCount === 'number' ? { stepCount } : {}),
+    ...(riskyActions && riskyActions.toLowerCase() !== 'none' ? { riskyActions } : {}),
+    ...(rawChecklist ? { rawChecklist } : {}),
+    hasStructuredContent: Boolean(summaryMarkdown || fallbackSteps.length),
+  };
+};
+
+export const buildApprovalDraftContent = (review: ApprovalReviewModel | null): string => {
+  if (!review) {
+    return '';
+  }
+  const lines: string[] = [`# ${review.planTitle}`];
+  if (review.summaryMarkdown.trim()) {
+    lines.push('', review.summaryMarkdown.trim());
+  }
+  if (review.steps.length) {
+    lines.push('', '## Execution Steps');
+    review.steps.forEach((step, index) => {
+      lines.push('', `${index + 1}. ${step.title}`);
+      if (step.detail) {
+        lines.push(`   - ${step.detail}`);
+      }
+      if (step.toolNames.length) {
+        lines.push(`   - Tools: ${step.toolNames.join(', ')}`);
+      }
+      if (step.fileImpacts.length) {
+        lines.push(
+          `   - Files: ${step.fileImpacts.map((impact) => `${impact.action}: ${impact.path}`).join(' | ')}`,
+        );
+      }
+    });
+  } else if (review.rawChecklist) {
+    lines.push('', '## Checklist', '', review.rawChecklist.trim());
+  }
+  if (review.riskyActions) {
+    lines.push('', '## Risks', '', review.riskyActions);
+  }
+  return `${lines.join('\n').trim()}\n`;
+};

--- a/frontend/src/components/chat/interruptActions.ts
+++ b/frontend/src/components/chat/interruptActions.ts
@@ -1,0 +1,7 @@
+import type { InterruptAction } from '../../types';
+
+export type RenderableInterruptAction = InterruptAction & {
+  source: 'dynamic' | 'approval' | 'clarification-choice' | 'clarification-text';
+  legacyDecision?: 'approve' | 'edit' | 'reject';
+  choiceId?: string;
+};

--- a/frontend/src/components/markdown/MarkdownShared.tsx
+++ b/frontend/src/components/markdown/MarkdownShared.tsx
@@ -1,0 +1,488 @@
+/* eslint-disable react-refresh/only-export-components */
+import { Children, isValidElement, useEffect, useRef, useState, type ReactNode } from 'react';
+import mermaid from 'mermaid';
+import type { Components } from 'react-markdown';
+import { getWorkspaceFilePreview } from '../../services/fileApi';
+import PlotlyChart, { type PlotlySpec } from '../PlotlyChart';
+
+export type MermaidColorMode = 'light' | 'dark';
+
+type WorkspaceImagePreview = {
+  mimeType?: string | null;
+  encoding: 'text' | 'base64';
+  content: string;
+};
+
+type MarkdownComponentOptions = {
+  workspaceId?: string;
+  colorMode: MermaidColorMode;
+  codeBlockClassName?: string;
+  inlineCodeClassName?: string;
+  imageClassName?: string;
+  paragraphClassName?: string;
+  enablePlotly?: boolean;
+  codeBlockShell?: (args: {
+    blockId: string;
+    codeContent: string;
+    languageLabel: string;
+    className?: string;
+    children: ReactNode;
+  }) => ReactNode;
+};
+
+const BLOCK_LEVEL_TAGS = ['div', 'pre', 'table', 'blockquote', 'ul', 'ol', 'hr'];
+
+const buildMermaidTheme = (mode: MermaidColorMode) => (
+  mode === 'dark'
+    ? {
+        background: '#0f172a',
+        primaryColor: '#818cf8',
+        primaryBorderColor: '#6366f1',
+        primaryTextColor: '#e2e8f0',
+        secondaryColor: '#1e293b',
+        secondaryBorderColor: '#334155',
+        secondaryTextColor: '#cbd5e1',
+        tertiaryColor: '#111827',
+        tertiaryBorderColor: '#374151',
+        tertiaryTextColor: '#cbd5e1',
+        lineColor: '#94a3b8',
+        textColor: '#e2e8f0',
+        mainBkg: '#0b1220',
+        edgeLabelBackground: '#0b1220',
+        actorBorder: '#6366f1',
+        actorBkg: '#1e293b',
+        actorTextColor: '#e2e8f0',
+        labelBoxBkgColor: '#1e293b',
+        labelBoxBorderColor: '#334155',
+        gridColor: '#334155',
+        section0: '#1e293b',
+        section1: '#1f2937',
+        section2: '#0f172a',
+        sectionBkgColor: '#111827',
+        cScale0: '#818cf8',
+        cScale1: '#60a5fa',
+        cScale2: '#34d399',
+      }
+    : {
+        background: '#ffffff',
+        primaryColor: '#4f46e5',
+        primaryBorderColor: '#3730a3',
+        primaryTextColor: '#0f172a',
+        secondaryColor: '#dbeafe',
+        secondaryBorderColor: '#93c5fd',
+        secondaryTextColor: '#0f172a',
+        tertiaryColor: '#eef2ff',
+        tertiaryBorderColor: '#a5b4fc',
+        tertiaryTextColor: '#0f172a',
+        lineColor: '#334155',
+        textColor: '#0f172a',
+        mainBkg: '#ffffff',
+        edgeLabelBackground: '#f8fafc',
+        actorBorder: '#3730a3',
+        actorBkg: '#c7d2fe',
+        actorTextColor: '#0f172a',
+        labelBoxBkgColor: '#f8fafc',
+        labelBoxBorderColor: '#94a3b8',
+        gridColor: '#cbd5e1',
+        section0: '#e0e7ff',
+        section1: '#f1f5f9',
+        section2: '#e2e8f0',
+        sectionBkgColor: '#f8fafc',
+        cScale0: '#3730a3',
+        cScale1: '#1d4ed8',
+        cScale2: '#0f766e',
+      }
+);
+
+export const normalizeWorkspaceRelativePath = (rawPath: string) => (
+  String(rawPath || '')
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^\.\/+/, '')
+    .replace(/^\/+/, '')
+);
+
+export const getMermaidColorMode = (): MermaidColorMode => {
+  if (typeof document === 'undefined') {
+    return 'light';
+  }
+  const mode = document.documentElement.getAttribute('data-theme');
+  if (mode === 'dark' || mode === 'light') {
+    return mode;
+  }
+  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
+export const useMermaidColorMode = () => {
+  const [colorMode, setColorMode] = useState<MermaidColorMode>(() => getMermaidColorMode());
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return undefined;
+    }
+    const root = document.documentElement;
+    const observer = new MutationObserver(() => {
+      setColorMode(getMermaidColorMode());
+    });
+    observer.observe(root, { attributes: true, attributeFilter: ['data-theme'] });
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return colorMode;
+};
+
+export const configureMermaid = (mode: MermaidColorMode) => {
+  mermaid.initialize({
+    startOnLoad: false,
+    securityLevel: 'loose',
+    theme: 'base',
+    themeVariables: buildMermaidTheme(mode),
+    fontFamily: 'Inter, "Segoe UI", Arial, sans-serif',
+  });
+};
+
+export const extractCodeText = (value: ReactNode): string => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (Array.isArray(value)) {
+    return value.map((child) => extractCodeText(child)).join('');
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    return String(value);
+  }
+  return '';
+};
+
+export const inferInlineCode = (
+  inline: boolean | undefined,
+  className: string | undefined,
+  content: string,
+  node?: { position?: { start?: { line?: number }; end?: { line?: number } } }
+) => {
+  if (typeof inline === 'boolean') {
+    return inline;
+  }
+  const startLine = node?.position?.start?.line;
+  const endLine = node?.position?.end?.line;
+  if (typeof startLine === 'number' && typeof endLine === 'number' && endLine > startLine) {
+    return false;
+  }
+  if (className && /language-\w+/i.test(className)) {
+    return false;
+  }
+  if (content.includes('\n')) {
+    return false;
+  }
+  return true;
+};
+
+export const classifyCodeBlockLabel = (languageMatch: RegExpExecArray | null, content: string) => {
+  const language = languageMatch?.[1]?.toUpperCase();
+  if (language) {
+    return language;
+  }
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return 'TEXT';
+  }
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    return 'JSON';
+  }
+  if (/^(graph|flowchart|sequenceDiagram|classDiagram|erDiagram|journey|gantt|pie|mindmap|timeline|gitGraph|stateDiagram|quadrantChart|requirementDiagram|xychart-beta|block-beta)\b/i.test(trimmed)) {
+    return 'MERMAID';
+  }
+  return 'CODE';
+};
+
+const isExternalSource = (src: string) => /^(https?:|data:|blob:)/i.test(src);
+
+const MermaidFallback = ({ chart }: { chart: string }) => (
+  <pre className="my-4 overflow-x-auto rounded-xl bg-red-50 p-4 text-sm text-red-700">
+    {chart}
+  </pre>
+);
+
+export const MermaidDiagram = ({
+  chart,
+  colorMode,
+  className,
+  fallbackClassName,
+}: {
+  chart: string;
+  colorMode: MermaidColorMode;
+  className?: string;
+  fallbackClassName?: string;
+}) => {
+  const diagramRef = useRef<HTMLDivElement>(null);
+  const idRef = useRef(`mermaid-md-${Math.random().toString(36).slice(2, 11)}`);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const renderDiagram = async () => {
+      if (!diagramRef.current) {
+        return;
+      }
+      try {
+        setErrorMessage(null);
+        diagramRef.current.innerHTML = '';
+        configureMermaid(colorMode);
+        await mermaid.parse(chart);
+        const renderId = `${idRef.current}-${Date.now()}`;
+        const { svg } = await mermaid.render(renderId, chart);
+        if (!cancelled && diagramRef.current) {
+          diagramRef.current.innerHTML = svg;
+        }
+      } catch (error) {
+        console.error('Mermaid rendering error:', error);
+        if (!cancelled) {
+          setErrorMessage(error instanceof Error ? error.message : 'Unable to render Mermaid diagram.');
+        }
+      }
+    };
+
+    void renderDiagram();
+    return () => {
+      cancelled = true;
+    };
+  }, [chart, colorMode]);
+
+  if (errorMessage) {
+    return (
+      <div className={fallbackClassName}>
+        <p className="mb-2 text-sm font-medium text-red-600">
+          Unable to render Mermaid diagram.
+        </p>
+        <MermaidFallback chart={chart} />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={diagramRef}
+      className={className || `mermaid-container my-4 overflow-auto rounded-xl border p-4 ${colorMode === 'dark' ? 'border-slate-700 bg-slate-950' : 'border-gray-200 bg-white'}`}
+    />
+  );
+};
+
+export const WorkspaceMarkdownImage = ({
+  src,
+  alt,
+  workspaceId,
+  className,
+}: {
+  src?: string;
+  alt?: string;
+  workspaceId?: string;
+  className?: string;
+}) => {
+  const resolvedSrc = typeof src === 'string' ? src.trim() : '';
+  const [preview, setPreview] = useState<WorkspaceImagePreview | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!resolvedSrc || isExternalSource(resolvedSrc) || !workspaceId) {
+      setPreview(null);
+      setLoadError(null);
+      return undefined;
+    }
+
+    const loadPreview = async () => {
+      try {
+        setLoadError(null);
+        const data = await getWorkspaceFilePreview(workspaceId, normalizeWorkspaceRelativePath(resolvedSrc));
+        if (!cancelled) {
+          setPreview(data as WorkspaceImagePreview);
+        }
+      } catch (error) {
+        console.error('Failed to resolve markdown image path:', error);
+        if (!cancelled) {
+          setLoadError(resolvedSrc);
+          setPreview(null);
+        }
+      }
+    };
+
+    void loadPreview();
+    return () => {
+      cancelled = true;
+    };
+  }, [resolvedSrc, workspaceId]);
+
+  if (!resolvedSrc) {
+    return null;
+  }
+
+  if (isExternalSource(resolvedSrc)) {
+    return (
+      <img
+        className={className || 'max-w-full h-auto rounded-lg shadow-md'}
+        loading="lazy"
+        src={resolvedSrc}
+        alt={alt || 'Image'}
+      />
+    );
+  }
+
+  if (!workspaceId) {
+    return (
+      <span className="text-xs text-slate-500">
+        Image path: <code>{resolvedSrc}</code>
+      </span>
+    );
+  }
+
+  if (preview?.content) {
+    const previewSrc = preview.encoding === 'base64'
+      ? `data:${preview.mimeType || 'image/*'};base64,${preview.content}`
+      : preview.content;
+    return (
+      <img
+        className={className || 'max-w-full h-auto rounded-lg shadow-md'}
+        loading="lazy"
+        src={previewSrc}
+        alt={alt || 'Image'}
+      />
+    );
+  }
+
+  if (loadError) {
+    return (
+      <span className="text-xs text-rose-600">
+        Unable to load image: <code>{loadError}</code>
+      </span>
+    );
+  }
+
+  return <span className="text-xs text-slate-500">Loading image...</span>;
+};
+
+export const createMarkdownComponents = ({
+  workspaceId,
+  colorMode,
+  codeBlockClassName = 'my-4 overflow-x-auto rounded-xl bg-gray-900 p-4 text-sm text-gray-100',
+  inlineCodeClassName = 'inline-code rounded-md px-1.5 py-0.5 font-mono text-xs',
+  imageClassName = 'max-w-full h-auto rounded-lg shadow-md',
+  paragraphClassName = 'mb-4 last:mb-0',
+  enablePlotly = true,
+  codeBlockShell,
+}: MarkdownComponentOptions): Components => ({
+  p({ children }) {
+    const childArray = Children.toArray(children);
+    const containsBlockChild = childArray.some((child) => {
+      if (!isValidElement(child)) {
+        return false;
+      }
+      const childProps = child.props as {
+        inline?: boolean;
+        node?: { tagName?: string; position?: { start?: { line?: number }; end?: { line?: number } } };
+        className?: string;
+        children?: ReactNode;
+      };
+      if (typeof child.type === 'string') {
+        return BLOCK_LEVEL_TAGS.includes(child.type);
+      }
+      if (childProps.inline === false) {
+        return true;
+      }
+      if (childProps.node?.tagName && BLOCK_LEVEL_TAGS.includes(childProps.node.tagName)) {
+        return true;
+      }
+      if (childProps.node?.tagName === 'code') {
+        return !inferInlineCode(
+          childProps.inline,
+          childProps.className,
+          extractCodeText(childProps.children),
+          childProps.node
+        );
+      }
+      return false;
+    });
+    const Element: 'p' | 'div' = containsBlockChild ? 'div' : 'p';
+    return <Element className={paragraphClassName}>{children}</Element>;
+  },
+  img({ src, alt }) {
+    return (
+      <WorkspaceMarkdownImage
+        src={src}
+        alt={alt}
+        workspaceId={workspaceId}
+        className={imageClassName}
+      />
+    );
+  },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  code({ inline, className, children, node, ...props }: any) {
+    const codeContent = extractCodeText(children).replace(/\n$/, '');
+    const isInline = inferInlineCode(inline, className, codeContent, node);
+
+    if (isInline) {
+      return (
+        <code className={`${inlineCodeClassName} ${className || ''}`.trim()} {...props}>
+          {children}
+        </code>
+      );
+    }
+
+    const languageMatch = /language-(\w[\w-]*)/.exec(className || '');
+    const language = languageMatch?.[1]?.toLowerCase();
+
+    if (language === 'mermaid') {
+      return (
+        <MermaidDiagram
+          chart={codeContent}
+          colorMode={colorMode}
+          fallbackClassName="my-4"
+        />
+      );
+    }
+
+    if (enablePlotly && language === 'plotly') {
+      try {
+        const spec = JSON.parse(codeContent) as PlotlySpec;
+        if (!spec || typeof spec !== 'object' || !Array.isArray(spec.data)) {
+          throw new Error('Plotly spec must include a top-level "data" array.');
+        }
+        return (
+          <div className="my-4 overflow-hidden rounded-xl border border-gray-200 bg-white p-2">
+            <PlotlyChart spec={spec} minHeight={360} />
+          </div>
+        );
+      } catch (error) {
+        return (
+          <pre className="my-4 overflow-x-auto rounded-xl bg-red-50 p-4 text-sm text-red-700">
+            Invalid Plotly JSON: {error instanceof Error ? error.message : 'Unknown error'}
+          </pre>
+        );
+      }
+    }
+
+    const languageLabel = classifyCodeBlockLabel(languageMatch, codeContent);
+    const blockId = `${languageLabel}-${codeContent.length}-${codeContent.charCodeAt(0) || 0}`;
+
+    if (codeBlockShell) {
+      return codeBlockShell({
+        blockId,
+        codeContent,
+        languageLabel,
+        className,
+        children,
+      });
+    }
+
+    return (
+      <pre className={codeBlockClassName}>
+        <code className={`font-mono ${className || ''}`.trim()} {...props}>
+          {children}
+        </code>
+      </pre>
+    );
+  },
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -363,26 +363,6 @@ body {
   text-decoration: underline;
 }
 
-/* MDX editor toolbar polish (light theme) */
-.mdxeditor-root [role='toolbar'],
-.mdxeditor-root .mdxeditor-toolbar {
-  background: #f8fafc;
-  border-bottom: 1px solid #e2e8f0;
-}
-
-.mdxeditor-root [role='toolbar'] button,
-.mdxeditor-root [role='toolbar'] select,
-.mdxeditor-root .mdxeditor-toolbar button,
-.mdxeditor-root .mdxeditor-toolbar select {
-  color: #334155;
-  border-color: #e2e8f0;
-}
-
-.mdxeditor-root [role='toolbar'] button:hover,
-.mdxeditor-root .mdxeditor-toolbar button:hover {
-  background: #e2e8f0;
-}
-
 .inline-code {
   background: #f6f8fa;
   border: 1px solid #e2e8f0;
@@ -395,185 +375,208 @@ body {
   color: #e6edf3;
 }
 
-/* MDX editor dark theme tuning */
-:root[data-theme='dark'] .mdxeditor-root {
-  background: var(--surface);
-  color: #e6edf3;
-}
-
-:root[data-theme='dark'] .mdxeditor-root [contenteditable='true'] {
-  color: #e6edf3;
+.helpudoc-markdown {
+  color: #0f172a;
   line-height: 1.7;
 }
 
-:root[data-theme='dark'] .mdxeditor-root [contenteditable='true'] p,
-:root[data-theme='dark'] .mdxeditor-root [contenteditable='true'] li,
-:root[data-theme='dark'] .mdxeditor-root [contenteditable='true'] blockquote {
-  color: #e6edf3;
-}
-
-:root[data-theme='dark'] .mdxeditor-root [contenteditable='true'] h1,
-:root[data-theme='dark'] .mdxeditor-root [contenteditable='true'] h2 {
-  color: #9bbcff;
+.helpudoc-markdown h1,
+.helpudoc-markdown h2,
+.helpudoc-markdown h3,
+.helpudoc-markdown h4,
+.helpudoc-markdown h5,
+.helpudoc-markdown h6 {
+  color: #0f172a;
   font-weight: 700;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.02em;
+  margin-top: 1.4em;
+  margin-bottom: 0.6em;
 }
 
-:root[data-theme='dark'] .mdxeditor-root [contenteditable='true'] h3,
-:root[data-theme='dark'] .mdxeditor-root [contenteditable='true'] h4,
-:root[data-theme='dark'] .mdxeditor-root [contenteditable='true'] h5,
-:root[data-theme='dark'] .mdxeditor-root [contenteditable='true'] h6 {
-  color: #a9c3ff;
-  font-weight: 600;
+.helpudoc-markdown h1 {
+  font-size: 2.25rem;
+  line-height: 1.1;
 }
 
-:root[data-theme='dark'] .mdxeditor-root [contenteditable='true'] code {
-  background: #2d333b;
-  border: 1px solid #3a4350;
-  color: #e6edf3;
+.helpudoc-markdown h2 {
+  font-size: 1.875rem;
+  line-height: 1.15;
+}
+
+.helpudoc-markdown h3 {
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+.helpudoc-markdown h4 {
+  font-size: 1.25rem;
+  line-height: 1.3;
+}
+
+.helpudoc-markdown h5 {
+  font-size: 1.125rem;
+  line-height: 1.35;
+}
+
+.helpudoc-markdown h6 {
+  font-size: 1rem;
+  line-height: 1.4;
+  letter-spacing: 0;
+}
+
+.helpudoc-markdown p,
+.helpudoc-markdown li,
+.helpudoc-markdown td,
+.helpudoc-markdown th {
+  color: inherit;
+}
+
+.helpudoc-markdown pre {
+  background: #0f172a;
+  border: 1px solid #1e293b;
+  border-radius: 16px;
+  padding: 1rem 1.125rem;
+  color: #e2e8f0;
+}
+
+.helpudoc-markdown pre code {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: inherit;
+}
+
+.helpudoc-markdown code {
+  background: #f8fafc;
+  border: 1px solid #dbe4f0;
+  color: #1e293b;
   font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
   padding: 0.1rem 0.35rem;
   border-radius: 6px;
   font-size: 0.85em;
 }
 
-:root[data-theme='dark'] .mdxeditor-root [contenteditable='true'] pre {
-  background: #0b1220;
-  border: 1px solid #1f2937;
-  border-radius: 12px;
-  padding: 0.75rem 1rem;
+.helpudoc-markdown blockquote {
+  border-left: 4px solid #cbd5e1;
+  color: #475569;
 }
 
-:root[data-theme='dark'] .mdxeditor-root [contenteditable='true'] pre code {
-  background: transparent;
-  border: none;
-  padding: 0;
-  font-size: 0.9em;
+.helpudoc-markdown hr,
+.helpudoc-markdown table,
+.helpudoc-markdown thead,
+.helpudoc-markdown tbody tr {
+  border-color: #e2e8f0;
 }
 
-:root[data-theme='dark'] .mdxeditor-root [role='toolbar'],
-:root[data-theme='dark'] .mdxeditor-root .mdxeditor-toolbar {
-  background: rgba(15, 23, 42, 0.92);
-  border-bottom: 1px solid #1f2937;
-  backdrop-filter: blur(8px);
+.helpudoc-markdown img {
+  margin: 0.75rem 0;
 }
 
-:root[data-theme='dark'] .mdxeditor-root [role='toolbar'] button,
-:root[data-theme='dark'] .mdxeditor-root [role='toolbar'] select,
-:root[data-theme='dark'] .mdxeditor-root .mdxeditor-toolbar button,
-:root[data-theme='dark'] .mdxeditor-root .mdxeditor-toolbar select {
+.helpudoc-markdown-editor {
+  min-height: 100%;
+  padding: 1.25rem;
+}
+
+.helpudoc-mdxeditor-shell {
+  background: #fff;
+}
+
+.helpudoc-mdxeditor {
+  background: #fff;
+  color: #0f172a;
+}
+
+.helpudoc-mdxeditor .mdxeditor-toolbar,
+.helpudoc-mdxeditor [role='toolbar'] {
+  background: #f8fafc;
+  border-bottom: 1px solid #e2e8f0;
+  padding: 0.5rem 0.75rem;
+}
+
+.helpudoc-mdxeditor .mdxeditor-toolbar button,
+.helpudoc-mdxeditor .mdxeditor-toolbar select,
+.helpudoc-mdxeditor [role='toolbar'] button,
+.helpudoc-mdxeditor [role='toolbar'] select {
+  color: #334155;
+  border-color: #dbe4f0;
+}
+
+.helpudoc-mdxeditor .mdxeditor-toolbar button:hover,
+.helpudoc-mdxeditor [role='toolbar'] button:hover {
+  background: #e2e8f0;
+}
+
+.helpudoc-mdxeditor .mdxeditor-toolbar button[aria-pressed='true'],
+.helpudoc-mdxeditor [role='toolbar'] button[aria-pressed='true'] {
+  background: #dbeafe;
+}
+
+:root[data-theme='dark'] .helpudoc-markdown {
   color: #e6edf3;
-  border-color: #263245;
 }
 
-:root[data-theme='dark'] .mdxeditor-root [role='toolbar'] button:hover,
-:root[data-theme='dark'] .mdxeditor-root .mdxeditor-toolbar button:hover {
-  background: #1f2937;
-}
-
-:root[data-theme='dark'] .mdxeditor-root [role='toolbar'] button[aria-pressed='true'],
-:root[data-theme='dark'] .mdxeditor-root .mdxeditor-toolbar button[aria-pressed='true'] {
-  background: #26334a;
-}
-
-:root[data-theme='dark'] .mdxeditor-root [role='toolbar'] svg,
-:root[data-theme='dark'] .mdxeditor-root .mdxeditor-toolbar svg {
-  color: #e6edf3;
-}
-
-/* Prose (ReactMarkdown) dark mode styles for FileRenderer */
-:root[data-theme='dark'] .prose {
-  color: #e6edf3;
-}
-
-:root[data-theme='dark'] .prose h1,
-:root[data-theme='dark'] .prose h2 {
+:root[data-theme='dark'] .helpudoc-markdown h1,
+:root[data-theme='dark'] .helpudoc-markdown h2 {
   color: #9bbcff;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  border-bottom-color: #1f2937;
 }
 
-:root[data-theme='dark'] .prose h3,
-:root[data-theme='dark'] .prose h4,
-:root[data-theme='dark'] .prose h5,
-:root[data-theme='dark'] .prose h6 {
-  color: #a9c3ff;
-  font-weight: 600;
+:root[data-theme='dark'] .helpudoc-markdown h3,
+:root[data-theme='dark'] .helpudoc-markdown h4,
+:root[data-theme='dark'] .helpudoc-markdown h5,
+:root[data-theme='dark'] .helpudoc-markdown h6 {
+  color: #bfd2ff;
 }
 
-:root[data-theme='dark'] .prose p,
-:root[data-theme='dark'] .prose li,
-:root[data-theme='dark'] .prose td,
-:root[data-theme='dark'] .prose th {
-  color: #e6edf3;
-}
-
-:root[data-theme='dark'] .prose strong {
-  color: #f0f6fc;
-  font-weight: 600;
-}
-
-:root[data-theme='dark'] .prose em {
-  color: #e6edf3;
-}
-
-:root[data-theme='dark'] .prose a {
-  color: #58a6ff;
-  text-decoration: underline;
-}
-
-:root[data-theme='dark'] .prose a:hover {
-  color: #79c0ff;
-}
-
-:root[data-theme='dark'] .prose code {
+:root[data-theme='dark'] .helpudoc-markdown code {
   background: #2d333b;
-  border: 1px solid #3a4350;
+  border-color: #3a4350;
   color: #e6edf3;
-  font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-  padding: 0.1rem 0.35rem;
-  border-radius: 6px;
-  font-size: 0.85em;
 }
 
-:root[data-theme='dark'] .prose pre {
+:root[data-theme='dark'] .helpudoc-markdown pre {
   background: #0b1220;
-  border: 1px solid #1f2937;
-  border-radius: 12px;
-  padding: 0.75rem 1rem;
+  border-color: #1f2937;
 }
 
-:root[data-theme='dark'] .prose pre code {
-  background: transparent;
-  border: none;
-  padding: 0;
-  font-size: 0.9em;
-  color: #e6edf3;
-}
-
-:root[data-theme='dark'] .prose blockquote {
+:root[data-theme='dark'] .helpudoc-markdown blockquote {
   border-left-color: #3a4350;
   color: #cbd5e1;
 }
 
-:root[data-theme='dark'] .prose hr {
+:root[data-theme='dark'] .helpudoc-markdown hr,
+:root[data-theme='dark'] .helpudoc-markdown table,
+:root[data-theme='dark'] .helpudoc-markdown thead,
+:root[data-theme='dark'] .helpudoc-markdown tbody tr {
   border-color: #1f2937;
 }
 
-:root[data-theme='dark'] .prose table {
-  border-color: #1f2937;
+:root[data-theme='dark'] .helpudoc-mdxeditor-shell,
+:root[data-theme='dark'] .helpudoc-mdxeditor {
+  background: #0f172a;
+  color: #e6edf3;
 }
 
-:root[data-theme='dark'] .prose thead {
+:root[data-theme='dark'] .helpudoc-mdxeditor .mdxeditor-toolbar,
+:root[data-theme='dark'] .helpudoc-mdxeditor [role='toolbar'] {
+  background: rgba(15, 23, 42, 0.92);
   border-bottom-color: #1f2937;
+  backdrop-filter: blur(8px);
 }
 
-:root[data-theme='dark'] .prose tbody tr {
-  border-bottom-color: #1f2937;
+:root[data-theme='dark'] .helpudoc-mdxeditor .mdxeditor-toolbar button,
+:root[data-theme='dark'] .helpudoc-mdxeditor .mdxeditor-toolbar select,
+:root[data-theme='dark'] .helpudoc-mdxeditor [role='toolbar'] button,
+:root[data-theme='dark'] .helpudoc-mdxeditor [role='toolbar'] select {
+  color: #e6edf3;
+  border-color: #263245;
 }
 
-:root[data-theme='dark'] .prose ul > li::marker,
-:root[data-theme='dark'] .prose ol > li::marker {
-  color: #94a3b8;
+:root[data-theme='dark'] .helpudoc-mdxeditor .mdxeditor-toolbar button:hover,
+:root[data-theme='dark'] .helpudoc-mdxeditor [role='toolbar'] button:hover {
+  background: #1f2937;
+}
+
+:root[data-theme='dark'] .helpudoc-mdxeditor .mdxeditor-toolbar button[aria-pressed='true'],
+:root[data-theme='dark'] .helpudoc-mdxeditor [role='toolbar'] button[aria-pressed='true'] {
+  background: #26334a;
 }

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -12,10 +12,11 @@ import {
 import { CheckSquare, Copy, Edit, Trash, Plus, Minus, ChevronLeft, RotateCcw, X, Printer, Download, Link as LinkIcon, Loader2 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { getWorkspaces, createWorkspace, deleteWorkspace } from '../services/workspaceApi';
+import { getWorkspaces, createWorkspace, deleteWorkspace, updateWorkspaceSettings } from '../services/workspaceApi';
 import {
   getFiles,
   createFile,
+  createTextFile,
   updateFileContent,
   deleteFile,
   getFileContent,
@@ -58,6 +59,7 @@ import FileEditor from '../components/FileEditor';
 import UIBlockRenderer, { type UIBlock } from '../components/UIBlockRenderer';
 import ExpandableSidebar from '../components/ExpandableSidebar';
 import AgentChatPane from '../components/chat/AgentChatPane';
+import { buildApprovalDraftContent, buildApprovalReview } from '../components/chat/approvalReview';
 import type { RenderableInterruptAction } from '../components/chat/interruptActions';
 import ToolOutputFilePreview from '../components/chat/ToolOutputFilePreview';
 import { useAuth } from '../auth/AuthProvider';
@@ -185,6 +187,17 @@ const generateTurnId = () => {
   return `turn-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 };
 
+const DEFAULT_PLAN_FILE_PATH = 'research_plan.md';
+
+const normalizeWorkspaceRelativePath = (value?: string): string =>
+  String(value || '')
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .trim();
+
+const isDraftWorkspaceFile = (file?: WorkspaceFile | null): boolean =>
+  Boolean(file && typeof file.id === 'string' && String(file.id).startsWith('draft:'));
+
 const mergePersistedAgentMessage = (
   persisted: ConversationMessage,
   existing?: ConversationMessage | null,
@@ -251,6 +264,7 @@ export default function WorkspacePage() {
   });
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [selectedWorkspace, setSelectedWorkspace] = useState<Workspace | null>(null);
+  const [workspaceSettingsBusy, setWorkspaceSettingsBusy] = useState(false);
   const [files, setFiles] = useState<WorkspaceFile[]>([]);
   const [selectedFile, setSelectedFile] = useState<WorkspaceFile | null>(null);
   const [selectedFileDetails, setSelectedFileDetails] = useState<WorkspaceFile | null>(null);
@@ -1058,6 +1072,20 @@ export default function WorkspacePage() {
 
   const handleDeleteSingleFile = async (file: WorkspaceFile) => {
     if (!selectedWorkspace) return;
+    if (isDraftWorkspaceFile(file)) {
+      setFiles((prev) => prev.filter((item) => item.id !== file.id));
+      setSelectedFiles((prev) => {
+        const next = new Set(prev);
+        next.delete(file.id);
+        return next;
+      });
+      if (selectedFile?.id === file.id) {
+        setSelectedFile(null);
+        setSelectedFileDetails(null);
+        setFileContent('');
+      }
+      return;
+    }
     const confirmed = window.confirm(`Delete ${file.name}?`);
     if (!confirmed) return;
 
@@ -1683,6 +1711,45 @@ export default function WorkspacePage() {
     fetchWorkspaces();
   }, []);
 
+  const applyWorkspacePlanApprovalSetting = useCallback((workspaceId: string, skipPlanApprovals: boolean) => {
+    setWorkspaces((prev) => prev.map((workspace) => (
+      workspace.id === workspaceId ? { ...workspace, skipPlanApprovals } : workspace
+    )));
+    setSelectedWorkspace((prev) => (
+      prev && prev.id === workspaceId ? { ...prev, skipPlanApprovals } : prev
+    ));
+  }, []);
+
+  const handleUpdateWorkspacePlanApprovalSetting = useCallback(
+    async (skipPlanApprovals: boolean, requireConfirm = false) => {
+      if (!selectedWorkspace || workspaceSettingsBusy) {
+        return false;
+      }
+      if (
+        skipPlanApprovals &&
+        requireConfirm &&
+        !window.confirm(
+          'Enable trusted mode for this workspace and skip future plan approvals? You can turn approvals back on from the workspace sidebar.',
+        )
+      ) {
+        return false;
+      }
+      try {
+        setWorkspaceSettingsBusy(true);
+        const settings = await updateWorkspaceSettings(selectedWorkspace.id, { skipPlanApprovals });
+        applyWorkspacePlanApprovalSetting(selectedWorkspace.id, Boolean(settings.skipPlanApprovals));
+        return true;
+      } catch (error) {
+        console.error('Failed to update workspace settings', error);
+        addLocalSystemMessage('Unable to update workspace approval preferences right now.');
+        return false;
+      } finally {
+        setWorkspaceSettingsBusy(false);
+      }
+    },
+    [addLocalSystemMessage, applyWorkspacePlanApprovalSetting, selectedWorkspace, workspaceSettingsBusy],
+  );
+
   useEffect(() => {
     if (selectedWorkspace) {
       loadFilesForWorkspace(selectedWorkspace.id);
@@ -1694,8 +1761,59 @@ export default function WorkspacePage() {
     }
   };
 
+  const openPlanApprovalEditor = useCallback((
+    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  ) => {
+    if (!selectedWorkspace) {
+      return;
+    }
+    const actionRequests = Array.isArray(pendingInterrupt?.actionRequests) ? pendingInterrupt.actionRequests : [];
+    const review = buildApprovalReview(pendingInterrupt, actionRequests[0]);
+    const targetPath = normalizeWorkspaceRelativePath(review?.planFilePath || DEFAULT_PLAN_FILE_PATH) || DEFAULT_PLAN_FILE_PATH;
+    const existingFile = files.find((file) => normalizeWorkspaceRelativePath(file.name || file.path) === targetPath);
+    setIsAgentPaneVisible(true);
+    setIsFilePaneVisible(true);
+    setCanvasZoom(1);
+    setIsEditMode(true);
+
+    if (existingFile) {
+      setSelectedFile(existingFile);
+      setSelectedFileDetails(null);
+      setFileContent('');
+      return;
+    }
+
+    const draftContent = buildApprovalDraftContent(review);
+    const draftFile: WorkspaceFile = {
+      id: `draft:${targetPath}`,
+      name: targetPath,
+      path: targetPath,
+      workspaceId: selectedWorkspace.id,
+      storageType: 'local',
+      mimeType: 'text/markdown',
+      content: draftContent,
+    };
+    setFiles((prev) => {
+      if (prev.some((file) => String(file.id) === draftFile.id)) {
+        return prev;
+      }
+      return [draftFile, ...prev];
+    });
+    setSelectedFile(draftFile);
+    setSelectedFileDetails(draftFile);
+    setFileContent(draftContent);
+    lastAutoSavedContentRef.current = draftContent;
+  }, [files, selectedWorkspace]);
+
   const fetchFileContent = async () => {
     if (selectedFile && selectedWorkspace) {
+      if (isDraftWorkspaceFile(selectedFile)) {
+        const draftContent = selectedFile.content || '';
+        setSelectedFileDetails(selectedFile);
+        setFileContent(draftContent);
+        lastAutoSavedContentRef.current = draftContent;
+        return;
+      }
       try {
         const fileWithContent = await getFileContent(selectedWorkspace.id, selectedFile.id);
         setSelectedFileDetails(fileWithContent);
@@ -2635,6 +2753,13 @@ export default function WorkspacePage() {
       const messageKey = String(message.id);
       const primaryAction = getPrimaryInterruptAction(pendingInterrupt);
       const isPlanApproval = isPlanApprovalInterrupt(pendingInterrupt);
+      const approvalReview = isPlanApproval ? buildApprovalReview(pendingInterrupt, primaryAction) : null;
+      const approvalPlanPath = normalizeWorkspaceRelativePath(approvalReview?.planFilePath || DEFAULT_PLAN_FILE_PATH);
+      const activeEditorPath = normalizeWorkspaceRelativePath(selectedFile?.name || selectedFile?.path);
+      const editedPlanContent =
+        isPlanApproval && approvalPlanPath && activeEditorPath === approvalPlanPath
+          ? fileContent.trim()
+          : '';
       const feedbackKey = isPlanApproval
         ? interruptFieldKey(messageKey, 'feedback')
         : interruptFieldKey(messageKey, 'reject-note');
@@ -2665,6 +2790,8 @@ export default function WorkspacePage() {
               args: {
                 ...originalArgs,
                 reviewer_feedback: rawFeedback,
+                plan_file_path: approvalPlanPath || DEFAULT_PLAN_FILE_PATH,
+                ...(editedPlanContent ? { edited_plan_content: editedPlanContent } : {}),
               },
             };
             options.message = rawFeedback || 'User requested edits.';
@@ -2736,12 +2863,14 @@ export default function WorkspacePage() {
     },
     [
       addLocalSystemMessage,
+      fileContent,
       interruptInputByMessageId,
       interruptFieldKey,
       findRunIdForMessage,
       getPrimaryInterruptAction,
       getAllowedDecisions,
       isPlanApprovalInterrupt,
+      selectedFile,
       rebuildRunInfoForMessage,
       markRunStreamLaunching,
       registerActiveRun,
@@ -3011,6 +3140,16 @@ export default function WorkspacePage() {
       updateMessagesForConversation,
     ],
   );
+
+  const prepareInterruptAction = useCallback((
+    _message: ConversationMessage,
+    action: RenderableInterruptAction,
+    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  ) => {
+    if (action.source === 'approval' && action.legacyDecision === 'edit' && isPlanApprovalInterrupt(pendingInterrupt)) {
+      openPlanApprovalEditor(pendingInterrupt);
+    }
+  }, [isPlanApprovalInterrupt, openPlanApprovalEditor]);
 
   useEffect(() => {
     if (!activeConversationId) {
@@ -3864,20 +4003,38 @@ export default function WorkspacePage() {
     }
   };
 
-  const handleUpdateFile = useCallback(async (id: number, content: string) => {
-    if (!selectedWorkspace) return;
+  const handleUpdateFile = useCallback(async (targetFile: WorkspaceFile | null, content: string) => {
+    if (!selectedWorkspace || !targetFile) return;
 
     try {
-      await updateFileContent(selectedWorkspace.id, id, content);
+      if (isDraftWorkspaceFile(targetFile)) {
+        const createdFile = await createTextFile(selectedWorkspace.id, {
+          name: targetFile.name,
+          content,
+          mimeType: targetFile.mimeType || 'text/markdown',
+        });
+        setFiles((prev) => {
+          const withoutDraft = prev.filter((file) => String(file.id) !== String(targetFile.id));
+          return [createdFile, ...withoutDraft];
+        });
+        const hydratedCreatedFile = {
+          ...createdFile,
+          content,
+        };
+        setSelectedFile(hydratedCreatedFile);
+        setSelectedFileDetails(hydratedCreatedFile);
+      } else {
+        await updateFileContent(selectedWorkspace.id, Number(targetFile.id), content);
+        setSelectedFileDetails((prev) => (prev ? { ...prev, content } : prev));
+      }
       lastAutoSavedContentRef.current = content;
-      // Optionally, you can refetch the file or update it in the state
     } catch (error) {
       console.error('Failed to update file:', error);
     }
   }, [selectedWorkspace]);
 
   useEffect(() => {
-    if (!isEditMode || !selectedWorkspace || !selectedFile) return;
+    if (!isEditMode || !selectedWorkspace || !selectedFile || isDraftWorkspaceFile(selectedFile)) return;
 
     if (autoSaveTimerRef.current) {
       window.clearTimeout(autoSaveTimerRef.current);
@@ -3887,7 +4044,7 @@ export default function WorkspacePage() {
       if (fileContent === lastAutoSavedContentRef.current) {
         return;
       }
-      await handleUpdateFile(Number(selectedFile.id), fileContent);
+      await handleUpdateFile(selectedFile, fileContent);
       lastAutoSavedContentRef.current = fileContent;
     }, 2000);
 
@@ -3910,6 +4067,9 @@ export default function WorkspacePage() {
 
     try {
       for (const fileId of selectedFiles) {
+        if (String(fileId).startsWith('draft:')) {
+          continue;
+        }
         await deleteFile(selectedWorkspace.id, fileId);
       }
       setFiles((prevFiles) =>
@@ -4035,6 +4195,10 @@ export default function WorkspacePage() {
           colorMode={colorMode}
           onToggleColorMode={toggleColorMode}
           onSignOut={handleSignOut}
+          onToggleSkipPlanApprovals={(checked) => {
+            void handleUpdateWorkspacePlanApprovalSetting(checked, checked);
+          }}
+          workspaceSettingsBusy={workspaceSettingsBusy}
         />
         <Box
           component="main"
@@ -4217,7 +4381,7 @@ export default function WorkspacePage() {
                             </div>
                             {!isPendingJob && (
                               <div className={`shrink-0 items-center gap-1 ml-1 ${hoveredFileId === file.id ? 'flex' : 'hidden group-hover:flex'}`}>
-                                {file.publicUrl && (
+                                {file.publicUrl && !isDraftWorkspaceFile(file) && (
                                   <button
                                     type="button"
                                     onClick={(event) => {
@@ -4230,17 +4394,19 @@ export default function WorkspacePage() {
                                     <LinkIcon size={14} className="text-gray-600" />
                                   </button>
                                 )}
-                                <button
-                                  type="button"
-                                  onClick={(event) => {
-                                    event.stopPropagation();
-                                    handleRenameFile(file);
-                                  }}
-                                  className="p-1 rounded hover:bg-gray-200"
-                                  title="Rename"
-                                >
-                                  <Edit size={14} className="text-gray-600" />
-                                </button>
+                                {!isDraftWorkspaceFile(file) ? (
+                                  <button
+                                    type="button"
+                                    onClick={(event) => {
+                                      event.stopPropagation();
+                                      handleRenameFile(file);
+                                    }}
+                                    className="p-1 rounded hover:bg-gray-200"
+                                    title="Rename"
+                                  >
+                                    <Edit size={14} className="text-gray-600" />
+                                  </button>
+                                ) : null}
                                 <button
                                   type="button"
                                   onClick={(event) => {
@@ -4335,7 +4501,7 @@ export default function WorkspacePage() {
                       )}
                       <button
                         className="h-9 px-3 inline-flex items-center justify-center rounded-lg text-sm font-medium text-slate-700 hover:bg-gray-200 disabled:opacity-50"
-                        onClick={() => selectedFile && handleUpdateFile(Number(selectedFile.id), fileContent)}
+                        onClick={() => selectedFile && handleUpdateFile(selectedFile, fileContent)}
                         disabled={!isEditMode}
                       >
                         Save
@@ -4452,6 +4618,8 @@ export default function WorkspacePage() {
               getPrimaryInterruptAction={getPrimaryInterruptAction}
               isPlanApprovalInterrupt={isPlanApprovalInterrupt}
               setInterruptInputByMessageId={setInterruptInputByMessageId}
+              workspaceSkipPlanApprovals={Boolean(selectedWorkspace?.skipPlanApprovals)}
+              workspaceSettingsBusy={workspaceSettingsBusy}
               onToggleAgentPaneVisibility={() => setIsAgentPaneVisible((prev) => !prev)}
               onModeChange={handleModeChange}
               onToggleHistory={() => setIsHistoryOpen((prev) => !prev)}
@@ -4464,7 +4632,9 @@ export default function WorkspacePage() {
               onToggleToolActivityVisibility={toggleToolActivityVisibility}
               onCopyMessageText={handleCopyMessageText}
               onRerunMessage={handleRerunMessage}
+              onPrepareInterruptAction={prepareInterruptAction}
               onInterruptAction={handleInterruptAction}
+              onEnableTrustedPlanMode={() => handleUpdateWorkspacePlanApprovalSetting(true, true)}
               onChatInputChange={handleChatInputChange}
               onChatInputKeyDown={handleChatInputKeyDown}
               onChatInputKeyUp={handleChatInputKeyUp}

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -222,8 +222,16 @@ const mergePersistedAgentMessage = (
           : undefined,
   };
 
+  const persistedText = typeof hydrated.text === 'string' ? hydrated.text : '';
+  const existingText = typeof existing?.text === 'string' ? existing.text : '';
+  const mergedText =
+    persistedText.trim().length > 0 || !existingText.trim().length
+      ? persistedText
+      : existingText;
+
   return {
     ...hydrated,
+    text: mergedText,
     thinkingText: hydrated.thinkingText ?? existing?.thinkingText,
     toolEvents: hydrated.toolEvents ?? existing?.toolEvents,
     metadata: Object.keys(mergedMetadata).length ? mergedMetadata : undefined,

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -355,9 +355,16 @@ export default function WorkspacePage() {
     () => (activeConversationId ? conversationMessages[activeConversationId] || [] : []),
     [activeConversationId, conversationMessages],
   );
+  const hasRunningAgentMessage = useMemo(
+    () =>
+      messages.some(
+        (message) => message.sender === 'agent' && message.metadata?.status === 'running',
+      ),
+    [messages],
+  );
   const isStreaming = useMemo(
-    () => (activeConversationId ? conversationStreaming[activeConversationId] || false : false),
-    [activeConversationId, conversationStreaming],
+    () => (activeConversationId ? conversationStreaming[activeConversationId] || false : false) || hasRunningAgentMessage,
+    [activeConversationId, conversationStreaming, hasRunningAgentMessage],
   );
   const systemFiles = useMemo(() => files.filter(isSystemFile), [files]);
   const visibleFiles = useMemo(
@@ -2726,7 +2733,7 @@ export default function WorkspacePage() {
   };
 
   const streamRunForConversation = useCallback(
-    async (runInfo: ActiveRunInfo, replayFromStart = false) => {
+    async (runInfo: ActiveRunInfo, replayFromStart = false, resumeAfterId?: string) => {
       const { conversationId, runId, turnId, placeholderId } = runInfo;
       // Mark the run as actively handled before any state updates land so the
       // resume effect does not start a second stream for the same run.
@@ -2751,6 +2758,7 @@ export default function WorkspacePage() {
       streamAbortMapRef.current.set(conversationId, controller);
       setStreamingForConversation(conversationId, true);
       let finalStatus: AgentRunStatus = 'completed';
+      let lastStreamId = resumeAfterId || runInfo.lastStreamId;
       let latestInterrupt:
         | ConversationMessageMetadata['pendingInterrupt']
         | undefined;
@@ -2762,6 +2770,10 @@ export default function WorkspacePage() {
         await streamAgentRun(
           runId,
           (chunk) => {
+            const resumableChunk = chunk as AgentStreamChunk & { id?: string };
+            if (typeof resumableChunk.id === 'string') {
+              lastStreamId = resumableChunk.id;
+            }
             if (chunk.type === 'interrupt') {
               latestInterrupt = {
                 kind: chunk.kind,
@@ -2780,7 +2792,7 @@ export default function WorkspacePage() {
             handleStreamChunk(conversationId, agentMessageIndex, chunk, runId);
           },
           controller.signal,
-          replayFromStart ? undefined : undefined
+          replayFromStart ? undefined : (resumeAfterId || runInfo.lastStreamId)
         );
       } catch (error) {
         const supersededByNewerStream = streamAbortMapRef.current.get(conversationId) !== controller;
@@ -2846,6 +2858,25 @@ export default function WorkspacePage() {
         }
         flushBufferedAgentChunks();
         if (supersededByNewerStream) {
+          return;
+        }
+        if (finalStatus === 'running' || finalStatus === 'queued') {
+          const resumedRunInfo: ActiveRunInfo = {
+            ...runInfo,
+            status: 'running',
+            lastStreamId,
+          };
+          registerActiveRun(resumedRunInfo);
+          if (streamAbortMapRef.current.get(conversationId) === controller) {
+            streamAbortMapRef.current.delete(conversationId);
+          }
+          window.setTimeout(() => {
+            const activeRun = activeRunsRef.current[runId];
+            if (!activeRun || activeRun.status !== 'running') {
+              return;
+            }
+            void streamRunForConversation(activeRun, false, activeRun.lastStreamId);
+          }, 300);
           return;
         }
         await persistAgentProgress(

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -2287,7 +2287,13 @@ export default function WorkspacePage() {
   );
 
   const persistAgentProgress = useCallback(
-    async (runInfo: ActiveRunInfo, statusOverride?: AgentRunStatus) => {
+    async (
+      runInfo: ActiveRunInfo,
+      statusOverride?: AgentRunStatus,
+      options?: {
+        metadataOverride?: Partial<ConversationMessageMetadata>;
+      },
+    ) => {
       const { runId, conversationId, turnId, placeholderId } = runInfo;
       if (persistInFlightRef.current.has(runId)) {
         return;
@@ -2297,7 +2303,12 @@ export default function WorkspacePage() {
       const lastText = lastPersistedAgentTextRef.current[runId];
       const nextStatus = statusOverride || message?.metadata?.status || runInfo.status || 'running';
       const lastStatus = lastPersistedStatusRef.current[runId];
-      const metadata = { ...(buildMessageMetadata(message) || {}), runId, status: nextStatus };
+      const metadata = {
+        ...(buildMessageMetadata(message) || {}),
+        ...(options?.metadataOverride || {}),
+        runId,
+        status: nextStatus,
+      } satisfies ConversationMessageMetadata;
       const metadataSignature = JSON.stringify(metadata);
       const lastMetadataSignature = lastPersistedMetadataRef.current[runId];
       if (text === lastText && nextStatus === lastStatus && metadataSignature === lastMetadataSignature) {
@@ -2807,6 +2818,16 @@ export default function WorkspacePage() {
               }
             }
           }
+          if (finalStatus === 'awaiting_approval' && !latestRunMeta?.pendingInterrupt && !latestInterrupt) {
+            for (let attempt = 0; attempt < 8; attempt += 1) {
+              await new Promise((resolve) => window.setTimeout(resolve, 250));
+              latestRunMeta = await getRunStatus(runId);
+              finalStatus = latestRunMeta.status;
+              if (latestRunMeta.pendingInterrupt) {
+                break;
+              }
+            }
+          }
         } catch (statusError) {
           console.error('Failed to fetch final run status', statusError);
         }
@@ -2827,7 +2848,17 @@ export default function WorkspacePage() {
         if (supersededByNewerStream) {
           return;
         }
-        await persistAgentProgress({ ...runInfo, status: finalStatus }, finalStatus);
+        await persistAgentProgress(
+          { ...runInfo, status: finalStatus },
+          finalStatus,
+          effectivePendingInterrupt
+            ? {
+                metadataOverride: {
+                  pendingInterrupt: effectivePendingInterrupt,
+                },
+              }
+            : undefined,
+        );
         setStreamingForConversation(conversationId, false);
         if (streamAbortMapRef.current.get(conversationId) === controller) {
           streamAbortMapRef.current.delete(conversationId);

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -28,6 +28,7 @@ import {
   getRunStatus,
   startAgentRun,
   streamAgentRun,
+  submitRunAction,
   submitRunDecision,
   submitRunResponse,
   type AgentRunStatus,
@@ -50,12 +51,14 @@ import type {
   ToolEvent,
   ToolOutputFile,
   ConversationMessageMetadata,
+  InterruptAction,
 } from '../types';
 import CollapsibleDrawer from '../components/CollapsibleDrawer';
 import FileEditor from '../components/FileEditor';
 import UIBlockRenderer, { type UIBlock } from '../components/UIBlockRenderer';
 import ExpandableSidebar from '../components/ExpandableSidebar';
 import AgentChatPane from '../components/chat/AgentChatPane';
+import type { RenderableInterruptAction } from '../components/chat/interruptActions';
 import ToolOutputFilePreview from '../components/chat/ToolOutputFilePreview';
 import { useAuth } from '../auth/AuthProvider';
 import {
@@ -324,6 +327,7 @@ export default function WorkspacePage() {
   const [interruptInputByMessageId, setInterruptInputByMessageId] = useState<Record<string, string>>({});
   const [interruptSelectedChoicesByMessageId, setInterruptSelectedChoicesByMessageId] = useState<Record<string, string[]>>({});
   const [interruptSubmittingByMessageId, setInterruptSubmittingByMessageId] = useState<Record<string, boolean>>({});
+  const [interruptErrorByMessageId, setInterruptErrorByMessageId] = useState<Record<string, string>>({});
   const ragStatusFetchedRef = useRef<Record<string, boolean>>({});
   const resumeInFlightRef = useRef<Set<string>>(new Set());
   const resumeAttemptedRef = useRef<Set<string>>(new Set());
@@ -424,6 +428,19 @@ export default function WorkspacePage() {
     const sameConversationRun = runs.find((run) => run.conversationId === message.conversationId);
     return sameConversationRun?.runId;
   }, []);
+
+  const rebuildRunInfoForMessage = useCallback(async (message: ConversationMessage, runId: string): Promise<ActiveRunInfo> => {
+    const status = await getRunStatus(runId);
+    return {
+      runId,
+      conversationId: message.conversationId,
+      workspaceId: status.workspaceId,
+      persona: status.persona,
+      turnId: message.turnId || status.turnId || generateTurnId(),
+      placeholderId: message.id,
+      status: status.status,
+    };
+  }, [getRunStatus]);
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', colorMode);
@@ -2155,26 +2172,126 @@ export default function WorkspacePage() {
     field: 'feedback' | 'edit-json' | 'reject-note' | 'clarification-text',
   ): string => `${messageKey}:${field}`, []);
 
+  const interruptActionFieldKey = useCallback((messageKey: string, actionId: string): string => (
+    `${messageKey}:action:${actionId}`
+  ), []);
+
   const getAllowedDecisions = useCallback((
     pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   ): Array<'approve' | 'edit' | 'reject'> => {
     const defaults: Array<'approve' | 'edit' | 'reject'> = ['approve', 'edit', 'reject'];
+    if (getInterruptKind(pendingInterrupt) === 'clarification') {
+      return [];
+    }
     const actionRequests = Array.isArray(pendingInterrupt?.actionRequests) ? pendingInterrupt.actionRequests : [];
     const reviewConfigs = Array.isArray(pendingInterrupt?.reviewConfigs) ? pendingInterrupt.reviewConfigs : [];
-    if (!actionRequests.length || !reviewConfigs.length) {
-      return defaults;
+    if (reviewConfigs.length) {
+      const firstActionName = typeof actionRequests[0]?.name === 'string' ? actionRequests[0]?.name : undefined;
+      const matchingConfigs = firstActionName
+        ? reviewConfigs.filter((config) => config?.action_name === firstActionName)
+        : reviewConfigs;
+      const allowed = Array.from(
+        new Set(
+          matchingConfigs.flatMap((config) =>
+            Array.isArray(config?.allowed_decisions) ? config.allowed_decisions : [],
+          ),
+        ),
+      ).filter(
+        (value): value is 'approve' | 'edit' | 'reject' => value === 'approve' || value === 'edit' || value === 'reject',
+      );
+      if (allowed.length) {
+        return allowed;
+      }
     }
-    const firstActionName = typeof actionRequests[0]?.name === 'string' ? actionRequests[0]?.name : undefined;
-    if (!firstActionName) {
-      return defaults;
+    return defaults;
+  }, [getInterruptKind]);
+
+  const getInterruptActions = useCallback((
+    pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  ): RenderableInterruptAction[] => {
+    const interruptActions = Array.isArray(pendingInterrupt?.actions)
+      ? pendingInterrupt.actions.filter(
+          (action): action is InterruptAction =>
+            Boolean(action) &&
+            typeof action === 'object' &&
+            !Array.isArray(action) &&
+            typeof action.id === 'string' &&
+            typeof action.label === 'string',
+        )
+      : [];
+    if (interruptActions.length) {
+      return interruptActions.map((action) => ({
+        ...action,
+        source: 'dynamic',
+      }));
     }
-    const matchingConfig = reviewConfigs.find((config) => config?.action_name === firstActionName);
-    const allowedRaw = Array.isArray(matchingConfig?.allowed_decisions) ? matchingConfig?.allowed_decisions : [];
-    const allowed = allowedRaw.filter(
-      (value): value is 'approve' | 'edit' | 'reject' => value === 'approve' || value === 'edit' || value === 'reject',
-    );
-    return allowed.length ? allowed : defaults;
-  }, []);
+
+    if (getInterruptKind(pendingInterrupt) === 'clarification') {
+      const responseSpec = pendingInterrupt?.responseSpec;
+      const clarificationChoices = Array.isArray(responseSpec?.choices) ? responseSpec.choices : [];
+      const derivedActions: RenderableInterruptAction[] = clarificationChoices.map((choice) => ({
+        id: `choice:${choice.id}`,
+        label: choice.label,
+        style: 'secondary',
+        inputMode: 'none',
+        value: choice.value,
+        source: 'clarification-choice',
+        choiceId: choice.id,
+      }));
+      const inputMode = responseSpec?.inputMode || 'text';
+      if (inputMode === 'text' || inputMode === 'text_or_choice' || !derivedActions.length) {
+        derivedActions.push({
+          id: 'clarification-text',
+          label: responseSpec?.submitLabel || 'Continue',
+          style: 'primary',
+          inputMode: 'text',
+          placeholder: responseSpec?.placeholder || 'Type your answer for the agent',
+          submitLabel: responseSpec?.submitLabel || 'Continue',
+          source: 'clarification-text',
+        });
+      }
+      return derivedActions;
+    }
+
+    const isPlanApproval = isPlanApprovalInterrupt(pendingInterrupt);
+    return getAllowedDecisions(pendingInterrupt).map((decision) => {
+      if (decision === 'approve') {
+        return {
+          id: 'approve',
+          label: 'Approve',
+          style: 'primary',
+          inputMode: 'none',
+          source: 'approval',
+          legacyDecision: 'approve',
+        } satisfies RenderableInterruptAction;
+      }
+      if (decision === 'edit') {
+        return {
+          id: 'edit',
+          label: 'Edit',
+          style: 'secondary',
+          inputMode: 'text',
+          placeholder: isPlanApproval
+            ? 'Describe the revisions you want before the agent resubmits the plan'
+            : 'Optional edit feedback or updated args JSON',
+          submitLabel: 'Save Changes',
+          source: 'approval',
+          legacyDecision: 'edit',
+        } satisfies RenderableInterruptAction;
+      }
+      return {
+        id: 'reject',
+        label: 'Reject',
+        style: 'danger',
+        inputMode: 'text',
+        placeholder: 'Reason for rejection (optional)',
+        submitLabel: 'Confirm Rejection',
+        confirm: true,
+        source: 'approval',
+        legacyDecision: 'reject',
+      } satisfies RenderableInterruptAction;
+    });
+  }, [getAllowedDecisions, getInterruptKind, isPlanApprovalInterrupt]);
 
   const handleStreamChunk = (
     conversationId: string,
@@ -2241,6 +2358,7 @@ export default function WorkspacePage() {
           description: chunk.description,
           stepIndex: chunk.stepIndex,
           stepCount: chunk.stepCount,
+          actions: chunk.actions,
           actionRequests: chunk.actionRequests,
           reviewConfigs: chunk.reviewConfigs,
           responseSpec: chunk.responseSpec,
@@ -2321,6 +2439,7 @@ export default function WorkspacePage() {
                 description: chunk.description,
                 stepIndex: chunk.stepIndex,
                 stepCount: chunk.stepCount,
+                actions: chunk.actions,
                 actionRequests: chunk.actionRequests,
                 reviewConfigs: chunk.reviewConfigs,
                 responseSpec: chunk.responseSpec,
@@ -2446,6 +2565,12 @@ export default function WorkspacePage() {
         : interruptFieldKey(messageKey, 'reject-note');
       const rawFeedback = (interruptInputByMessageId[feedbackKey] || '').trim();
       setInterruptSubmittingByMessageId((prev) => ({ ...prev, [messageKey]: true }));
+      setInterruptErrorByMessageId((prev) => {
+        if (!prev[messageKey]) return prev;
+        const next = { ...prev };
+        delete next[messageKey];
+        return next;
+      });
       try {
         const options: {
           editedAction?: { name: string; args: Record<string, unknown> };
@@ -2503,7 +2628,21 @@ export default function WorkspacePage() {
           next[idx] = { ...current, metadata };
           return next;
         });
-        const runInfo = activeRunsRef.current[runId];
+        setInterruptInputByMessageId((prev) => {
+          const next = { ...prev };
+          delete next[interruptFieldKey(messageKey, 'feedback')];
+          delete next[interruptFieldKey(messageKey, 'edit-json')];
+          delete next[interruptFieldKey(messageKey, 'reject-note')];
+          return next;
+        });
+        setInterruptErrorByMessageId((prev) => {
+          if (!prev[messageKey]) return prev;
+          const next = { ...prev };
+          delete next[messageKey];
+          return next;
+        });
+        const runInfo = activeRunsRef.current[runId] || await rebuildRunInfoForMessage(message, runId);
+        registerActiveRun(runInfo);
         if (runInfo) {
           await streamRunForConversation(runInfo, false);
         } else {
@@ -2511,7 +2650,10 @@ export default function WorkspacePage() {
         }
       } catch (error) {
         console.error('Failed to submit approval decision', error);
-        addLocalSystemMessage(error instanceof Error ? error.message : 'Failed to submit approval decision.');
+        setInterruptErrorByMessageId((prev) => ({
+          ...prev,
+          [messageKey]: error instanceof Error ? error.message : 'Failed to submit approval decision.',
+        }));
       } finally {
         setInterruptSubmittingByMessageId((prev) => ({ ...prev, [messageKey]: false }));
       }
@@ -2524,6 +2666,8 @@ export default function WorkspacePage() {
       getPrimaryInterruptAction,
       getAllowedDecisions,
       isPlanApprovalInterrupt,
+      rebuildRunInfoForMessage,
+      registerActiveRun,
       streamRunForConversation,
       updateMessagesForConversation,
     ],
@@ -2558,6 +2702,12 @@ export default function WorkspacePage() {
       }
 
       setInterruptSubmittingByMessageId((prev) => ({ ...prev, [messageKey]: true }));
+      setInterruptErrorByMessageId((prev) => {
+        if (!prev[messageKey]) return prev;
+        const next = { ...prev };
+        delete next[messageKey];
+        return next;
+      });
       try {
         await submitRunResponse(runId, {
           message: rawMessage || undefined,
@@ -2584,7 +2734,14 @@ export default function WorkspacePage() {
           delete next[messageKey];
           return next;
         });
-        const runInfo = activeRunsRef.current[runId];
+        setInterruptErrorByMessageId((prev) => {
+          if (!prev[messageKey]) return prev;
+          const next = { ...prev };
+          delete next[messageKey];
+          return next;
+        });
+        const runInfo = activeRunsRef.current[runId] || await rebuildRunInfoForMessage(message, runId);
+        registerActiveRun(runInfo);
         if (runInfo) {
           await streamRunForConversation(runInfo, false);
         } else {
@@ -2592,7 +2749,10 @@ export default function WorkspacePage() {
         }
       } catch (error) {
         console.error('Failed to submit clarification response', error);
-        addLocalSystemMessage(error instanceof Error ? error.message : 'Failed to submit clarification response.');
+        setInterruptErrorByMessageId((prev) => ({
+          ...prev,
+          [messageKey]: error instanceof Error ? error.message : 'Failed to submit clarification response.',
+        }));
       } finally {
         setInterruptSubmittingByMessageId((prev) => ({ ...prev, [messageKey]: false }));
       }
@@ -2604,6 +2764,158 @@ export default function WorkspacePage() {
       interruptFieldKey,
       interruptInputByMessageId,
       interruptSelectedChoicesByMessageId,
+      rebuildRunInfoForMessage,
+      registerActiveRun,
+      streamRunForConversation,
+      updateMessagesForConversation,
+    ],
+  );
+
+  const handleInterruptAction = useCallback(
+    async (
+      message: ConversationMessage,
+      action: RenderableInterruptAction,
+      pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+    ) => {
+      if (action.source === 'approval' && action.legacyDecision) {
+        await handleInterruptDecision(message, action.legacyDecision, pendingInterrupt);
+        return;
+      }
+
+      if (action.source === 'clarification-text') {
+        await handleClarificationResponse(message, pendingInterrupt);
+        return;
+      }
+
+      const runId = findRunIdForMessage(message);
+      if (!runId) {
+        addLocalSystemMessage('Missing run id for interrupt action.');
+        return;
+      }
+
+      const messageKey = String(message.id);
+      const actionTextKey = interruptActionFieldKey(messageKey, action.id);
+      const actionText = (interruptInputByMessageId[actionTextKey] || '').trim();
+
+      if (action.source === 'clarification-choice') {
+        setInterruptSubmittingByMessageId((prev) => ({ ...prev, [messageKey]: true }));
+        setInterruptErrorByMessageId((prev) => {
+          if (!prev[messageKey]) return prev;
+          const next = { ...prev };
+          delete next[messageKey];
+          return next;
+        });
+        try {
+          await submitRunResponse(runId, {
+            selectedChoiceIds: action.choiceId ? [action.choiceId] : undefined,
+            selectedValues: action.value ? [action.value] : undefined,
+          });
+          updateMessagesForConversation(message.conversationId, (prev) => {
+            const next = [...prev];
+            const idx = next.findIndex((item) => item.id === message.id);
+            if (idx === -1) return next;
+            const current = next[idx];
+            const metadata = { ...((current.metadata as ConversationMessageMetadata | undefined) || {}) };
+            metadata.pendingInterrupt = undefined;
+            next[idx] = { ...current, metadata };
+            return next;
+          });
+          setInterruptErrorByMessageId((prev) => {
+            if (!prev[messageKey]) return prev;
+            const next = { ...prev };
+            delete next[messageKey];
+            return next;
+          });
+          const runInfo = activeRunsRef.current[runId] || await rebuildRunInfoForMessage(message, runId);
+          registerActiveRun(runInfo);
+          if (runInfo) {
+            await streamRunForConversation(runInfo, false);
+          } else {
+            addLocalSystemMessage('Response saved. Refreshing stream state...');
+          }
+        } catch (error) {
+          console.error('Failed to submit clarification choice', error);
+          setInterruptErrorByMessageId((prev) => ({
+            ...prev,
+            [messageKey]: error instanceof Error ? error.message : 'Failed to submit clarification response.',
+          }));
+        } finally {
+          setInterruptSubmittingByMessageId((prev) => ({ ...prev, [messageKey]: false }));
+        }
+        return;
+      }
+
+      if (action.inputMode === 'text' && !actionText) {
+        setInterruptErrorByMessageId((prev) => ({
+          ...prev,
+          [messageKey]: 'This action requires text input before continuing.',
+        }));
+        return;
+      }
+
+      setInterruptSubmittingByMessageId((prev) => ({ ...prev, [messageKey]: true }));
+      setInterruptErrorByMessageId((prev) => {
+        if (!prev[messageKey]) return prev;
+        const next = { ...prev };
+        delete next[messageKey];
+        return next;
+      });
+      try {
+        await submitRunAction(runId, {
+          actionId: action.id,
+          text: actionText || undefined,
+        });
+        updateMessagesForConversation(message.conversationId, (prev) => {
+          const next = [...prev];
+          const idx = next.findIndex((item) => item.id === message.id);
+          if (idx === -1) return next;
+          const current = next[idx];
+          const metadata = { ...((current.metadata as ConversationMessageMetadata | undefined) || {}) };
+          metadata.pendingInterrupt = undefined;
+          next[idx] = { ...current, metadata };
+          return next;
+        });
+        setInterruptInputByMessageId((prev) => {
+          const next = { ...prev };
+          Object.keys(next).forEach((key) => {
+            if (key.startsWith(`${messageKey}:action:`)) {
+              delete next[key];
+            }
+          });
+          return next;
+        });
+        setInterruptErrorByMessageId((prev) => {
+          if (!prev[messageKey]) return prev;
+          const next = { ...prev };
+          delete next[messageKey];
+          return next;
+        });
+        const runInfo = activeRunsRef.current[runId] || await rebuildRunInfoForMessage(message, runId);
+        registerActiveRun(runInfo);
+        if (runInfo) {
+          await streamRunForConversation(runInfo, false);
+        } else {
+          addLocalSystemMessage('Action saved. Refreshing stream state...');
+        }
+      } catch (error) {
+        console.error('Failed to submit interrupt action', error);
+        setInterruptErrorByMessageId((prev) => ({
+          ...prev,
+          [messageKey]: error instanceof Error ? error.message : 'Failed to submit interrupt action.',
+        }));
+      } finally {
+        setInterruptSubmittingByMessageId((prev) => ({ ...prev, [messageKey]: false }));
+      }
+    },
+    [
+      addLocalSystemMessage,
+      findRunIdForMessage,
+      handleClarificationResponse,
+      handleInterruptDecision,
+      interruptActionFieldKey,
+      interruptInputByMessageId,
+      rebuildRunInfoForMessage,
+      registerActiveRun,
       streamRunForConversation,
       updateMessagesForConversation,
     ],
@@ -4023,8 +4335,8 @@ export default function WorkspacePage() {
               expandedThinkingMessages={expandedThinkingMessages}
               copiedMessageId={copiedMessageId}
               interruptInputByMessageId={interruptInputByMessageId}
-              interruptSelectedChoicesByMessageId={interruptSelectedChoicesByMessageId}
               interruptSubmittingByMessageId={interruptSubmittingByMessageId}
+              interruptErrorByMessageId={interruptErrorByMessageId}
               chatMessage={chatMessage}
               chatAttachments={chatAttachments}
               showPaper2SlidesControls={showPaper2SlidesControls}
@@ -4041,12 +4353,12 @@ export default function WorkspacePage() {
               workspaceId={selectedWorkspace?.id}
               formatMessageTimestamp={formatMessageTimestamp}
               interruptFieldKey={interruptFieldKey}
+              interruptActionFieldKey={interruptActionFieldKey}
               getInterruptKind={getInterruptKind}
-              getAllowedDecisions={getAllowedDecisions}
+              getInterruptActions={getInterruptActions}
               getPrimaryInterruptAction={getPrimaryInterruptAction}
               isPlanApprovalInterrupt={isPlanApprovalInterrupt}
               setInterruptInputByMessageId={setInterruptInputByMessageId}
-              setInterruptSelectedChoicesByMessageId={setInterruptSelectedChoicesByMessageId}
               onToggleAgentPaneVisibility={() => setIsAgentPaneVisible((prev) => !prev)}
               onModeChange={handleModeChange}
               onToggleHistory={() => setIsHistoryOpen((prev) => !prev)}
@@ -4059,8 +4371,7 @@ export default function WorkspacePage() {
               onToggleToolActivityVisibility={toggleToolActivityVisibility}
               onCopyMessageText={handleCopyMessageText}
               onRerunMessage={handleRerunMessage}
-              onInterruptDecision={handleInterruptDecision}
-              onClarificationResponse={handleClarificationResponse}
+              onInterruptAction={handleInterruptAction}
               onChatInputChange={handleChatInputChange}
               onChatInputKeyDown={handleChatInputKeyDown}
               onChatInputKeyUp={handleChatInputKeyUp}

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -194,10 +194,11 @@ const mergePersistedAgentMessage = (
   const existingMetadata = (existing?.metadata as ConversationMessageMetadata | null | undefined) || {};
   const persistedStatus = persistedMetadata.status;
   const existingStatus = existingMetadata.status;
-  const effectiveStatus =
-    (persistedStatus === 'running' || persistedStatus === 'queued') && existingStatus === 'awaiting_approval'
-      ? 'awaiting_approval'
-      : persistedStatus ?? existingStatus;
+  const shouldPreserveAwaitingApproval =
+    (persistedStatus === 'running' || persistedStatus === 'queued') &&
+    existingStatus === 'awaiting_approval' &&
+    persistedMetadata.pendingInterrupt !== undefined;
+  const effectiveStatus = shouldPreserveAwaitingApproval ? 'awaiting_approval' : persistedStatus ?? existingStatus;
 
   const mergedMetadata: ConversationMessageMetadata = {
     ...existingMetadata,
@@ -2293,6 +2294,64 @@ export default function WorkspacePage() {
     });
   }, [getAllowedDecisions, getInterruptKind, isPlanApprovalInterrupt]);
 
+  const waitForInterruptResumeReady = useCallback(
+    async (
+      runId: string,
+      expected: 'approval' | 'clarification' | 'action',
+    ): Promise<boolean> => {
+      const deadline = Date.now() + 3000;
+      while (Date.now() < deadline) {
+        try {
+          const status = await getRunStatus(runId);
+          if (status.status === 'awaiting_approval') {
+            const interruptKind = getInterruptKind(status.pendingInterrupt);
+            if (expected === 'approval' && interruptKind !== 'clarification') {
+              return true;
+            }
+            if (expected === 'clarification' && interruptKind === 'clarification') {
+              return true;
+            }
+            if (
+              expected === 'action' &&
+              Array.isArray(status.pendingInterrupt?.actions) &&
+              status.pendingInterrupt.actions.length > 0
+            ) {
+              return true;
+            }
+          }
+        } catch (error) {
+          console.error('Failed to poll run status before interrupt retry', error);
+        }
+        await new Promise((resolve) => window.setTimeout(resolve, 200));
+      }
+      return false;
+    },
+    [getInterruptKind],
+  );
+
+  const submitInterruptWithRetry = useCallback(
+    async (
+      runId: string,
+      expected: 'approval' | 'clarification' | 'action',
+      submit: () => Promise<unknown>,
+    ) => {
+      try {
+        return await submit();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error || '');
+        if (!/Run is not awaiting/i.test(message)) {
+          throw error;
+        }
+        const ready = await waitForInterruptResumeReady(runId, expected);
+        if (!ready) {
+          throw error;
+        }
+        return submit();
+      }
+    },
+    [waitForInterruptResumeReady],
+  );
+
   const handleStreamChunk = (
     conversationId: string,
     agentMessageIndex: number,
@@ -2452,16 +2511,22 @@ export default function WorkspacePage() {
           replayFromStart ? undefined : undefined
         );
       } catch (error) {
+        const supersededByNewerStream = streamAbortMapRef.current.get(conversationId) !== controller;
         if ((error as DOMException)?.name === 'AbortError') {
-          const stopLabel = stopRequestedRef.current ? '\n[Stopped by user]' : '\n[Stream cancelled]';
-          appendAgentChunk(conversationId, agentMessageIndex, stopLabel);
-          finalStatus = 'cancelled';
+          if (stopRequestedRef.current) {
+            appendAgentChunk(conversationId, agentMessageIndex, '\n[Stopped by user]');
+            finalStatus = 'cancelled';
+          } else if (!supersededByNewerStream) {
+            appendAgentChunk(conversationId, agentMessageIndex, '\n[Stream cancelled]');
+            finalStatus = 'cancelled';
+          }
         } else {
           console.error('Failed to stream agent run', error);
           appendAgentChunk(conversationId, agentMessageIndex, '\nSorry, something went wrong.');
           finalStatus = 'failed';
         }
       } finally {
+        const supersededByNewerStream = streamAbortMapRef.current.get(conversationId) !== controller;
         let latestRunMeta:
           | Awaited<ReturnType<typeof getRunStatus>>
           | null = null;
@@ -2484,8 +2549,8 @@ export default function WorkspacePage() {
         } catch (statusError) {
           console.error('Failed to fetch final run status', statusError);
         }
-        const effectivePendingInterrupt = latestRunMeta?.pendingInterrupt ?? latestInterrupt;
-        if (effectivePendingInterrupt) {
+        const effectivePendingInterrupt = latestRunMeta ? latestRunMeta.pendingInterrupt : latestInterrupt;
+        if (!supersededByNewerStream && effectivePendingInterrupt) {
             finalStatus = 'awaiting_approval';
             updateMessageMetadataAtIndex(conversationId, agentMessageIndex, (metadata) => ({
               ...metadata,
@@ -2498,9 +2563,14 @@ export default function WorkspacePage() {
           console.debug('[WorkspacePage] stream finished', { runId, status: finalStatus });
         }
         flushBufferedAgentChunks();
+        if (supersededByNewerStream) {
+          return;
+        }
         await persistAgentProgress({ ...runInfo, status: finalStatus }, finalStatus);
         setStreamingForConversation(conversationId, false);
-        streamAbortMapRef.current.delete(conversationId);
+        if (streamAbortMapRef.current.get(conversationId) === controller) {
+          streamAbortMapRef.current.delete(conversationId);
+        }
         stopRequestedRef.current = false;
         resumeInFlightRef.current.delete(runId);
         if (finalStatus === 'awaiting_approval') {
@@ -2617,7 +2687,7 @@ export default function WorkspacePage() {
             };
           }
         }
-        await submitRunDecision(runId, decision, options);
+        await submitInterruptWithRetry(runId, 'approval', () => submitRunDecision(runId, decision, options));
         updateMessagesForConversation(message.conversationId, (prev) => {
           const next = [...prev];
           const idx = next.findIndex((item) => item.id === message.id);
@@ -2668,6 +2738,7 @@ export default function WorkspacePage() {
       isPlanApprovalInterrupt,
       rebuildRunInfoForMessage,
       registerActiveRun,
+      submitInterruptWithRetry,
       streamRunForConversation,
       updateMessagesForConversation,
     ],
@@ -2709,11 +2780,13 @@ export default function WorkspacePage() {
         return next;
       });
       try {
-        await submitRunResponse(runId, {
-          message: rawMessage || undefined,
-          selectedChoiceIds: selectedChoiceIds.length ? selectedChoiceIds : undefined,
-          selectedValues: selectedValues.length ? selectedValues : undefined,
-        });
+        await submitInterruptWithRetry(runId, 'clarification', () =>
+          submitRunResponse(runId, {
+            message: rawMessage || undefined,
+            selectedChoiceIds: selectedChoiceIds.length ? selectedChoiceIds : undefined,
+            selectedValues: selectedValues.length ? selectedValues : undefined,
+          })
+        );
         updateMessagesForConversation(message.conversationId, (prev) => {
           const next = [...prev];
           const idx = next.findIndex((item) => item.id === message.id);
@@ -2766,6 +2839,7 @@ export default function WorkspacePage() {
       interruptSelectedChoicesByMessageId,
       rebuildRunInfoForMessage,
       registerActiveRun,
+      submitInterruptWithRetry,
       streamRunForConversation,
       updateMessagesForConversation,
     ],
@@ -2806,10 +2880,12 @@ export default function WorkspacePage() {
           return next;
         });
         try {
-          await submitRunResponse(runId, {
-            selectedChoiceIds: action.choiceId ? [action.choiceId] : undefined,
-            selectedValues: action.value ? [action.value] : undefined,
-          });
+          await submitInterruptWithRetry(runId, 'clarification', () =>
+            submitRunResponse(runId, {
+              selectedChoiceIds: action.choiceId ? [action.choiceId] : undefined,
+              selectedValues: action.value ? [action.value] : undefined,
+            })
+          );
           updateMessagesForConversation(message.conversationId, (prev) => {
             const next = [...prev];
             const idx = next.findIndex((item) => item.id === message.id);
@@ -2861,10 +2937,12 @@ export default function WorkspacePage() {
         return next;
       });
       try {
-        await submitRunAction(runId, {
-          actionId: action.id,
-          text: actionText || undefined,
-        });
+        await submitInterruptWithRetry(runId, 'action', () =>
+          submitRunAction(runId, {
+            actionId: action.id,
+            text: actionText || undefined,
+          })
+        );
         updateMessagesForConversation(message.conversationId, (prev) => {
           const next = [...prev];
           const idx = next.findIndex((item) => item.id === message.id);
@@ -2916,6 +2994,7 @@ export default function WorkspacePage() {
       interruptInputByMessageId,
       rebuildRunInfoForMessage,
       registerActiveRun,
+      submitInterruptWithRetry,
       streamRunForConversation,
       updateMessagesForConversation,
     ],

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -207,11 +207,7 @@ const mergePersistedAgentMessage = (
   const existingMetadata = (existing?.metadata as ConversationMessageMetadata | null | undefined) || {};
   const persistedStatus = persistedMetadata.status;
   const existingStatus = existingMetadata.status;
-  const shouldPreserveAwaitingApproval =
-    (persistedStatus === 'running' || persistedStatus === 'queued') &&
-    existingStatus === 'awaiting_approval' &&
-    persistedMetadata.pendingInterrupt !== undefined;
-  const effectiveStatus = shouldPreserveAwaitingApproval ? 'awaiting_approval' : persistedStatus ?? existingStatus;
+  const effectiveStatus = persistedStatus ?? existingStatus;
 
   const mergedMetadata: ConversationMessageMetadata = {
     ...existingMetadata,
@@ -221,7 +217,7 @@ const mergePersistedAgentMessage = (
     pendingInterrupt:
       persistedMetadata.pendingInterrupt !== undefined
         ? persistedMetadata.pendingInterrupt
-        : effectiveStatus === 'awaiting_approval'
+        : persistedStatus === undefined && effectiveStatus === 'awaiting_approval'
           ? existingMetadata.pendingInterrupt
           : undefined,
   };
@@ -2618,6 +2614,12 @@ export default function WorkspacePage() {
     }
 
     if (chunk.type === 'thought') {
+      updateMessageMetadataAtIndex(conversationId, agentMessageIndex, (metadata) => ({
+        ...metadata,
+        ...(runId ? { runId } : {}),
+        status: 'running',
+        pendingInterrupt: undefined,
+      }));
       appendAgentThought(conversationId, agentMessageIndex, chunk.content || '');
       return;
     }
@@ -2626,6 +2628,7 @@ export default function WorkspacePage() {
       updateMessageMetadataAtIndex(conversationId, agentMessageIndex, (metadata) => ({
         ...metadata,
         ...(runId ? { runId } : {}),
+        status: 'running',
         pendingInterrupt: undefined,
       }));
       appendToolStart(conversationId, agentMessageIndex, chunk);
@@ -2633,11 +2636,23 @@ export default function WorkspacePage() {
     }
 
     if (chunk.type === 'tool_end') {
+      updateMessageMetadataAtIndex(conversationId, agentMessageIndex, (metadata) => ({
+        ...metadata,
+        ...(runId ? { runId } : {}),
+        status: 'running',
+        pendingInterrupt: undefined,
+      }));
       appendToolEnd(conversationId, agentMessageIndex, chunk);
       return;
     }
 
     if (chunk.type === 'tool_error') {
+      updateMessageMetadataAtIndex(conversationId, agentMessageIndex, (metadata) => ({
+        ...metadata,
+        ...(runId ? { runId } : {}),
+        status: 'running',
+        pendingInterrupt: undefined,
+      }));
       appendToolEnd(conversationId, agentMessageIndex, chunk, 'error');
       return;
     }
@@ -2668,6 +2683,7 @@ export default function WorkspacePage() {
       updateMessageMetadataAtIndex(conversationId, agentMessageIndex, (metadata) => ({
         ...metadata,
         ...(runId ? { runId } : {}),
+        status: 'running',
         pendingInterrupt: undefined,
       }));
       if (chunk.role && chunk.role !== 'assistant') {
@@ -2948,7 +2964,20 @@ export default function WorkspacePage() {
           delete next[messageKey];
           return next;
         });
-        const runInfo = activeRunsRef.current[runId] || await rebuildRunInfoForMessage(message, runId);
+        const existingRunInfo = activeRunsRef.current[runId];
+        const rebuiltRunInfo = await rebuildRunInfoForMessage(message, runId).catch(() => undefined);
+        const runInfo = {
+          ...(existingRunInfo || rebuiltRunInfo || {
+            runId,
+            conversationId: message.conversationId,
+            workspaceId: selectedWorkspace?.id || '',
+            persona: normalizePersonaName(activeConversationPersona || selectedPersona || DEFAULT_PERSONA_NAME),
+            turnId: message.turnId || generateTurnId(),
+            placeholderId: message.id,
+            status: 'running' as AgentRunStatus,
+          }),
+          status: 'running' as AgentRunStatus,
+        };
         markRunStreamLaunching(runId);
         registerActiveRun(runInfo);
         if (runInfo) {
@@ -3045,7 +3074,20 @@ export default function WorkspacePage() {
           delete next[messageKey];
           return next;
         });
-        const runInfo = activeRunsRef.current[runId] || await rebuildRunInfoForMessage(message, runId);
+        const existingRunInfo = activeRunsRef.current[runId];
+        const rebuiltRunInfo = await rebuildRunInfoForMessage(message, runId).catch(() => undefined);
+        const runInfo = {
+          ...(existingRunInfo || rebuiltRunInfo || {
+            runId,
+            conversationId: message.conversationId,
+            workspaceId: selectedWorkspace?.id || '',
+            persona: normalizePersonaName(activeConversationPersona || selectedPersona || DEFAULT_PERSONA_NAME),
+            turnId: message.turnId || generateTurnId(),
+            placeholderId: message.id,
+            status: 'running' as AgentRunStatus,
+          }),
+          status: 'running' as AgentRunStatus,
+        };
         markRunStreamLaunching(runId);
         registerActiveRun(runInfo);
         if (runInfo) {
@@ -3127,7 +3169,20 @@ export default function WorkspacePage() {
             delete next[messageKey];
             return next;
           });
-          const runInfo = activeRunsRef.current[runId] || await rebuildRunInfoForMessage(message, runId);
+          const existingRunInfo = activeRunsRef.current[runId];
+          const rebuiltRunInfo = await rebuildRunInfoForMessage(message, runId).catch(() => undefined);
+          const runInfo = {
+            ...(existingRunInfo || rebuiltRunInfo || {
+              runId,
+              conversationId: message.conversationId,
+              workspaceId: selectedWorkspace?.id || '',
+              persona: normalizePersonaName(activeConversationPersona || selectedPersona || DEFAULT_PERSONA_NAME),
+              turnId: message.turnId || generateTurnId(),
+              placeholderId: message.id,
+              status: 'running' as AgentRunStatus,
+            }),
+            status: 'running' as AgentRunStatus,
+          };
           markRunStreamLaunching(runId);
           registerActiveRun(runInfo);
           if (runInfo) {
@@ -3185,7 +3240,20 @@ export default function WorkspacePage() {
           delete next[messageKey];
           return next;
         });
-        const runInfo = activeRunsRef.current[runId] || await rebuildRunInfoForMessage(message, runId);
+        const existingRunInfo = activeRunsRef.current[runId];
+        const rebuiltRunInfo = await rebuildRunInfoForMessage(message, runId).catch(() => undefined);
+        const runInfo = {
+          ...(existingRunInfo || rebuiltRunInfo || {
+            runId,
+            conversationId: message.conversationId,
+            workspaceId: selectedWorkspace?.id || '',
+            persona: normalizePersonaName(activeConversationPersona || selectedPersona || DEFAULT_PERSONA_NAME),
+            turnId: message.turnId || generateTurnId(),
+            placeholderId: message.id,
+            status: 'running' as AgentRunStatus,
+          }),
+          status: 'running' as AgentRunStatus,
+        };
         markRunStreamLaunching(runId);
         registerActiveRun(runInfo);
         if (runInfo) {

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -2209,6 +2209,79 @@ export default function WorkspacePage() {
     [updateMessagesForConversation],
   );
 
+  const clearPendingInterruptForRun = useCallback(
+    (
+      conversationId: string,
+      runId: string,
+      turnId?: string,
+    ) => {
+      updateMessagesForConversation(conversationId, (prev) => {
+        const matchingIndexes = prev
+          .map((message, index) => ({ message, index }))
+          .filter(({ message }) => {
+            if (message.sender !== 'agent') {
+              return false;
+            }
+            const metadata = (message.metadata as ConversationMessageMetadata | undefined) || undefined;
+            return metadata?.runId === runId || Boolean(turnId && message.turnId === turnId);
+          })
+          .map(({ index }) => index);
+
+        if (!matchingIndexes.length) {
+          return prev;
+        }
+
+        const next = [...prev];
+        const chooseScore = (message: ConversationMessage) => (
+          (message.text?.length || 0) * 1000 +
+          (message.thinkingText?.length || 0) * 100 +
+          (message.toolEvents?.length || 0) * 10 +
+          ((((message.metadata as ConversationMessageMetadata | undefined) || {}).pendingInterrupt) ? 5 : 0)
+        );
+
+        const primaryIndex = matchingIndexes.reduce((best, current) => (
+          chooseScore(next[current]) > chooseScore(next[best]) ? current : best
+        ), matchingIndexes[0]);
+
+        const merged = matchingIndexes.reduce((acc, index) => {
+          const candidate = next[index];
+          return {
+            ...acc,
+            text: (candidate.text?.length || 0) > (acc.text?.length || 0) ? candidate.text : acc.text,
+            thinkingText:
+              (candidate.thinkingText?.length || 0) > (acc.thinkingText?.length || 0)
+                ? candidate.thinkingText
+                : acc.thinkingText,
+            toolEvents:
+              (candidate.toolEvents?.length || 0) > (acc.toolEvents?.length || 0)
+                ? candidate.toolEvents
+                : acc.toolEvents,
+          };
+        }, next[primaryIndex]);
+
+        const metadata = {
+          ...(((merged.metadata as ConversationMessageMetadata | undefined) || {})),
+          runId,
+          status: 'running' as AgentRunStatus,
+          pendingInterrupt: undefined,
+        };
+
+        next[primaryIndex] = {
+          ...merged,
+          metadata,
+        };
+
+        if (matchingIndexes.length === 1) {
+          return next;
+        }
+
+        const duplicatesToRemove = new Set(matchingIndexes.filter((index) => index !== primaryIndex));
+        return next.filter((_, index) => !duplicatesToRemove.has(index));
+      });
+    },
+    [updateMessagesForConversation],
+  );
+
   const persistAgentProgress = useCallback(
     async (runInfo: ActiveRunInfo, statusOverride?: AgentRunStatus) => {
       const { runId, conversationId, turnId, placeholderId } = runInfo;
@@ -2861,16 +2934,7 @@ export default function WorkspacePage() {
           }
         }
         await submitInterruptWithRetry(runId, 'approval', () => submitRunDecision(runId, decision, options));
-        updateMessagesForConversation(message.conversationId, (prev) => {
-          const next = [...prev];
-          const idx = next.findIndex((item) => item.id === message.id);
-          if (idx === -1) return next;
-          const current = next[idx];
-          const metadata = { ...((current.metadata as ConversationMessageMetadata | undefined) || {}) };
-          metadata.pendingInterrupt = undefined;
-          next[idx] = { ...current, metadata };
-          return next;
-        });
+        clearPendingInterruptForRun(message.conversationId, runId, message.turnId);
         setInterruptInputByMessageId((prev) => {
           const next = { ...prev };
           delete next[interruptFieldKey(messageKey, 'feedback')];
@@ -2913,11 +2977,11 @@ export default function WorkspacePage() {
       isPlanApprovalInterrupt,
       selectedFile,
       rebuildRunInfoForMessage,
+      clearPendingInterruptForRun,
       markRunStreamLaunching,
       registerActiveRun,
       submitInterruptWithRetry,
       streamRunForConversation,
-      updateMessagesForConversation,
     ],
   );
 
@@ -2964,16 +3028,7 @@ export default function WorkspacePage() {
             selectedValues: selectedValues.length ? selectedValues : undefined,
           })
         );
-        updateMessagesForConversation(message.conversationId, (prev) => {
-          const next = [...prev];
-          const idx = next.findIndex((item) => item.id === message.id);
-          if (idx === -1) return next;
-          const current = next[idx];
-          const metadata = { ...((current.metadata as ConversationMessageMetadata | undefined) || {}) };
-          metadata.pendingInterrupt = undefined;
-          next[idx] = { ...current, metadata };
-          return next;
-        });
+        clearPendingInterruptForRun(message.conversationId, runId, message.turnId);
         setInterruptInputByMessageId((prev) => {
           const next = { ...prev };
           delete next[textKey];
@@ -3016,11 +3071,11 @@ export default function WorkspacePage() {
       interruptInputByMessageId,
       interruptSelectedChoicesByMessageId,
       rebuildRunInfoForMessage,
+      clearPendingInterruptForRun,
       markRunStreamLaunching,
       registerActiveRun,
       submitInterruptWithRetry,
       streamRunForConversation,
-      updateMessagesForConversation,
     ],
   );
 
@@ -3065,16 +3120,7 @@ export default function WorkspacePage() {
               selectedValues: action.value ? [action.value] : undefined,
             })
           );
-          updateMessagesForConversation(message.conversationId, (prev) => {
-            const next = [...prev];
-            const idx = next.findIndex((item) => item.id === message.id);
-            if (idx === -1) return next;
-            const current = next[idx];
-            const metadata = { ...((current.metadata as ConversationMessageMetadata | undefined) || {}) };
-            metadata.pendingInterrupt = undefined;
-            next[idx] = { ...current, metadata };
-            return next;
-          });
+          clearPendingInterruptForRun(message.conversationId, runId, message.turnId);
           setInterruptErrorByMessageId((prev) => {
             if (!prev[messageKey]) return prev;
             const next = { ...prev };
@@ -3123,16 +3169,7 @@ export default function WorkspacePage() {
             text: actionText || undefined,
           })
         );
-        updateMessagesForConversation(message.conversationId, (prev) => {
-          const next = [...prev];
-          const idx = next.findIndex((item) => item.id === message.id);
-          if (idx === -1) return next;
-          const current = next[idx];
-          const metadata = { ...((current.metadata as ConversationMessageMetadata | undefined) || {}) };
-          metadata.pendingInterrupt = undefined;
-          next[idx] = { ...current, metadata };
-          return next;
-        });
+        clearPendingInterruptForRun(message.conversationId, runId, message.turnId);
         setInterruptInputByMessageId((prev) => {
           const next = { ...prev };
           Object.keys(next).forEach((key) => {
@@ -3148,9 +3185,9 @@ export default function WorkspacePage() {
           delete next[messageKey];
           return next;
         });
-          const runInfo = activeRunsRef.current[runId] || await rebuildRunInfoForMessage(message, runId);
-          markRunStreamLaunching(runId);
-          registerActiveRun(runInfo);
+        const runInfo = activeRunsRef.current[runId] || await rebuildRunInfoForMessage(message, runId);
+        markRunStreamLaunching(runId);
+        registerActiveRun(runInfo);
         if (runInfo) {
           await streamRunForConversation(runInfo, false);
         } else {
@@ -3174,11 +3211,11 @@ export default function WorkspacePage() {
       interruptActionFieldKey,
       interruptInputByMessageId,
       rebuildRunInfoForMessage,
+      clearPendingInterruptForRun,
       markRunStreamLaunching,
       registerActiveRun,
       submitInterruptWithRetry,
       streamRunForConversation,
-      updateMessagesForConversation,
     ],
   );
 

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -2158,6 +2158,57 @@ export default function WorkspacePage() {
     return !message.text && !message.thinkingText && !message.toolEvents?.length;
   }, []);
 
+  const upsertPersistedAgentMessage = useCallback(
+    (
+      conversationId: string,
+      persisted: ConversationMessage,
+      options?: {
+        placeholderId?: ConversationMessage['id'];
+        existing?: ConversationMessage | null;
+      },
+    ) => {
+      updateMessagesForConversation(conversationId, (prev) => {
+        const updated = [...prev];
+        const matchingIndexes = updated
+          .map((message, index) => ({ message, index }))
+          .filter(({ message }) => {
+            if (message.sender !== 'agent') {
+              return false;
+            }
+            if (message.id === persisted.id) {
+              return true;
+            }
+            if (options?.placeholderId !== undefined && message.id === options.placeholderId) {
+              return true;
+            }
+            return Boolean(persisted.turnId && message.turnId === persisted.turnId);
+          })
+          .map(({ index }) => index);
+
+        const primaryIndex = matchingIndexes[0] ?? updated.length;
+        const existing =
+          matchingIndexes[0] !== undefined
+            ? updated[matchingIndexes[0]]
+            : options?.existing || undefined;
+        const merged = mergePersistedAgentMessage(persisted, existing);
+
+        if (matchingIndexes[0] !== undefined) {
+          updated[primaryIndex] = merged;
+        } else {
+          updated.push(merged);
+        }
+
+        if (matchingIndexes.length <= 1) {
+          return updated;
+        }
+
+        const duplicatesToRemove = new Set(matchingIndexes.slice(1));
+        return updated.filter((_, index) => !duplicatesToRemove.has(index));
+      });
+    },
+    [updateMessagesForConversation],
+  );
+
   const persistAgentProgress = useCallback(
     async (runInfo: ActiveRunInfo, statusOverride?: AgentRunStatus) => {
       const { runId, conversationId, turnId, placeholderId } = runInfo;
@@ -2191,19 +2242,9 @@ export default function WorkspacePage() {
           replaceExisting: true,
           metadata,
         });
-        updateMessagesForConversation(conversationId, (prev) => {
-          const updated = [...prev];
-          const existingIndex = updated.findIndex(
-            (m) => m.id === persisted.id || (m.sender === 'agent' && m.turnId === persisted.turnId)
-          );
-          const existing = existingIndex !== -1 ? updated[existingIndex] : undefined;
-          const merged = mergePersistedAgentMessage(persisted, existing);
-          if (existingIndex !== -1) {
-            updated[existingIndex] = merged;
-          } else {
-            updated.push(merged);
-          }
-          return updated;
+        upsertPersistedAgentMessage(conversationId, persisted, {
+          placeholderId,
+          existing: message,
         });
         lastPersistedAgentTextRef.current[runId] = text;
         lastPersistedStatusRef.current[runId] = nextStatus;
@@ -2218,7 +2259,7 @@ export default function WorkspacePage() {
         persistInFlightRef.current.delete(runId);
       }
     },
-    [getBufferedAgentText, findAgentMessageForRun, updateMessagesForConversation],
+    [getBufferedAgentText, findAgentMessageForRun, upsertPersistedAgentMessage],
   );
 
   const bufferAgentChunk = (conversationId: string, index: number, chunk: string) => {
@@ -3439,14 +3480,9 @@ export default function WorkspacePage() {
             replaceExisting: true,
             metadata: { ...metadata, runId },
           });
-          updateMessagesForConversation(conversationId, (prev) => {
-            const updated = [...prev];
-            if (targetIndex >= 0) {
-              updated[targetIndex] = mergePersistedAgentMessage(persisted, updated[targetIndex]);
-            } else {
-              updated.push(mergePersistedAgentMessage(persisted));
-            }
-            return updated;
+          upsertPersistedAgentMessage(conversationId, persisted, {
+            placeholderId,
+            existing: agentMessage,
           });
           if (placeholderId !== null && placeholderId !== undefined) {
             agentMessageBufferRef.current.delete(placeholderId);
@@ -3855,14 +3891,9 @@ export default function WorkspacePage() {
             metadata: { ...metadata, runId },
             replaceExisting: true,
           });
-          updateMessagesForConversation(conversationId, (prev) => {
-            const updated = [...prev];
-            if (targetIndex >= 0) {
-              updated[targetIndex] = mergePersistedAgentMessage(persisted, updated[targetIndex]);
-            } else {
-              updated.push(mergePersistedAgentMessage(persisted));
-            }
-            return updated;
+          upsertPersistedAgentMessage(conversationId, persisted, {
+            placeholderId,
+            existing: agentMessage,
           });
           if (placeholderId !== null && placeholderId !== undefined) {
             agentMessageBufferRef.current.delete(placeholderId);

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -3461,7 +3461,6 @@ export default function WorkspacePage() {
       };
       markRunStreamLaunching(runId);
       registerActiveRun(runInfo);
-      await persistAgentProgress(runInfo, 'running');
       await streamRunForConversation(runInfo, true);
 
       const messagesSnapshot = getConversationMessagesSnapshot(conversationId);
@@ -3872,7 +3871,6 @@ export default function WorkspacePage() {
       };
       markRunStreamLaunching(runId);
       registerActiveRun(runInfo);
-      await persistAgentProgress(runInfo, 'running');
       await streamRunForConversation(runInfo, true);
 
       const messagesSnapshot = getConversationMessagesSnapshot(conversationId);

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -443,6 +443,11 @@ export default function WorkspacePage() {
     };
   }, [getRunStatus]);
 
+  const markRunStreamLaunching = useCallback((runId: string) => {
+    resumeAttemptedRef.current.add(runId);
+    resumeInFlightRef.current.add(runId);
+  }, []);
+
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', colorMode);
     if (typeof window !== 'undefined') {
@@ -2712,6 +2717,7 @@ export default function WorkspacePage() {
           return next;
         });
         const runInfo = activeRunsRef.current[runId] || await rebuildRunInfoForMessage(message, runId);
+        markRunStreamLaunching(runId);
         registerActiveRun(runInfo);
         if (runInfo) {
           await streamRunForConversation(runInfo, false);
@@ -2737,6 +2743,7 @@ export default function WorkspacePage() {
       getAllowedDecisions,
       isPlanApprovalInterrupt,
       rebuildRunInfoForMessage,
+      markRunStreamLaunching,
       registerActiveRun,
       submitInterruptWithRetry,
       streamRunForConversation,
@@ -2814,6 +2821,7 @@ export default function WorkspacePage() {
           return next;
         });
         const runInfo = activeRunsRef.current[runId] || await rebuildRunInfoForMessage(message, runId);
+        markRunStreamLaunching(runId);
         registerActiveRun(runInfo);
         if (runInfo) {
           await streamRunForConversation(runInfo, false);
@@ -2838,6 +2846,7 @@ export default function WorkspacePage() {
       interruptInputByMessageId,
       interruptSelectedChoicesByMessageId,
       rebuildRunInfoForMessage,
+      markRunStreamLaunching,
       registerActiveRun,
       submitInterruptWithRetry,
       streamRunForConversation,
@@ -2903,6 +2912,7 @@ export default function WorkspacePage() {
             return next;
           });
           const runInfo = activeRunsRef.current[runId] || await rebuildRunInfoForMessage(message, runId);
+          markRunStreamLaunching(runId);
           registerActiveRun(runInfo);
           if (runInfo) {
             await streamRunForConversation(runInfo, false);
@@ -2968,8 +2978,9 @@ export default function WorkspacePage() {
           delete next[messageKey];
           return next;
         });
-        const runInfo = activeRunsRef.current[runId] || await rebuildRunInfoForMessage(message, runId);
-        registerActiveRun(runInfo);
+          const runInfo = activeRunsRef.current[runId] || await rebuildRunInfoForMessage(message, runId);
+          markRunStreamLaunching(runId);
+          registerActiveRun(runInfo);
         if (runInfo) {
           await streamRunForConversation(runInfo, false);
         } else {
@@ -2993,6 +3004,7 @@ export default function WorkspacePage() {
       interruptActionFieldKey,
       interruptInputByMessageId,
       rebuildRunInfoForMessage,
+      markRunStreamLaunching,
       registerActiveRun,
       submitInterruptWithRetry,
       streamRunForConversation,
@@ -3267,6 +3279,7 @@ export default function WorkspacePage() {
         placeholderId,
         status: 'running',
       };
+      markRunStreamLaunching(runId);
       registerActiveRun(runInfo);
       await persistAgentProgress(runInfo, 'running');
       await streamRunForConversation(runInfo, true);
@@ -3682,6 +3695,7 @@ export default function WorkspacePage() {
         placeholderId,
         status: 'running',
       };
+      markRunStreamLaunching(runId);
       registerActiveRun(runInfo);
       await persistAgentProgress(runInfo, 'running');
       await streamRunForConversation(runInfo, true);

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -2149,6 +2149,31 @@ export default function WorkspacePage() {
     [],
   );
 
+  const findAgentMessageIndexForRun = useCallback(
+    (
+      conversationId: string,
+      placeholderId: ConversationMessage['id'],
+      turnId: string,
+      runId?: string,
+    ) => {
+      const messages = conversationMessagesRef.current[conversationId] || [];
+      if (runId) {
+        const byRunId = messages.findIndex((message) => (
+          message.sender === 'agent' && message.metadata?.runId === runId
+        ));
+        if (byRunId !== -1) {
+          return byRunId;
+        }
+      }
+      const byId = messages.findIndex((message) => message.id === placeholderId);
+      if (byId !== -1) {
+        return byId;
+      }
+      return messages.findIndex((message) => message.sender === 'agent' && message.turnId === turnId);
+    },
+    [],
+  );
+
   const getBufferedAgentText = useCallback(
     (runInfo: ActiveRunInfo) => {
       const { placeholderId, conversationId, turnId } = runInfo;
@@ -2740,8 +2765,8 @@ export default function WorkspacePage() {
       resumeAttemptedRef.current.add(runId);
       resumeInFlightRef.current.add(runId);
       cancelStreamForConversation(conversationId);
-      const agentMessageIndex = ensureAgentPlaceholder(conversationId, placeholderId, turnId, replayFromStart);
-      if (agentMessageIndex < 0) {
+      const initialAgentMessageIndex = ensureAgentPlaceholder(conversationId, placeholderId, turnId, replayFromStart);
+      if (initialAgentMessageIndex < 0) {
         if (STREAM_DEBUG_ENABLED) {
           console.debug('[WorkspacePage] missing placeholder', { runId, conversationId });
         }
@@ -2770,6 +2795,10 @@ export default function WorkspacePage() {
         await streamAgentRun(
           runId,
           (chunk) => {
+            const agentMessageIndex = (() => {
+              const resolved = findAgentMessageIndexForRun(conversationId, placeholderId, turnId, runId);
+              return resolved >= 0 ? resolved : initialAgentMessageIndex;
+            })();
             const resumableChunk = chunk as AgentStreamChunk & { id?: string };
             if (typeof resumableChunk.id === 'string') {
               lastStreamId = resumableChunk.id;
@@ -2796,6 +2825,10 @@ export default function WorkspacePage() {
         );
       } catch (error) {
         const supersededByNewerStream = streamAbortMapRef.current.get(conversationId) !== controller;
+        const agentMessageIndex = (() => {
+          const resolved = findAgentMessageIndexForRun(conversationId, placeholderId, turnId, runId);
+          return resolved >= 0 ? resolved : initialAgentMessageIndex;
+        })();
         if ((error as DOMException)?.name === 'AbortError') {
           if (stopRequestedRef.current) {
             appendAgentChunk(conversationId, agentMessageIndex, '\n[Stopped by user]');
@@ -2845,6 +2878,10 @@ export default function WorkspacePage() {
         }
         const effectivePendingInterrupt = latestRunMeta ? latestRunMeta.pendingInterrupt : latestInterrupt;
         if (!supersededByNewerStream && effectivePendingInterrupt) {
+            const agentMessageIndex = (() => {
+              const resolved = findAgentMessageIndexForRun(conversationId, placeholderId, turnId, runId);
+              return resolved >= 0 ? resolved : initialAgentMessageIndex;
+            })();
             finalStatus = 'awaiting_approval';
             updateMessageMetadataAtIndex(conversationId, agentMessageIndex, (metadata) => ({
               ...metadata,
@@ -2914,6 +2951,7 @@ export default function WorkspacePage() {
       handleStreamChunk,
       flushBufferedAgentChunks,
       getBufferedAgentText,
+      findAgentMessageIndexForRun,
       getRunStatus,
       addLocalSystemMessage,
       removeActiveRun,

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef, useCallback, useMemo, Children, isValidElement, type ChangeEvent } from 'react';
-import type { CSSProperties, ReactNode } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, type ChangeEvent } from 'react';
+import type { ComponentProps, CSSProperties } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -61,7 +61,6 @@ import ExpandableSidebar from '../components/ExpandableSidebar';
 import AgentChatPane from '../components/chat/AgentChatPane';
 import { buildApprovalDraftContent, buildApprovalReview } from '../components/chat/approvalReview';
 import type { RenderableInterruptAction } from '../components/chat/interruptActions';
-import ToolOutputFilePreview from '../components/chat/ToolOutputFilePreview';
 import { useAuth } from '../auth/AuthProvider';
 import {
   CANVAS_ZOOM_STEP,
@@ -73,6 +72,7 @@ import {
 } from '../constants/workspace';
 import { getFileDisplayName, getFileTypeIcon, isSystemFile, normalizeFilePath } from '../utils/files';
 import { buildMessageMetadata, mapMessagesToAgentHistory, mergeMessageMetadata, sanitizeRunPolicy } from '../utils/messages';
+import { createMarkdownComponents } from '../components/markdown/MarkdownShared';
 
 const drawerWidth = 280;
 
@@ -175,7 +175,6 @@ type ActiveRunInfo = {
 };
 
 const ACTIVE_RUNS_STORAGE_KEY = 'helpudoc-active-runs';
-const BLOCK_LEVEL_TAGS = ['div', 'pre', 'table', 'ol', 'ul', 'li', 'blockquote', 'section', 'article'];
 const MARKDOWN_FILE_EXTENSIONS = ['.md'];
 const HTML_FILE_EXTENSIONS = ['.html', '.htm'];
 const IMAGE_FILE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp'];
@@ -646,96 +645,37 @@ export default function WorkspacePage() {
     }
   }, []);
 
-  const classifyCodeBlockLabel = useCallback((languageMatch: RegExpExecArray | null, content: string) => {
-    if (languageMatch?.[1]) {
-      return languageMatch[1].toUpperCase();
-    }
-    const trimmed = content.trim();
-    const isSingleLine = !trimmed.includes('\n');
-    if (isSingleLine && /^[\w-]+\.[\w.-]+$/.test(trimmed)) {
-      return 'FILE';
-    }
-    if (isSingleLine && /^[a-z0-9_-]+$/i.test(trimmed)) {
-      return 'TOOL';
-    }
-    return 'CODE';
-  }, []);
-
-  const extractCodeText = useCallback((value: ReactNode): string => {
-    if (value === null || value === undefined) {
-      return '';
-    }
-    if (Array.isArray(value)) {
-      return value.map((child) => extractCodeText(child)).join('');
-    }
-    if (typeof value === 'string' || typeof value === 'number') {
-      return String(value);
-    }
-    return '';
-  }, []);
-
-  const inferInlineCode = useCallback(
-    (inline: boolean | undefined, className: string | undefined, content: string, node?: any) => {
-      if (typeof inline === 'boolean') {
-        return inline;
-      }
-      const startLine = node?.position?.start?.line;
-      const endLine = node?.position?.end?.line;
-      if (typeof startLine === 'number' && typeof endLine === 'number' && endLine > startLine) {
-        return false;
-      }
-      if (className && /language-\w+/i.test(className)) {
-        return false;
-      }
-      if (content.includes('\n')) {
-        return false;
-      }
-      return true;
-    },
-    []
-  );
-
   const markdownComponents = useMemo(
     () => ({
-      p({ children }: { children?: ReactNode }) {
-        const childArray = Children.toArray(children);
-        const containsBlockChild = childArray.some(
-          (child) => {
-            if (!isValidElement(child)) {
-              return false;
-            }
-            const childProps = child.props as {
-              inline?: boolean;
-              node?: { tagName?: string };
-              className?: string;
-              children?: ReactNode;
-            };
-            if (typeof child.type === 'string') {
-              return BLOCK_LEVEL_TAGS.includes(child.type);
-            }
-            if (childProps.inline === false) {
-              return true;
-            }
-            if (childProps.node?.tagName && BLOCK_LEVEL_TAGS.includes(childProps.node.tagName)) {
-              return true;
-            }
-            if (childProps.node?.tagName === 'code') {
-              const content = extractCodeText(childProps.children);
-              const isInline = inferInlineCode(
-                childProps.inline,
-                childProps.className,
-                content,
-                childProps.node
-              );
-              return !isInline;
-            }
-            return false;
-          }
-        );
-        const Element: 'p' | 'div' = containsBlockChild ? 'div' : 'p';
-        return <Element className="mb-4 leading-relaxed text-slate-700">{children}</Element>;
-      },
-      a({ ...props }: any) {
+      ...createMarkdownComponents({
+        workspaceId: selectedWorkspace?.id,
+        colorMode: colorMode === 'dark' ? 'dark' : 'light',
+        paragraphClassName: 'mb-4 leading-relaxed text-slate-700',
+        inlineCodeClassName: 'rounded-md bg-slate-200 px-1.5 py-0.5 font-mono text-xs text-slate-800',
+        codeBlockShell: ({ blockId, codeContent, languageLabel, className, children }) => {
+          const copyLabel = copiedCodeBlockId === blockId ? 'Copied' : 'Copy';
+          return (
+            <div className="mb-4 mt-2 overflow-hidden rounded-2xl border border-slate-200 bg-slate-950/90 text-slate-100 shadow-lg">
+              <div className="flex items-center justify-between border-b border-slate-800 bg-slate-900/60 px-4 py-2 text-[11px] font-semibold tracking-wide uppercase text-slate-300">
+                <span>{languageLabel}</span>
+                <button
+                  type="button"
+                  onClick={() => handleCopyCodeBlock(blockId, codeContent)}
+                  className="flex items-center gap-1 rounded-full border border-slate-600 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-slate-200 hover:border-slate-400"
+                >
+                  {copyLabel}
+                </button>
+              </div>
+              <pre className="overflow-x-auto px-4 py-3 text-xs leading-relaxed whitespace-pre-wrap break-words sm:text-sm">
+                <code className={`font-mono ${className || ''}`.trim()}>
+                  {children}
+                </code>
+              </pre>
+            </div>
+          );
+        },
+      }),
+      a({ ...props }: ComponentProps<'a'>) {
         return (
           <a
             {...props}
@@ -745,78 +685,8 @@ export default function WorkspacePage() {
           />
         );
       },
-      img({ src, alt }: { src?: string; alt?: string }) {
-        const resolvedSrc = typeof src === 'string' ? src.trim() : '';
-        if (!resolvedSrc) {
-          return null;
-        }
-        if (/^(https?:|data:|blob:)/i.test(resolvedSrc)) {
-          return (
-            <img
-              src={resolvedSrc}
-              alt={alt || 'Image'}
-              className="my-3 max-w-full rounded border border-gray-200"
-            />
-          );
-        }
-        if (!selectedWorkspace?.id) {
-          return (
-            <span className="text-xs text-slate-500">
-              Image path: <code>{resolvedSrc}</code>
-            </span>
-          );
-        }
-        return (
-          <div className="my-3">
-            <ToolOutputFilePreview
-              workspaceId={selectedWorkspace.id}
-              file={{ path: resolvedSrc, mimeType: 'image/*' }}
-            />
-          </div>
-        );
-      },
-      code({ inline, className, children, node, ...props }: any) {
-        const rawCodeContent = extractCodeText(children);
-        const isInline = inferInlineCode(inline, className, rawCodeContent, node);
-        if (isInline) {
-          return (
-            <code
-              className={`rounded-md bg-slate-200 px-1.5 py-0.5 font-mono text-xs text-slate-800 ${className || ''}`}
-              {...props}
-            >
-              {children}
-            </code>
-          );
-        }
-
-        const languageMatch = /language-(\w+)/.exec(className || '');
-        const codeContent = rawCodeContent.replace(/\n$/, '');
-        const languageLabel = classifyCodeBlockLabel(languageMatch, codeContent);
-        const blockId = `${languageLabel}-${codeContent.length}-${codeContent.charCodeAt(0) || 0}`;
-        const copyLabel = copiedCodeBlockId === blockId ? 'Copied' : 'Copy';
-
-        return (
-          <div className="mb-4 mt-2 overflow-hidden rounded-2xl border border-slate-200 bg-slate-950/90 text-slate-100 shadow-lg">
-            <div className="flex items-center justify-between border-b border-slate-800 bg-slate-900/60 px-4 py-2 text-[11px] font-semibold tracking-wide uppercase text-slate-300">
-              <span>{languageLabel}</span>
-              <button
-                type="button"
-                onClick={() => handleCopyCodeBlock(blockId, codeContent)}
-                className="flex items-center gap-1 rounded-full border border-slate-600 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-slate-200 hover:border-slate-400"
-              >
-                {copyLabel}
-              </button>
-            </div>
-            <pre className="overflow-x-auto px-4 py-3 text-xs leading-relaxed whitespace-pre-wrap break-words sm:text-sm">
-              <code {...props} className={`font-mono ${className || ''}`}>
-                {children}
-              </code>
-            </pre>
-          </div>
-        );
-      },
     }),
-    [classifyCodeBlockLabel, copiedCodeBlockId, extractCodeText, handleCopyCodeBlock, inferInlineCode, selectedWorkspace?.id]
+    [colorMode, copiedCodeBlockId, handleCopyCodeBlock, selectedWorkspace?.id]
   );
 
   const toggleToolActivityVisibility = useCallback((messageId: ConversationMessage['id']) => {
@@ -4801,6 +4671,7 @@ export default function WorkspacePage() {
                         >
                           <UIBlockRenderer
                             blocks={canvasBlocks}
+                            workspaceId={selectedWorkspace?.id}
                             className="h-full w-full"
                             emptyState={
                               <div className="text-center text-gray-400">

--- a/frontend/src/services/agentApi.ts
+++ b/frontend/src/services/agentApi.ts
@@ -19,6 +19,18 @@ export type AgentRunStartResponse = {
   status: AgentRunStatus;
 };
 
+const readErrorMessage = async (response: Response, fallback: string): Promise<string> => {
+  try {
+    const payload = await response.json();
+    if (payload && typeof payload === 'object' && typeof payload.error === 'string' && payload.error.trim()) {
+      return payload.error;
+    }
+  } catch {
+    // Ignore non-JSON error responses and fall back to the generic message.
+  }
+  return fallback;
+};
+
 export const startAgentRun = async (
   workspaceId: string,
   persona: string,
@@ -110,7 +122,7 @@ export const submitRunDecision = async (
     }),
   });
   if (!response.ok) {
-    throw new Error('Failed to submit run decision');
+    throw new Error(await readErrorMessage(response, 'Failed to submit run decision'));
   }
   return response.json();
 };
@@ -131,7 +143,27 @@ export const submitRunResponse = async (
     body: JSON.stringify(payload),
   });
   if (!response.ok) {
-    throw new Error('Failed to submit clarification response');
+    throw new Error(await readErrorMessage(response, 'Failed to submit clarification response'));
+  }
+  return response.json();
+};
+
+export const submitRunAction = async (
+  runId: string,
+  payload: {
+    actionId: string;
+    text?: string;
+  },
+) => {
+  const response = await apiFetch(`${API_URL}/agent/runs/${runId}/act`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error(await readErrorMessage(response, 'Failed to submit interrupt action'));
   }
   return response.json();
 };

--- a/frontend/src/services/fileApi.ts
+++ b/frontend/src/services/fileApi.ts
@@ -40,6 +40,23 @@ export const createFile = async (workspaceId: string, file: File) => {
   return response.json();
 };
 
+export const createTextFile = async (
+  workspaceId: string,
+  payload: { name: string; content: string; mimeType?: string },
+) => {
+  const response = await apiFetch(`${API_URL}/workspaces/${workspaceId}/files/text`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error('Failed to create text file');
+  }
+  return response.json();
+};
+
 export const updateFileContent = async (
   workspaceId: string,
   fileId: number,

--- a/frontend/src/services/workspaceApi.ts
+++ b/frontend/src/services/workspaceApi.ts
@@ -15,6 +15,14 @@ export const getWorkspace = async (workspaceId: string) => {
   return response.json();
 };
 
+export const getWorkspaceSettings = async (workspaceId: string) => {
+  const response = await apiFetch(`${API_URL}/workspaces/${workspaceId}/settings`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch workspace settings');
+  }
+  return response.json();
+};
+
 
 export const createWorkspace = async (name: string) => {
   const response = await apiFetch(`${API_URL}/workspaces`, {
@@ -37,4 +45,21 @@ export const deleteWorkspace = async (workspaceId: string) => {
   if (!response.ok) {
     throw new Error('Failed to delete workspace');
   }
+};
+
+export const updateWorkspaceSettings = async (
+  workspaceId: string,
+  payload: { skipPlanApprovals: boolean },
+) => {
+  const response = await apiFetch(`${API_URL}/workspaces/${workspaceId}/settings`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error('Failed to update workspace settings');
+  }
+  return response.json();
 };

--- a/packages/shared/src/services/agentStream.ts
+++ b/packages/shared/src/services/agentStream.ts
@@ -21,6 +21,17 @@ export type AgentStreamChunk =
       description?: string;
       stepIndex?: number;
       stepCount?: number;
+      actions?: Array<{
+        id: string;
+        label: string;
+        style?: 'primary' | 'secondary' | 'danger';
+        inputMode?: 'none' | 'text';
+        placeholder?: string;
+        submitLabel?: string;
+        confirm?: boolean;
+        value?: string;
+        payload?: Record<string, unknown>;
+      }>;
       actionRequests?: Array<{ name?: string; args?: Record<string, unknown> }>;
       reviewConfigs?: Array<{ action_name?: string; allowed_decisions?: string[] }>;
       responseSpec?: {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2,6 +2,7 @@ export interface Workspace {
   id: string;
   name: string;
   lastUsed: string;
+  skipPlanApprovals?: boolean;
 }
 
 export interface File {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -53,6 +53,18 @@ export interface InterruptChoice {
   value: string;
 }
 
+export interface InterruptAction {
+  id: string;
+  label: string;
+  style?: 'primary' | 'secondary' | 'danger';
+  inputMode?: 'none' | 'text';
+  placeholder?: string;
+  submitLabel?: string;
+  confirm?: boolean;
+  value?: string;
+  payload?: Record<string, unknown>;
+}
+
 export interface InterruptResponseSpec {
   inputMode?: 'none' | 'text' | 'choice' | 'text_or_choice';
   multiple?: boolean;
@@ -70,6 +82,7 @@ export interface PendingInterrupt {
   description?: string;
   stepIndex?: number;
   stepCount?: number;
+  actions?: InterruptAction[];
   actionRequests?: Array<{ name?: string; args?: Record<string, unknown> }>;
   reviewConfigs?: Array<{ action_name?: string; allowed_decisions?: string[] }>;
   responseSpec?: InterruptResponseSpec;

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -4,6 +4,8 @@ description: Produce a sourced, long-form research report in the user's language
 tools:
   - google_search
   - request_plan_approval
+  - request_clarification
+  - request_human_action
 source_skills:
   - research-core
   - research-sub_researcher


### PR DESCRIPTION
## Summary
- wire the MDXEditor rich markdown stack for links, tables, images, code blocks, and markdown shortcuts
- add shared markdown rendering helpers for Mermaid and workspace-relative images
- align rich editor and viewer markdown styling so heading scales and block rendering match

## Validation
- npm install
- npx tsc --noEmit
- NODE_OPTIONS=--max-old-space-size=4096 npm run build