### PR TITLE
Refine admin settings page scaffold

### DIFF
--- a/frontend/src/components/settings/AgentSettingsTabs.tsx
+++ b/frontend/src/components/settings/AgentSettingsTabs.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Wrench, Loader2, Library } from 'lucide-react';
+import { Wrench, Library, Loader2 } from 'lucide-react';
 import { fetchAgentConfig, saveAgentConfig } from '../../services/settingsApi';
 import ToolsTab from './ToolsTab';
 import SkillsRegistryTab from './SkillsRegistryTab';
+import { SettingsEmptyState, SettingsLoadingState, SettingsTabPanel, SettingsTabs } from './SettingsScaffold';
 import YAML from 'yaml';
 import { getAuthUser } from '../../auth/authStore';
 
@@ -36,7 +37,7 @@ const AgentSettingsTabs = () => {
     }, []);
 
     useEffect(() => {
-        loadConfig();
+        void loadConfig();
     }, [loadConfig]);
 
     const handleSave = async (newConfig: any) => {
@@ -62,59 +63,52 @@ const AgentSettingsTabs = () => {
 
     if (loading) {
         return (
-            <div className="flex items-center justify-center h-64">
-                <Loader2 className="animate-spin text-slate-400" size={32} />
-            </div>
+            <SettingsTabPanel className="flex min-h-[320px] items-center justify-center">
+                <SettingsLoadingState label="Loading agent configuration..." />
+            </SettingsTabPanel>
         );
     }
 
     if (error) {
         return (
-            <div className="p-6 text-center">
-                <p className="text-rose-600 mb-4">{error}</p>
-                <button
-                    onClick={loadConfig}
-                    className="px-4 py-2 bg-slate-900 text-white rounded-lg hover:bg-slate-800"
-                >
-                    Retry
-                </button>
-            </div>
+            <SettingsTabPanel className="flex min-h-[320px] items-center">
+                <SettingsEmptyState
+                    title="Unable to load settings"
+                    description={error}
+                    icon={Loader2}
+                    action={
+                        <button
+                            type="button"
+                            onClick={loadConfig}
+                            className="rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800"
+                        >
+                            Retry
+                        </button>
+                    }
+                />
+            </SettingsTabPanel>
         );
     }
 
     return (
         <div className="space-y-6">
-            <div className="flex items-center gap-1 bg-slate-100 p-1 rounded-xl w-fit">
-                <button
-                    onClick={() => setActiveTab('tools')}
-                    className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${activeTab === 'tools'
-                            ? 'bg-white text-slate-900 shadow-sm'
-                            : 'text-slate-600 hover:text-slate-900'
-                        }`}
-                >
-                    <Wrench size={16} />
-                    Tools & MCP
-                </button>
-                <button
-                    onClick={() => setActiveTab('skills')}
-                    className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${activeTab === 'skills'
-                            ? 'bg-white text-slate-900 shadow-sm'
-                            : 'text-slate-600 hover:text-slate-900'
-                        }`}
-                >
-                    <Library size={16} />
-                    Skill Registry
-                </button>
-            </div>
+            <SettingsTabs
+                tabs={[
+                    { id: 'skills', label: 'Skill Registry', icon: Library },
+                    { id: 'tools', label: 'Tools & MCP', icon: Wrench },
+                ]}
+                value={activeTab}
+                onChange={setActiveTab}
+            />
 
-            <div className="bg-white rounded-3xl border border-slate-200 shadow-sm p-6 min-h-[500px]">
+            <SettingsTabPanel>
                 {activeTab === 'tools' && (
                     <ToolsTab config={config} onSave={handleSave} isSaving={saving} />
                 )}
                 {activeTab === 'skills' && (
                     <SkillsRegistryTab />
                 )}
-            </div>
+            </SettingsTabPanel>
         </div>
     );
 };

--- a/frontend/src/components/settings/SettingsScaffold.tsx
+++ b/frontend/src/components/settings/SettingsScaffold.tsx
@@ -1,0 +1,180 @@
+import type { ComponentType, ReactNode } from 'react';
+import { Loader2 } from 'lucide-react';
+
+const cx = (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' ');
+
+type SurfaceProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export const SettingsSurface = ({ children, className }: SurfaceProps) => (
+  <section
+    className={cx(
+      'rounded-[28px] border border-slate-200/80 bg-white/95 p-6 shadow-[0_18px_45px_rgba(15,23,42,0.08)] backdrop-blur',
+      className,
+    )}
+  >
+    {children}
+  </section>
+);
+
+type SectionHeaderProps = {
+  title: string;
+  description?: string;
+  eyebrow?: string;
+  actions?: ReactNode;
+};
+
+export const SettingsSectionHeader = ({ title, description, eyebrow, actions }: SectionHeaderProps) => (
+  <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+    <div className="space-y-1.5">
+      {eyebrow ? (
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">{eyebrow}</p>
+      ) : null}
+      <h3 className="text-lg font-semibold text-slate-950">{title}</h3>
+      {description ? <p className="max-w-2xl text-sm leading-6 text-slate-600">{description}</p> : null}
+    </div>
+    {actions ? <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div> : null}
+  </div>
+);
+
+type NoticeProps = {
+  children: ReactNode;
+  variant?: 'info' | 'warning' | 'error';
+  className?: string;
+};
+
+const noticeStyles: Record<NonNullable<NoticeProps['variant']>, string> = {
+  info: 'border-slate-200 bg-slate-50 text-slate-700',
+  warning: 'border-amber-200 bg-amber-50 text-amber-800',
+  error: 'border-rose-200 bg-rose-50 text-rose-700',
+};
+
+export const SettingsNotice = ({ children, variant = 'info', className }: NoticeProps) => (
+  <div className={cx('rounded-2xl border px-4 py-3 text-sm shadow-sm', noticeStyles[variant], className)}>{children}</div>
+);
+
+type EmptyStateProps = {
+  title: string;
+  description: string;
+  icon?: ComponentType<{ size?: number; className?: string }>;
+  action?: ReactNode;
+  align?: 'left' | 'center';
+};
+
+export const SettingsEmptyState = ({
+  title,
+  description,
+  icon: Icon,
+  action,
+  align = 'center',
+}: EmptyStateProps) => (
+  <div
+    className={cx(
+      'rounded-[24px] border border-dashed border-slate-200 bg-slate-50/90 p-8',
+      align === 'center' ? 'text-center' : 'text-left',
+    )}
+  >
+    <div className={cx('flex gap-4', align === 'center' ? 'flex-col items-center' : 'items-start')}>
+      {Icon ? (
+        <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white text-slate-700 shadow-sm ring-1 ring-slate-200">
+          <Icon size={20} />
+        </span>
+      ) : null}
+      <div className={cx('space-y-2', align === 'center' ? 'max-w-md' : 'flex-1')}>
+        <p className="text-base font-semibold text-slate-900">{title}</p>
+        <p className="text-sm leading-6 text-slate-600">{description}</p>
+        {action ? <div className={cx('pt-2', align === 'center' ? 'flex justify-center' : 'flex')}>{action}</div> : null}
+      </div>
+    </div>
+  </div>
+);
+
+type LoadingStateProps = {
+  label: string;
+  className?: string;
+};
+
+export const SettingsLoadingState = ({ label, className }: LoadingStateProps) => (
+  <div className={cx('flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600', className)}>
+    <Loader2 className="h-4 w-4 animate-spin" />
+    {label}
+  </div>
+);
+
+type MetricsGridProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export const SettingsMetricsGrid = ({ children, className }: MetricsGridProps) => (
+  <div className={cx('grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3', className)}>{children}</div>
+);
+
+type MetricCardProps = {
+  label: string;
+  value: string;
+  hint?: string;
+  icon?: ComponentType<{ size?: number; className?: string }>;
+};
+
+export const SettingsMetricCard = ({ label, value, hint, icon: Icon }: MetricCardProps) => (
+  <div className="rounded-[24px] border border-slate-200/80 bg-gradient-to-br from-white via-slate-50 to-slate-100/80 p-5 shadow-[0_10px_30px_rgba(15,23,42,0.06)]">
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">{label}</p>
+        <p className="mt-3 text-3xl font-semibold text-slate-950">{value}</p>
+        {hint ? <p className="mt-1 text-sm text-slate-500">{hint}</p> : null}
+      </div>
+      {Icon ? (
+        <span className="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-900 text-white shadow-sm">
+          <Icon size={18} />
+        </span>
+      ) : null}
+    </div>
+  </div>
+);
+
+type TabsProps<T extends string> = {
+  tabs: Array<{
+    id: T;
+    label: string;
+    icon?: ComponentType<{ size?: number; className?: string }>;
+  }>;
+  value: T;
+  onChange: (value: T) => void;
+};
+
+export const SettingsTabs = <T extends string>({ tabs, value, onChange }: TabsProps<T>) => (
+  <div className="inline-flex flex-wrap items-center gap-1 rounded-2xl border border-slate-200 bg-slate-100/90 p-1 shadow-inner">
+    {tabs.map(({ id, label, icon: Icon }) => {
+      const isActive = id === value;
+      return (
+        <button
+          key={id}
+          type="button"
+          onClick={() => onChange(id)}
+          className={cx(
+            'inline-flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-medium transition',
+            isActive
+              ? 'bg-white text-slate-950 shadow-sm ring-1 ring-slate-200'
+              : 'text-slate-600 hover:bg-white/80 hover:text-slate-900',
+          )}
+        >
+          {Icon ? <Icon size={16} /> : null}
+          {label}
+        </button>
+      );
+    })}
+  </div>
+);
+
+type TabPanelProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export const SettingsTabPanel = ({ children, className }: TabPanelProps) => (
+  <SettingsSurface className={cx('min-h-[500px]', className)}>{children}</SettingsSurface>
+);

--- a/frontend/src/components/settings/SettingsShell.tsx
+++ b/frontend/src/components/settings/SettingsShell.tsx
@@ -7,6 +7,7 @@ import {
   CreditCard,
   MessageCircle,
   ArrowLeftCircle,
+  PanelLeft,
 } from 'lucide-react';
 
 type NavItem = {
@@ -37,13 +38,22 @@ const SettingsShell = ({ title, description, eyebrow = 'Workspace settings', act
   const navItems = useMemo(() => BASE_NAV_ITEMS, []);
 
   return (
-    <div className="flex min-h-screen bg-slate-50">
-      <aside className="w-64 border-r border-slate-200 bg-white/95 backdrop-blur flex flex-col">
-        <div className="p-6 border-b border-slate-100">
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(148,163,184,0.14),_transparent_35%),linear-gradient(180deg,_#f8fafc_0%,_#eef2f7_100%)] lg:flex">
+      <aside className="border-b border-slate-200/80 bg-white/90 backdrop-blur lg:flex lg:min-h-screen lg:w-72 lg:flex-col lg:border-b-0 lg:border-r">
+        <div className="border-b border-slate-100 px-6 py-5">
           <p className="text-[11px] uppercase tracking-[0.18em] text-slate-500">Workspace settings</p>
-          <h1 className="text-xl font-semibold text-slate-900 mt-1">Admin Portal</h1>
+          <div className="mt-2 flex items-center gap-3">
+            <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-slate-900 text-white shadow-sm">
+              <PanelLeft size={18} />
+            </span>
+            <div>
+              <h1 className="text-xl font-semibold text-slate-900">Admin Portal</h1>
+              <p className="text-sm text-slate-500">Unified settings, people, and knowledge controls.</p>
+            </div>
+          </div>
         </div>
-        <nav className="flex-1 p-4 space-y-1">
+        <nav className="flex-1 overflow-x-auto p-4">
+          <div className="flex gap-2 lg:block lg:space-y-1">
           {navItems.map(({ label, icon: Icon, path }) => {
             const isActive = path === '/settings'
               ? location.pathname === path
@@ -54,7 +64,7 @@ const SettingsShell = ({ title, description, eyebrow = 'Workspace settings', act
                 key={label}
                 to={path}
                 aria-current={isActive ? 'page' : undefined}
-                className={`flex items-center gap-3 px-3 py-2 rounded-xl text-sm font-medium transition-colors ${isActive
+                className={`flex min-w-fit items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-colors ${isActive
                   ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900/5'
                   : 'text-slate-600 hover:text-slate-900 hover:bg-slate-100'
                   }`}
@@ -64,8 +74,15 @@ const SettingsShell = ({ title, description, eyebrow = 'Workspace settings', act
               </Link>
             );
           })}
+          </div>
         </nav>
-        <div className="p-4 border-t border-slate-100">
+        <div className="border-t border-slate-100 p-4 lg:hidden">
+          <Link to="/" className="inline-flex items-center gap-2 text-sm text-slate-600 transition-colors hover:text-slate-900">
+            <ArrowLeftCircle size={16} />
+            Back to Workspace
+          </Link>
+        </div>
+        <div className="hidden border-t border-slate-100 p-4 lg:block">
           <Link to="/" className="inline-flex items-center gap-2 text-sm text-slate-600 hover:text-slate-900 transition-colors">
             <ArrowLeftCircle size={16} />
             Back to Workspace
@@ -73,20 +90,22 @@ const SettingsShell = ({ title, description, eyebrow = 'Workspace settings', act
         </div>
       </aside>
 
-      <main className="flex-1 overflow-y-auto bg-gradient-to-br from-slate-50 via-white to-slate-100">
-        <div className="mx-auto max-w-6xl px-8 py-12 space-y-8">
-          <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+      <main className="flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-10 lg:py-10">
+          <div className="space-y-6">
+          <div className="rounded-[32px] border border-slate-200/80 bg-white/92 p-6 shadow-[0_22px_55px_rgba(15,23,42,0.08)] backdrop-blur sm:p-8">
             <p className="text-xs uppercase tracking-wide text-slate-500">{eyebrow}</p>
             <div className="mt-3 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
               <div>
-                <h2 className="text-2xl font-semibold text-slate-900">{title}</h2>
-                {description && <p className="text-slate-600 mt-2 max-w-2xl">{description}</p>}
+                <h2 className="text-2xl font-semibold text-slate-900 sm:text-[2rem]">{title}</h2>
+                {description && <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600 sm:text-base">{description}</p>}
               </div>
-              {actions ? <div className="flex items-center gap-3">{actions}</div> : null}
+              {actions ? <div className="flex flex-wrap items-center gap-3">{actions}</div> : null}
             </div>
           </div>
 
           {children}
+          </div>
         </div>
       </main>
     </div>

--- a/frontend/src/pages/BillingPage.tsx
+++ b/frontend/src/pages/BillingPage.tsx
@@ -1,5 +1,6 @@
 import { CreditCard } from 'lucide-react';
 import SettingsShell from '../components/settings/SettingsShell';
+import { SettingsEmptyState, SettingsSurface } from '../components/settings/SettingsScaffold';
 
 const BillingPage = () => {
   return (
@@ -8,17 +9,13 @@ const BillingPage = () => {
       title="Billing"
       description="Manage your subscription, invoices, and payment methods."
     >
-      <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
-        <div className="flex flex-col items-center gap-4 text-center text-slate-600">
-          <span className="flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-100 text-slate-700">
-            <CreditCard size={28} />
-          </span>
-          <div>
-            <p className="font-semibold text-slate-900">Billing management is coming soon.</p>
-            <p className="mt-2">You&apos;ll be able to manage plans, invoices, and payment methods from here.</p>
-          </div>
-        </div>
-      </div>
+      <SettingsSurface>
+        <SettingsEmptyState
+          title="Billing management is coming soon"
+          description="You’ll be able to manage plans, invoices, and payment methods from this page once billing workflows are connected."
+          icon={CreditCard}
+        />
+      </SettingsSurface>
     </SettingsShell>
   );
 };

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,12 @@
 import { Link } from 'react-router-dom';
 import { Users2, Hammer, MessageCircle, Activity, Sparkles } from 'lucide-react';
 import SettingsShell from '../components/settings/SettingsShell';
+import {
+  SettingsMetricCard,
+  SettingsMetricsGrid,
+  SettingsSectionHeader,
+  SettingsSurface,
+} from '../components/settings/SettingsScaffold';
 
 const DashboardPage = () => {
   const stats = [
@@ -22,43 +28,36 @@ const DashboardPage = () => {
       description="Pulse for your admin portal with quick access to skills, users, and tools."
     >
       <div className="space-y-6">
-        <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <SettingsSurface>
+          <SettingsSectionHeader
+            eyebrow="Snapshot"
+            title="Key workspace signals"
+            description="A compact overview of usage, adoption, and tool activity across the admin portal."
+          />
+          <SettingsMetricsGrid className="mt-6 md:grid-cols-3">
             {stats.map(({ label, value, hint, icon: Icon }) => (
-              <div
-                key={label}
-                className="flex items-start justify-between gap-3 rounded-2xl border border-slate-100 bg-gradient-to-br from-slate-50 via-white to-slate-50 p-5 shadow-[0_6px_18px_rgba(15,23,42,0.06)]"
-              >
-                <div>
-                  <p className="text-[11px] uppercase tracking-[0.18em] text-slate-500">{label}</p>
-                  <p className="mt-2 text-3xl font-semibold text-slate-900">{value}</p>
-                  <p className="text-sm text-slate-500 mt-1">{hint}</p>
-                </div>
-                <span className="inline-flex h-11 w-11 items-center justify-center rounded-xl bg-slate-900 text-white shadow-sm">
-                  <Icon size={18} />
-                </span>
-              </div>
+              <SettingsMetricCard key={label} label={label} value={value} hint={hint} icon={Icon} />
             ))}
-          </div>
-        </section>
+          </SettingsMetricsGrid>
+        </SettingsSurface>
 
-        <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <div>
-              <h3 className="text-lg font-semibold text-slate-900">Recent Activity</h3>
-              <p className="text-sm text-slate-600">Stay on top of what changed across your workspace.</p>
-            </div>
-            <Link
-              to="/settings/agents"
-              className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-900 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800"
-            >
-              Manage skills
-            </Link>
-          </div>
-          <div className="mt-4 divide-y divide-slate-200">
+        <SettingsSurface>
+          <SettingsSectionHeader
+            title="Recent activity"
+            description="Stay on top of what changed across your workspace."
+            actions={(
+              <Link
+                to="/settings/agents"
+                className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-900 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800"
+              >
+                Manage skills
+              </Link>
+            )}
+          />
+          <div className="mt-6 divide-y divide-slate-200">
             {activities.map(({ title, meta, icon: Icon }) => (
               <div key={title} className="flex items-center gap-3 py-3">
-                <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-slate-100 text-slate-700">
+                <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-slate-100 text-slate-700">
                   <Icon size={18} />
                 </span>
                 <div>
@@ -68,7 +67,7 @@ const DashboardPage = () => {
               </div>
             ))}
           </div>
-        </section>
+        </SettingsSurface>
       </div>
     </SettingsShell>
   );

--- a/frontend/src/pages/KnowledgePage.tsx
+++ b/frontend/src/pages/KnowledgePage.tsx
@@ -2,6 +2,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { FileIcon, Loader2, NotebookPen, Plus, RotateCcw, Trash } from 'lucide-react';
 import SettingsShell from '../components/settings/SettingsShell';
+import {
+  SettingsEmptyState,
+  SettingsLoadingState,
+  SettingsNotice,
+  SettingsSectionHeader,
+  SettingsSurface,
+} from '../components/settings/SettingsScaffold';
 import { getWorkspaces } from '../services/workspaceApi';
 import { createKnowledge, deleteKnowledge, listKnowledge } from '../services/knowledgeApi';
 import { createFile, getRagStatuses } from '../services/fileApi';
@@ -360,30 +367,20 @@ const KnowledgePage = () => {
     >
       <div className="space-y-6">
         {!selectedWorkspace && !loadingWorkspaces ? (
-          <div className="rounded-3xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-700 shadow-sm">
-            Create or select a workspace to manage knowledge sources.
-          </div>
+          <SettingsNotice variant="warning">Create or select a workspace to manage knowledge sources.</SettingsNotice>
         ) : null}
 
         {errorMessage ? (
-          <div className="rounded-3xl border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700 shadow-sm">
-            {errorMessage}
-          </div>
+          <SettingsNotice variant="error">{errorMessage}</SettingsNotice>
         ) : null}
 
         <div className="grid gap-6 lg:grid-cols-[1.05fr_1.95fr]">
-          <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-            <div className="flex items-start gap-4">
-              <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-100 text-slate-700">
-                <NotebookPen size={22} />
-              </span>
-              <div>
-                <p className="text-lg font-semibold text-slate-900">Add knowledge</p>
-                <p className="text-sm text-slate-600">
-                  Upload files and we will index supported documents automatically.
-                </p>
-              </div>
-            </div>
+          <SettingsSurface>
+            <SettingsSectionHeader
+              eyebrow="Ingest"
+              title="Add knowledge"
+              description="Upload files and we’ll index supported documents automatically."
+            />
 
             <div className="mt-6 rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-6 text-center">
               <input
@@ -397,7 +394,7 @@ const KnowledgePage = () => {
                 type="button"
                 onClick={handleUploadClick}
                 disabled={!selectedWorkspaceId || uploading}
-                className="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800 disabled:opacity-60"
+                className="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-4 py-2.5 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800 disabled:opacity-60"
               >
                 {uploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus size={16} />}
                 Upload files
@@ -410,7 +407,7 @@ const KnowledgePage = () => {
               ) : null}
             </div>
 
-            <div className="mt-6 rounded-2xl border border-slate-100 bg-white/70 p-4">
+            <div className="mt-6 rounded-[24px] border border-slate-100 bg-white/70 p-5">
               <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Tips</p>
               <ul className="mt-2 space-y-2 text-sm text-slate-600">
                 <li>RAG indexing runs for PDF, DOC/DOCX, and Markdown files.</li>
@@ -419,42 +416,39 @@ const KnowledgePage = () => {
                 <li>Use the workspace selector above to target a different knowledge base.</li>
               </ul>
             </div>
-          </section>
+          </SettingsSurface>
 
-          <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-              <div>
-                <p className="text-lg font-semibold text-slate-900">Knowledge sources</p>
-                <p className="text-sm text-slate-600">
-                  {selectedWorkspace ? `Workspace: ${selectedWorkspace.name}` : 'No workspace selected'}
-                </p>
-              </div>
-              <div className="flex items-center gap-2 text-xs text-slate-500">
-                {loadingKnowledge ? 'Loading sources...' : `${knowledgeSources.length} sources`}
-              </div>
-            </div>
-
-            <div className="mt-4 space-y-3">
-              {loadingKnowledge ? (
-                <div className="flex items-center gap-3 rounded-2xl border border-slate-100 bg-slate-50 p-4 text-sm text-slate-600">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Loading knowledge sources...
+          <SettingsSurface>
+            <SettingsSectionHeader
+              title="Knowledge sources"
+              description={selectedWorkspace ? `Workspace: ${selectedWorkspace.name}` : 'No workspace selected'}
+              actions={(
+                <div className="flex items-center gap-2 text-xs text-slate-500">
+                  {loadingKnowledge ? 'Loading sources...' : `${knowledgeSources.length} sources`}
                 </div>
+              )}
+            />
+
+            <div className="mt-6 space-y-3">
+              {loadingKnowledge ? (
+                <SettingsLoadingState label="Loading knowledge sources..." />
               ) : null}
 
               {!loadingKnowledge && knowledgeSources.length === 0 ? (
-                <div className="rounded-2xl border border-slate-100 bg-slate-50 p-6 text-center text-sm text-slate-600">
-                  Upload files to start building your knowledge library.
-                </div>
+                <SettingsEmptyState
+                  title="No knowledge sources yet"
+                  description="Upload files to start building your workspace knowledge library."
+                  icon={NotebookPen}
+                />
               ) : null}
 
               {knowledgeSources.map((item) => (
                 <div
                   key={item.id}
-                  className="rounded-2xl border border-slate-100 bg-white p-4 shadow-[0_8px_18px_rgba(15,23,42,0.06)]"
+                  className="rounded-[24px] border border-slate-200 bg-slate-50/70 p-4 shadow-[0_10px_22px_rgba(15,23,42,0.06)]"
                 >
                   <div className="flex items-start gap-4">
-                    <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-slate-100 text-slate-700">
+                    <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white text-slate-700 ring-1 ring-slate-200">
                       <FileIcon size={18} />
                     </span>
                     <div className="flex-1 space-y-2">
@@ -470,7 +464,7 @@ const KnowledgePage = () => {
                           {renderStatusBadge(item.file?.name)}
                           <button
                             type="button"
-                            className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2 py-1 text-xs text-slate-600 hover:bg-slate-50"
+                            className="inline-flex items-center gap-1 rounded-xl border border-slate-200 bg-white px-2.5 py-1.5 text-xs text-slate-600 transition hover:bg-slate-50"
                             onClick={() => handleDeleteKnowledge(item)}
                           >
                             <Trash size={12} />
@@ -485,23 +479,23 @@ const KnowledgePage = () => {
                 </div>
               ))}
             </div>
-          </section>
+          </SettingsSurface>
         </div>
 
-        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-semibold text-slate-900">Need to tune skills?</p>
-              <p className="text-sm text-slate-600">Keep skills and tools aligned for best results.</p>
-            </div>
-            <Link
-              to="/settings/agents"
-              className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-900 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800"
-            >
-              Configure skills
-            </Link>
-          </div>
-        </div>
+        <SettingsSurface>
+          <SettingsSectionHeader
+            title="Need to tune skills?"
+            description="Keep skills and tools aligned for best results."
+            actions={(
+              <Link
+                to="/settings/agents"
+                className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-900 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800"
+              >
+                Configure skills
+              </Link>
+            )}
+          />
+        </SettingsSurface>
       </div>
     </SettingsShell>
   );

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -2,6 +2,13 @@ import { useEffect, useMemo, useState } from 'react';
 import { Plus, ShieldCheck, ShieldOff, Trash2, Users2 } from 'lucide-react';
 import SettingsShell from '../components/settings/SettingsShell';
 import {
+  SettingsEmptyState,
+  SettingsLoadingState,
+  SettingsNotice,
+  SettingsSectionHeader,
+  SettingsSurface,
+} from '../components/settings/SettingsScaffold';
+import {
   addGroupMember,
   createGroup,
   deleteGroup,
@@ -138,6 +145,8 @@ const UsersPage = () => {
   };
 
   const selectableUsers = users.filter((user) => !groupMembers.some((member) => member.id === user.id));
+  const usersSummary = `${users.length} user${users.length === 1 ? '' : 's'}`;
+  const groupsSummary = `${groups.length} group${groups.length === 1 ? '' : 's'}`;
 
   return (
     <SettingsShell
@@ -145,127 +154,179 @@ const UsersPage = () => {
       title="User & Group Management"
       description="Manage system administrators and in-app user groups for RBAC rollout."
     >
-      {error && (
-        <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-          {error}
-        </div>
-      )}
+      <div className="space-y-6">
+        {error ? <SettingsNotice variant="error">{error}</SettingsNotice> : null}
 
-      <div className="grid gap-6 lg:grid-cols-2">
-        <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-          <div className="mb-4 flex items-center gap-3">
-            <Users2 size={20} className="text-slate-700" />
-            <h3 className="text-lg font-semibold text-slate-900">Users</h3>
-          </div>
-
-          {loading ? (
-            <p className="text-sm text-slate-600">Loading users…</p>
-          ) : (
-            <div className="space-y-3">
-              {users.map((user) => (
-                <div key={user.id} className="flex items-center justify-between rounded-xl border border-slate-200 px-3 py-2">
-                  <div>
-                    <p className="text-sm font-medium text-slate-900">{user.displayName}</p>
-                    <p className="text-xs text-slate-500">{user.email || user.externalId}</p>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => handleToggleAdmin(user)}
-                    className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs font-semibold ${user.isAdmin
-                      ? 'bg-emerald-100 text-emerald-800 hover:bg-emerald-200'
-                      : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
-                      }`}
-                  >
-                    {user.isAdmin ? <ShieldCheck size={14} /> : <ShieldOff size={14} />}
-                    {user.isAdmin ? 'Admin' : 'Member'}
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-        </section>
-
-        <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 className="text-lg font-semibold text-slate-900">Groups</h3>
-
-          <div className="mt-4 flex gap-2">
-            <input
-              value={newGroupName}
-              onChange={(event) => setNewGroupName(event.target.value)}
-              placeholder="Create group (e.g. analysts)"
-              className="flex-1 rounded-xl border border-slate-300 px-3 py-2 text-sm"
+        <div className="grid gap-6 xl:grid-cols-[1.05fr_1.15fr]">
+          <SettingsSurface>
+            <SettingsSectionHeader
+              eyebrow="Access"
+              title="Users"
+              description="Promote administrators and review who currently has access to this workspace."
+              actions={<span className="text-sm font-medium text-slate-500">{loading ? 'Loading...' : usersSummary}</span>}
             />
-            <button
-              type="button"
-              onClick={handleCreateGroup}
-              className="inline-flex items-center gap-1 rounded-xl bg-slate-900 px-3 py-2 text-sm font-semibold text-white"
-            >
-              <Plus size={14} />
-              Add
-            </button>
-          </div>
 
-          <div className="mt-4 space-y-2">
-            {groups.map((group) => (
-              <div key={group.id} className={`flex items-center justify-between rounded-xl border px-3 py-2 ${group.id === selectedGroupId ? 'border-slate-700 bg-slate-50' : 'border-slate-200'}`}>
-                <button
-                  type="button"
-                  className="text-sm font-medium text-slate-900"
-                  onClick={() => setSelectedGroupId(group.id)}
-                >
-                  {group.name}
-                </button>
-                <button
-                  type="button"
-                  className="rounded-md p-1 text-rose-600 hover:bg-rose-50"
-                  onClick={() => handleDeleteGroup(group.id)}
-                >
-                  <Trash2 size={14} />
-                </button>
-              </div>
-            ))}
-          </div>
+            <div className="mt-6 space-y-3">
+              {loading ? <SettingsLoadingState label="Loading users..." /> : null}
 
-          {selectedGroup && (
-            <div className="mt-6 rounded-2xl border border-slate-200 p-4">
-              <p className="text-sm font-semibold text-slate-900">Members: {selectedGroup.name}</p>
-              <div className="mt-3 flex gap-2">
-                <select
-                  className="flex-1 rounded-xl border border-slate-300 px-3 py-2 text-sm"
-                  value={selectedUserId}
-                  onChange={(event) => setSelectedUserId(event.target.value)}
-                >
-                  <option value="">Select user</option>
-                  {selectableUsers.map((user) => (
-                    <option key={user.id} value={user.id}>{user.displayName}</option>
-                  ))}
-                </select>
-                <button
-                  type="button"
-                  onClick={handleAddMember}
-                  className="rounded-xl bg-slate-900 px-3 py-2 text-sm font-semibold text-white"
-                >
-                  Add member
-                </button>
-              </div>
+              {!loading && users.length === 0 ? (
+                <SettingsEmptyState
+                  title="No users found"
+                  description="Users will appear here once they have authenticated or been provisioned."
+                  icon={Users2}
+                />
+              ) : null}
 
-              <div className="mt-3 space-y-2">
-                {groupMembers.map((member) => (
-                  <div key={member.id} className="flex items-center justify-between rounded-lg border border-slate-200 px-3 py-2">
-                    <span className="text-sm text-slate-800">{member.displayName}</span>
+              {!loading &&
+                users.map((user) => (
+                  <div
+                    key={user.id}
+                    className="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3"
+                  >
+                    <div>
+                      <p className="text-sm font-medium text-slate-900">{user.displayName}</p>
+                      <p className="text-xs text-slate-500">{user.email || user.externalId}</p>
+                    </div>
                     <button
                       type="button"
-                      onClick={() => handleRemoveMember(member.id)}
-                      className="text-xs font-semibold text-rose-600"
+                      onClick={() => handleToggleAdmin(user)}
+                      className={`inline-flex items-center gap-2 rounded-xl px-3 py-2 text-xs font-semibold transition ${user.isAdmin
+                        ? 'bg-emerald-100 text-emerald-800 hover:bg-emerald-200'
+                        : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+                        }`}
                     >
-                      Remove
+                      {user.isAdmin ? <ShieldCheck size={14} /> : <ShieldOff size={14} />}
+                      {user.isAdmin ? 'Admin' : 'Member'}
                     </button>
                   </div>
                 ))}
-              </div>
             </div>
-          )}
-        </section>
+          </SettingsSurface>
+
+          <SettingsSurface>
+            <SettingsSectionHeader
+              eyebrow="Groups"
+              title="Group membership"
+              description="Create RBAC groups, inspect membership, and keep assignments up to date."
+              actions={<span className="text-sm font-medium text-slate-500">{groupsSummary}</span>}
+            />
+
+            <div className="mt-6 space-y-6">
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <input
+                  value={newGroupName}
+                  onChange={(event) => setNewGroupName(event.target.value)}
+                  placeholder="Create group (e.g. analysts)"
+                  className="flex-1 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm shadow-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-900/5"
+                />
+                <button
+                  type="button"
+                  onClick={handleCreateGroup}
+                  className="inline-flex items-center justify-center gap-2 rounded-2xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+                >
+                  <Plus size={14} />
+                  Add group
+                </button>
+              </div>
+
+              {groups.length === 0 ? (
+                <SettingsEmptyState
+                  title="No groups created yet"
+                  description="Create your first group to start organizing users for permissions and rollout controls."
+                  icon={Plus}
+                  align="left"
+                />
+              ) : (
+                <div className="space-y-3">
+                  {groups.map((group) => (
+                    <div
+                      key={group.id}
+                      className={`flex items-center justify-between rounded-2xl border px-4 py-3 transition ${group.id === selectedGroupId
+                        ? 'border-slate-900 bg-slate-100'
+                        : 'border-slate-200 bg-slate-50/70'
+                        }`}
+                    >
+                      <button
+                        type="button"
+                        className="text-sm font-medium text-slate-900"
+                        onClick={() => setSelectedGroupId(group.id)}
+                      >
+                        {group.name}
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-lg p-1.5 text-rose-600 transition hover:bg-rose-50"
+                        onClick={() => handleDeleteGroup(group.id)}
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {selectedGroup ? (
+                <div className="rounded-[24px] border border-slate-200 bg-slate-50/80 p-5">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                    <div>
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">Selected group</p>
+                      <p className="mt-1 text-base font-semibold text-slate-900">{selectedGroup.name}</p>
+                    </div>
+                    <p className="text-sm text-slate-500">
+                      {groupMembers.length} member{groupMembers.length === 1 ? '' : 's'}
+                    </p>
+                  </div>
+
+                  <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+                    <select
+                      className="flex-1 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm shadow-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-900/5"
+                      value={selectedUserId}
+                      onChange={(event) => setSelectedUserId(event.target.value)}
+                    >
+                      <option value="">Select user</option>
+                      {selectableUsers.map((user) => (
+                        <option key={user.id} value={user.id}>{user.displayName}</option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      onClick={handleAddMember}
+                      className="rounded-2xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+                    >
+                      Add member
+                    </button>
+                  </div>
+
+                  <div className="mt-4 space-y-2">
+                    {groupMembers.length === 0 ? (
+                      <SettingsEmptyState
+                        title="No members yet"
+                        description="Add users to this group to start testing or enforcing access boundaries."
+                        align="left"
+                      />
+                    ) : (
+                      groupMembers.map((member) => (
+                        <div
+                          key={member.id}
+                          className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white px-4 py-3"
+                        >
+                          <span className="text-sm text-slate-800">{member.displayName}</span>
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveMember(member.id)}
+                            className="text-xs font-semibold text-rose-600 transition hover:text-rose-700"
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </SettingsSurface>
+        </div>
       </div>
     </SettingsShell>
   );


### PR DESCRIPTION
## Summary
- standardize the admin area around a shared settings scaffold and reusable section primitives
- update dashboard, billing, knowledge, users, and agent settings pages to use consistent surfaces, headers, and state treatments
- improve the settings shell responsiveness and mobile navigation affordances

## Testing
- not run (no JS runtime/package manager available in this environment)