### PR TITLE
Refine sales skills around GWS-first seller workflows

### DIFF
--- a/skills/sales/CONNECTORS.md
+++ b/skills/sales/CONNECTORS.md
@@ -1,28 +1,55 @@
 # Connectors
 
-## How placeholders work
+## Operating Model
 
-These skills use placeholders such as `~~calendar` or `~~email` to refer to whichever MCP tools are connected in that category. In HelpUDoc, the preferred default for most seller workflows is Google Workspace.
+Sales skills in HelpUDoc should not treat connectors as interchangeable abstractions. Prefer the concrete tools that exist today and follow this source order:
 
-## Recommended connector mapping
+1. Google Workspace internal context
+2. Tagged workspace files and internal documents
+3. Google Search for current external context
+4. CRM and enrichment data when available
 
-| Category | Placeholder | Preferred source | What it adds |
-|----------|-------------|------------------|--------------|
-| Calendar | `~~calendar` | Google Calendar | Upcoming meetings, attendees, meeting descriptions |
-| Email | `~~email` | Gmail | Customer threads, unread priorities, Gmail draft creation |
-| Knowledge base | `~~knowledge base` | Google Drive | Notes, decks, proposals, transcript docs/files |
-| Spreadsheet data | `~~spreadsheet data` | Google Sheets | Pipeline trackers, account plans, export sheets |
-| CRM | `~~CRM` | HubSpot, Salesforce, Close, etc. | Deal history, stage, tasks, account records |
-| Data enrichment | `~~data enrichment` | Clay, ZoomInfo, Apollo | Verified contact data and firmographics |
-| Chat | `~~chat` | Slack or Teams | Internal seller chatter and account intel |
-| Competitive intelligence | `~~competitive intelligence` | Similarweb or docs | Market and competitor context |
+If a user tagged files, use `rag_query` first before broad web search.
 
-## Transcript guidance
+## Recommended Connector Mapping
+
+| Need | Placeholder | Preferred source | Typical actions |
+|---|---|---|---|
+| Upcoming meeting context | `~~calendar` | Google Calendar | Find meeting, attendees, description, timing |
+| Customer thread history and drafts | `~~email` | Gmail | Search messages and threads, inspect recap emails, create drafts |
+| Notes, decks, proposals, transcripts | `~~knowledge base` | Google Drive | Search docs/files, find prior materials, pull recap artifacts |
+| Trackers and planning sheets | `~~spreadsheet data` | Google Sheets | Look up account plans, pipeline rows, next-step trackers |
+| Internal tagged files | n/a | Workspace files via `rag_query` | Use tagged docs before broad search |
+| External market/account updates | n/a | `google_search` | Research current news, industry shifts, competitor updates |
+| Deal history and hygiene | `~~CRM` | HubSpot, Salesforce, Close, etc. | Pull stage, opp history, contacts, tasks |
+| Contact validation and firmographics | `~~data enrichment` | Clay, ZoomInfo, Apollo | Enrich contacts and account details |
+| Internal field chatter | `~~chat` | Slack or Teams | Pull deal chatter or field intel only when relevant |
+| Competitive research | `~~competitive intelligence` | Drive docs plus web research | Reuse internal battlecards, then enrich externally |
+
+## Transcript Guidance
 
 For v1, transcript lookup should search:
 
-1. Gmail for transcript emails or meeting recap threads
-2. Google Drive for transcript documents, notes, or recordings metadata
-3. CRM or conversation-intelligence tools only if those are connected
+1. Gmail for transcript or recap emails
+2. Google Drive for transcript docs, notes, or recording metadata
+3. Calendar details to disambiguate the correct meeting
+4. CRM or conversation-intelligence tools only if they are actually connected
 
 Do not assume direct Google Meet transcript APIs are available.
+
+## Handoff Guidance
+
+Sales skills should gather enough structured context before handing off to downstream workflows:
+
+- `research` for deeper external account, market, or industry analysis
+- `proposal-writing` for proposals, SOWs, or commercial documents
+- `frontend-slides` for decks, QBRs, or executive presentations
+- `create-an-asset` for customer-facing one-pagers, landing pages, or demo assets
+
+The handoff artifact should usually capture:
+
+- company and meeting context
+- key contacts and roles
+- goals, pain points, and objections
+- current deal or account status
+- source-backed notes and unresolved questions

--- a/skills/sales/README.md
+++ b/skills/sales/README.md
@@ -1,15 +1,62 @@
 # Sales Skills
 
-A Google Workspace-first sales skill pack for HelpUDoc. The workflows work standalone with web research and pasted context, and get better when Gmail, Google Calendar, Google Drive, Google Sheets, and optional CRM tools are connected through MCP.
+A Google Workspace-first sales skill pack for HelpUDoc. Treat this pack as the entrypoint for seller workflows: it gathers internal context from Gmail, Calendar, Drive, Sheets, and tagged workspace files, then produces concise sales briefs, drafts, and next-step plans. When the ask turns into a bigger deliverable, the pack should hand off to the right specialized skill instead of recreating that workflow inside sales.
 
-## Priority Workflows
+## Workflow Map
 
-| Workflow | Best-Fit Data Sources |
+| Workflow | Default output | Best-fit sources | Downstream handoff |
+|---|---|---|---|
+| `call-prep` | Prep brief, objections, agenda, meeting goals | Calendar, Gmail, Drive, Sheets, tagged files | `research` for deeper market/account research, `frontend-slides` for decks or QBRs |
+| `call-summary` | Internal recap, action items, Gmail-ready follow-up | Gmail, Drive, Calendar, tagged files | `proposal-writing` for SOW/proposal asks, `frontend-slides` for recap decks |
+| `daily-briefing` | Prioritized daily agenda and prep checklist | Calendar, Gmail, Drive, Sheets | `research` for high-priority account deep dives |
+| `draft-outreach` | Outreach brief plus Gmail draft | Gmail, Drive, Sheets, tagged files | `proposal-writing` for proposal-led outreach, `frontend-slides` for pitch narratives |
+
+## How The Pack Should Work
+
+Default source order for seller workflows:
+
+1. Google Workspace internal context
+2. Tagged workspace files and internal docs
+3. Google Search for current external enrichment
+4. CRM or enrichment systems when present
+
+That means:
+
+| Need | Default source |
 |---|---|
-| `call-prep` | Calendar, Gmail, Drive, optional CRM |
-| `call-summary` | Gmail, Drive, Calendar, optional CRM |
-| `daily-briefing` | Calendar, Gmail, Sheets, optional CRM |
-| `draft-outreach` | Gmail drafts, Drive context, web research, optional CRM |
+| Upcoming meetings and attendees | Google Calendar |
+| Threads, follow-ups, transcript emails | Gmail |
+| Notes, decks, proposals, recap docs, transcripts | Google Drive |
+| Account trackers and pipeline sheets | Google Sheets |
+| Tagged project files already in the workspace | `rag_query` before broad search |
+| Company news or industry developments | `google_search`, after internal context review |
+| Deal history or stage hygiene | CRM, when available |
+
+Transcript handling in v1 is intentionally simple:
+
+1. Search Gmail for recap or transcript emails.
+2. Search Drive for transcript docs, notes, or recording metadata.
+3. Use Calendar metadata to confirm the right meeting.
+4. Do not assume direct Google Meet transcript APIs.
+
+## Downstream Skills
+
+The sales pack should prepare context, then hand off when the user wants a larger artifact:
+
+| User intent | Preferred downstream skill |
+|---|---|
+| Deep account, market, or industry analysis | `research` |
+| Proposal, SOW, scope, or commercial document | `proposal-writing` |
+| Pitch deck, QBR, exec recap, or presentation | `frontend-slides` |
+| Customer-facing asset such as one-pager or landing page | `create-an-asset` |
+
+Handoffs should be brief-first, not automatic heavy generation. Sales skills should capture:
+
+- customer and meeting context
+- current priorities or pain points
+- objections, risks, and decision criteria
+- open questions and missing data
+- the intended downstream deliverable
 
 ## Commands
 
@@ -23,47 +70,19 @@ A Google Workspace-first sales skill pack for HelpUDoc. The workflows work stand
 
 | Skill | Description |
 |---|---|
-| `account-research` | Research a company or person with web search and optional CRM/enrichment context |
-| `call-prep` | Build a prep brief from meeting metadata, email history, Drive notes, and company research |
+| `account-research` | Account and contact research that starts with internal context, then expands to web search |
+| `call-prep` | Build a prep brief from meeting metadata, email history, Drive notes, Sheets context, and optional external research |
+| `call-summary` | Process call notes or transcript artifacts, then create recap and follow-up outputs |
+| `competitive-intelligence` | Build battlecards using internal docs plus current market research |
+| `create-an-asset` | Generate customer-facing assets when a deal needs a polished deliverable |
 | `daily-briefing` | Prioritized seller briefing using today’s meetings, inbox signals, and optional pipeline data |
-| `draft-outreach` | Research-first outreach with Gmail draft creation when available |
-| `competitive-intelligence` | Competitive research with optional Drive docs and CRM context |
-| `create-an-asset` | Generate custom sales assets such as landing pages, decks, and one-pagers |
-
-## Google Workspace-First Defaults
-
-When tools are connected, these skills should prefer:
-
-| Need | Default Source |
-|---|---|
-| Upcoming meetings | Google Calendar |
-| Customer threads, follow-ups, transcript emails | Gmail |
-| Notes, decks, proposals, transcript docs/files | Google Drive |
-| Pipeline trackers and account spreadsheets | Google Sheets |
-| Deal history and stage hygiene | CRM, when available |
-
-Transcript handling in v1 is intentionally simple: search Gmail and Drive first for transcript artifacts tied to the account or meeting. Do not assume direct Google Meet transcript APIs are available.
-
-## Example Uses
-
-```text
-Prep me for my call with Acme tomorrow
-```
-
-```text
-/call-summary
-```
-
-```text
-Start my day
-```
-
-```text
-Draft an email to the VP of Engineering at TechStart
-```
+| `draft-outreach` | Context-rich outreach that becomes a Gmail draft when possible |
+| `forecast` | Forecast from Sheets, CSV, or CRM data with CRM as enrichment, not a requirement |
+| `pipeline-review` | Weekly health review using Sheets, CSV, or CRM data |
 
 ## Notes
 
-- These skills are adapted for HelpUDoc and do not rely on Claude plugin installation metadata.
+- These skills are adapted for HelpUDoc and should cooperate with the general router and other specialized skills.
+- Default outputs should be brief-first markdown artifacts unless the user explicitly wants a larger document or deck.
 - CRM remains optional but still improves `forecast`, `pipeline-review`, and historical account context.
 - If Google OAuth scopes expand, existing users need to sign in with Google again so Gmail, Calendar, Drive, and Sheets access can be delegated to MCP servers.

--- a/skills/sales/skills/account-research/SKILL.md
+++ b/skills/sales/skills/account-research/SKILL.md
@@ -1,59 +1,38 @@
 ---
 name: account-research
-description: Research a company or person and get actionable sales intel. Works standalone with web search, supercharged when you connect enrichment tools or your CRM. Trigger with "research [company]", "look up [person]", "intel on [prospect]", "who is [name] at [company]", or "tell me about [company]".
+description: Research a company or person and get actionable sales intel. Start with internal context, then expand to current external research. Prefer tagged workspace files, Drive docs, Gmail history, and Sheets context before broader web research.
 ---
 
 # Account Research
 
-Get a complete picture of any company or person before outreach. This skill always works with web search, and gets significantly better with enrichment and CRM data.
+Get a complete picture of a company or person before outreach or a meeting, but keep the result useful for sellers rather than encyclopedic. This skill should produce a sharp brief that mixes internal knowledge with timely external context.
 
 ## How It Works
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
-│                     ACCOUNT RESEARCH                             │
+│                     ACCOUNT RESEARCH                            │
 ├─────────────────────────────────────────────────────────────────┤
-│  ALWAYS (works standalone via web search)                        │
-│  ✓ Company overview: what they do, size, industry               │
-│  ✓ Recent news: funding, leadership changes, announcements      │
-│  ✓ Hiring signals: open roles, growth indicators                │
-│  ✓ Key people: leadership team from LinkedIn                    │
-│  ✓ Product/service: what they sell, who they serve              │
+│  ALWAYS                                                         │
+│  ✓ Company overview, current updates, key people               │
+│  ✓ Signals that matter for outreach or discovery               │
+│  ✓ Recommended angle and questions                             │
 ├─────────────────────────────────────────────────────────────────┤
-│  SUPERCHARGED (when you connect your tools)                      │
-│  + Enrichment: verified emails, phone, tech stack, org chart    │
-│  + CRM: prior relationship, past opportunities, contacts        │
+│  INTERNAL-FIRST                                                 │
+│  + Tagged files, Drive docs, Gmail history, Sheets notes       │
+│  + Google Search for current public context                    │
+│  + CRM and enrichment as optional sharpening layers            │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
----
+## Retrieval Order
 
-## Getting Started
-
-Just tell me who to research:
-
-- "Research Stripe"
-- "Look up the CTO at Notion"
-- "Intel on acme.com"
-- "Who is Sarah Chen at TechCorp?"
-- "Tell me about [company] before my call"
-
-I'll run web searches immediately. If you have enrichment or CRM connected, I'll pull that data too.
-
----
-
-## Connectors (Optional)
-
-Connect your tools to supercharge this skill:
-
-| Connector | What It Adds |
-|-----------|--------------|
-| **Enrichment** | Verified emails, phone numbers, tech stack, org chart, funding details |
-| **CRM** | Prior relationship history, past opportunities, existing contacts, notes |
-
-> **No connectors?** No problem. Web search provides solid research for any company or person.
-
----
+1. Tagged workspace files via `rag_query`
+2. Google Drive for notes, decks, proposals, or prior account plans
+3. Gmail for prior conversations or recap emails
+4. Google Sheets for trackers or territory notes
+5. Google Search for current public context
+6. CRM and enrichment if available
 
 ## Output Format
 
@@ -61,227 +40,61 @@ Connect your tools to supercharge this skill:
 # Research: [Company or Person Name]
 
 **Generated:** [Date]
-**Sources:** Web Search [+ Enrichment] [+ CRM]
-
----
+**Sources:** [Tagged files / Drive / Gmail / Web / CRM / Enrichment]
 
 ## Quick Take
-
-[2-3 sentences: Who they are, why they might need you, best angle for outreach]
-
----
+[2-3 sentences on why this account matters now]
 
 ## Company Profile
-
 | Field | Value |
-|-------|-------|
-| **Company** | [Name] |
-| **Website** | [URL] |
-| **Industry** | [Industry] |
-| **Size** | [Employee count] |
-| **Headquarters** | [Location] |
-| **Founded** | [Year] |
-| **Funding** | [Stage + amount if known] |
-| **Revenue** | [Estimate if available] |
+|---|---|
+| Company | [Name] |
+| Industry | [Industry] |
+| Size | [Employee count] |
+| Headquarters | [Location] |
+| Funding | [If known] |
 
-### What They Do
-[1-2 sentence description of their business, product, and customers]
-
-### Recent News
-- **[Headline]** — [Date] — [Why it matters for your outreach]
-- **[Headline]** — [Date] — [Why it matters]
-
-### Hiring Signals
-- [X] open roles in [Department]
-- Notable: [Relevant roles like Engineering, Sales, AI/ML]
-- Growth indicator: [Hiring velocity interpretation]
-
----
+### Recent Updates
+- [Update 1 — why it matters]
+- [Update 2 — why it matters]
 
 ## Key People
-
 ### [Name] — [Title]
-| Field | Detail |
-|-------|--------|
-| **LinkedIn** | [URL] |
-| **Background** | [Prior companies, education] |
-| **Tenure** | [Time at company] |
-| **Email** | [If enrichment connected] |
-
-**Talking Points:**
-- [Personal hook based on background]
-- [Professional hook based on role]
-
-[Repeat for relevant contacts]
-
----
-
-## Tech Stack [If Enrichment Connected]
-
-| Category | Tools |
-|----------|-------|
-| **Cloud** | [AWS, GCP, Azure, etc.] |
-| **Data** | [Snowflake, Databricks, etc.] |
-| **CRM** | [e.g. Salesforce, HubSpot] |
-| **Other** | [Relevant tools] |
-
-**Integration Opportunity:** [How your product fits with their stack]
-
----
-
-## Prior Relationship [If CRM Connected]
-
-| Field | Detail |
-|-------|--------|
-| **Status** | [New / Prior prospect / Customer / Churned] |
-| **Last Contact** | [Date and type] |
-| **Previous Opps** | [Won/Lost and why] |
-| **Known Contacts** | [Names already in CRM] |
-
-**History:** [Summary of past relationship]
-
----
+- Background:
+- Talking point:
+- Internal relationship context:
 
 ## Qualification Signals
-
 ### Positive Signals
-- ✅ [Signal and evidence]
-- ✅ [Signal and evidence]
+- [Signal]
 
 ### Potential Concerns
-- ⚠️ [Concern and what to watch for]
+- [Concern]
 
-### Unknown (Ask in Discovery)
-- ❓ [Gap in understanding]
-
----
+### Unknowns
+- [What to ask next]
 
 ## Recommended Approach
-
-**Best Entry Point:** [Person and why]
-
-**Opening Hook:** [What to lead with based on research]
-
-**Discovery Questions:**
-1. [Question about their situation]
-2. [Question about pain points]
-3. [Question about decision process]
-
----
-
-## Sources
-- [Source 1](URL)
-- [Source 2](URL)
+- Best entry point:
+- Opening hook:
+- Discovery questions:
 ```
 
----
+## Execution Rules
 
-## Execution Flow
+- Prefer internal context first when it exists.
+- Use Google Search to fill gaps or get current developments, not as the only source by default.
+- If the user tagged files, use those before broad searching.
+- CRM and enrichment should sharpen the brief, not define the entire workflow.
 
-### Step 1: Parse Request
+## Handoff Rules
 
-```
-Identify what to research:
-- "Research Stripe" → Company research
-- "Look up John Smith at Acme" → Person + company
-- "Who is the CTO at Notion" → Role-based search
-- "Intel on acme.com" → Domain-based lookup
-```
+If the research ask becomes broader than a seller brief:
 
-### Step 2: Web Search (Always)
+- hand off to `research` for a deeper market, industry, or multi-source report
+- hand off to `draft-outreach` if the real ask is to turn the findings into outreach
+- hand off to `call-prep` if the findings are meant to prep an upcoming meeting
 
-```
-Run these searches:
-1. "[Company name]" → Homepage, about page
-2. "[Company name] news" → Recent announcements
-3. "[Company name] funding" → Investment history
-4. "[Company name] careers" → Hiring signals
-5. "[Person name] [Company] LinkedIn" → Profile info
-6. "[Company name] product" → What they sell
-7. "[Company name] customers" → Who they serve
-```
+### Example handoff
 
-**Extract:**
-- Company description and positioning
-- Recent news (last 90 days)
-- Leadership team
-- Open job postings
-- Technology mentions
-- Customer base
-
-### Step 3: Enrichment (If Connected)
-
-```
-If enrichment tools available:
-1. Enrich company → Firmographics, funding, tech stack
-2. Search people → Org chart, contact list
-3. Enrich person → Email, phone, background
-4. Get signals → Intent data, hiring velocity
-```
-
-**Enrichment adds:**
-- Verified contact info
-- Complete org chart
-- Precise employee count
-- Detailed tech stack
-- Funding history with investors
-
-### Step 4: CRM Check (If Connected)
-
-```
-If CRM available:
-1. Search for account by domain
-2. Get related contacts
-3. Get opportunity history
-4. Get activity timeline
-```
-
-**CRM adds:**
-- Prior relationship context
-- What happened before (won/lost deals)
-- Who we've talked to
-- Notes and history
-
-### Step 5: Synthesize
-
-```
-1. Combine all sources
-2. Prioritize enrichment data over web (more accurate)
-3. Add CRM context if exists
-4. Identify qualification signals
-5. Generate talking points
-6. Recommend approach
-```
-
----
-
-## Research Variations
-
-### Company Research
-Focus on: Business overview, news, hiring, leadership
-
-### Person Research
-Focus on: Background, role, LinkedIn activity, talking points
-
-### Competitor Research
-Focus on: Product comparison, positioning, win/loss patterns
-
-### Pre-Meeting Research
-Focus on: Attendee backgrounds, recent news, relationship history
-
----
-
-## Tips for Better Research
-
-1. **Include the domain** — "research acme.com" is more precise
-2. **Specify the person** — "look up Jane Smith, VP Sales at Acme"
-3. **State your goal** — "research Stripe before my demo call"
-4. **Ask for specifics** — "what's their tech stack?" after initial research
-
----
-
-## Related Skills
-
-- **call-prep** — Full meeting prep with this research plus context
-- **draft-outreach** — Write personalized message based on research
-- **prospecting** — Qualify and prioritize research targets
+If the user asks, "Research this account and write me a long industry report," produce the seller brief here, then route the deeper report work to `research`.

--- a/skills/sales/skills/call-prep/SKILL.md
+++ b/skills/sales/skills/call-prep/SKILL.md
@@ -1,66 +1,61 @@
 ---
 name: call-prep
-description: Prepare for a sales call with account context, attendee research, and suggested agenda. Works standalone with user input and web research, and becomes Google Workspace-first when Calendar, Gmail, Drive, and Sheets are connected. Trigger with "prep me for my call with [company]", "I'm meeting with [company] prep me", "call prep [company]", or "get me ready for [meeting]".
+description: Prepare for a sales call with account context, attendee research, and a suggested agenda. Works standalone with user input and targeted web research, and becomes Google Workspace-first when Calendar, Gmail, Drive, Sheets, and tagged workspace files are available.
 ---
 
 # Call Prep
 
-Get fully prepared for any sales call in minutes. This skill works with whatever context you provide, and gets significantly better when you connect your sales tools.
+Get fully prepared for a sales call without rebuilding the whole account story from scratch. This skill should work as the seller workflow entrypoint: gather internal context first, add external context second, and produce a concise prep brief that can later hand off into deeper research or a presentation workflow if needed.
 
 ## How It Works
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
-│                        CALL PREP                                 │
+│                        CALL PREP                                │
 ├─────────────────────────────────────────────────────────────────┤
-│  ALWAYS (works standalone)                                       │
-│  ✓ You tell me: company, meeting type, attendees                │
-│  ✓ Web search: recent news, funding, leadership changes         │
-│  ✓ Company research: what they do, size, industry               │
-│  ✓ Output: prep brief with agenda and questions                 │
+│  ALWAYS (works standalone)                                      │
+│  ✓ You tell me: company, meeting type, attendees               │
+│  ✓ I build: agenda, questions, objections, prep checklist      │
+│  ✓ I add: web research if internal context is limited          │
 ├─────────────────────────────────────────────────────────────────┤
-│  SUPERCHARGED (when you connect your tools)                      │
-│  + Calendar: auto-find meeting, pull attendees and notes        │
-│  + Gmail: recent threads, open questions, commitments           │
-│  + Drive: decks, notes, proposals, transcript artifacts         │
-│  + Sheets: account plans or pipeline trackers when relevant     │
-│  + CRM: account history, contacts, opportunities, activities    │
+│  GWS-FIRST (preferred path)                                     │
+│  + Calendar: meeting shell, attendees, timing, notes           │
+│  + Gmail: recent threads, commitments, unanswered questions    │
+│  + Drive: decks, notes, proposals, transcript artifacts        │
+│  + Sheets: account plans and trackers when relevant            │
+│  + Tagged files: workspace-specific context via rag_query      │
+│  + CRM: optional history and deal context                      │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
----
-
 ## Getting Started
 
-When you run this skill, I'll ask for what I need:
+When you run this skill, gather only what is still missing.
 
-**Required:**
+**Required if tools do not already provide it:**
 - Company or contact name
-- Meeting type (discovery, demo, negotiation, check-in, etc.)
+- Meeting type
 
-**Helpful if you have it:**
-- Who's attending (names and titles)
-- Any context you want me to know (paste prior notes, emails, etc.)
+**Helpful if available:**
+- Attendee names and titles
+- Your goal for the call
+- Any pasted notes, emails, or transcript snippets
 
-If you've connected Calendar, Gmail, Drive, Sheets, or CRM tools, I'll pull context automatically and skip the questions.
+If Calendar, Gmail, Drive, Sheets, or tagged files are available, use them before asking the user to restate obvious context.
 
----
+## Retrieval Order
 
-## Connectors (Optional)
+Follow this order every time:
 
-Connect your tools to supercharge this skill:
+1. Google Calendar for the meeting shell
+2. Gmail for recent threads and unanswered questions
+3. Google Drive for notes, decks, proposals, and transcript artifacts
+4. Tagged workspace files via `rag_query`
+5. Google Sheets for account plans or trackers when relevant
+6. Google Search for current company, market, or attendee context
+7. CRM only if connected or clearly requested
 
-| Connector | What It Adds |
-|-----------|--------------|
-| **Calendar** | Auto-find the meeting, pull attendees, description, and timing |
-| **Gmail** | Recent threads with the company, open questions, commitments, transcript emails |
-| **Drive** | Meeting notes, decks, proposals, transcript docs/files |
-| **Sheets** | Account plans, deal trackers, or territory spreadsheets |
-| **CRM** | Account details, contact history, open deals, recent activities |
-
-> **No connectors?** No problem. Just tell me about the meeting and paste any context you have. I'll research the rest.
-
----
+If a source is missing, keep going. Do not block the workflow because CRM or a transcript system is absent.
 
 ## Output Format
 
@@ -80,7 +75,7 @@ Connect your tools to supercharge this skill:
 | **Company** | [Name] |
 | **Industry** | [Industry] |
 | **Size** | [Employees / Revenue if known] |
-| **Status** | [New prospect / Active opportunity / Customer] |
+| **Status** | [Prospect / Active opportunity / Customer] |
 | **Last Touch** | [Date and summary] |
 
 ---
@@ -88,13 +83,10 @@ Connect your tools to supercharge this skill:
 ## Who You're Meeting
 
 ### [Name] — [Title]
-- **Background:** [Career history, education if found]
-- **LinkedIn:** [URL]
+- **Background:** [Relevant background]
 - **Role in Deal:** [Decision maker / Champion / Evaluator / etc.]
 - **Last Interaction:** [Summary if known]
-- **Talking Point:** [Something personal/professional to reference]
-
-[Repeat for each attendee]
+- **Talking Point:** [Something useful to reference]
 
 ---
 
@@ -103,9 +95,9 @@ Connect your tools to supercharge this skill:
 **What's happened so far:**
 - [Key point from prior interactions]
 - [Open commitments or action items]
-- [Any concerns or objections raised]
+- [Concerns or objections raised]
 
-**Recent news about [Company]:**
+**Recent updates about [Company]:**
 - [News item 1 — why it matters]
 - [News item 2 — why it matters]
 
@@ -114,22 +106,18 @@ Connect your tools to supercharge this skill:
 ## Suggested Agenda
 
 1. **Open** — [Reference last conversation or trigger event]
-2. **[Topic 1]** — [Discovery question or value discussion]
-3. **[Topic 2]** — [Address known concern or explore priority]
-4. **[Topic 3]** — [Demo section / Proposal review / etc.]
-5. **Next Steps** — [Propose clear follow-up with timeline]
+2. **Discovery / Review** — [Topic]
+3. **Objection Handling** — [Known concern]
+4. **Next Steps** — [Specific alignment ask]
 
 ---
 
 ## Discovery Questions
 
-Ask these to fill gaps in your understanding:
-
-1. [Question about their current situation]
+1. [Question about current situation]
 2. [Question about pain points or priorities]
-3. [Question about decision process and timeline]
+3. [Question about decision process]
 4. [Question about success criteria]
-5. [Question about other stakeholders]
 
 ---
 
@@ -137,124 +125,132 @@ Ask these to fill gaps in your understanding:
 
 | Objection | Suggested Response |
 |-----------|-------------------|
-| [Likely objection based on context] | [How to address it] |
+| [Likely objection] | [How to address it] |
 | [Common objection for this stage] | [How to address it] |
 
 ---
 
-## Internal Notes
+## Pre-Call Checklist
 
-[Any Gmail, Drive, CRM, or internal chat context relevant to the meeting]
-
----
-
-## After the Call
-
-Run **call-summary** to:
-- Extract action items
-- Update your CRM
-- Draft a follow-up in Gmail or plain text
+- Read: [notes, deck, proposal, transcript]
+- Confirm: [goal, next step, stakeholder]
+- Bring: [proof point, example, pricing context]
 ```
-
----
 
 ## Execution Flow
 
-### Step 1: Gather Context
+### Step 1: Resolve the meeting
 
-**If connectors available:**
-```
-1. Calendar → Find upcoming meeting matching company name
-   - Pull: title, time, attendees, description, links
+Use Calendar first whenever possible:
 
-2. Gmail → Search recent threads
-   - Query: emails with attendee names or company domain (last 30 days)
-   - Extract: key topics, open questions, commitments, attachments mentioned
+- find the most likely upcoming meeting
+- capture title, time, attendee emails, description, and links
+- infer the company or account from attendee domains and event title
 
-3. Drive → Search account materials
-   - Pull: decks, notes, proposals, account plans, transcript docs/files
-   - Extract: prior commitments, current proposal status, transcript highlights
+If no meeting is available, ask only for the minimum:
 
-4. Sheets → Search account trackers when relevant
-   - Pull: pipeline rows, account plan notes, next-step trackers
+- company or contact name
+- meeting type
+- timing if known
 
-5. CRM → Query account
-   - Pull: account details, contacts, open opportunities, recent activities
+### Step 2: Pull internal account context
 
-6. Chat → Search internal discussions if available
-   - Query: company name mentions (last 30 days)
-   - Extract: colleague insights, competitive intel
-```
+Use Gmail next:
 
-**If no connectors:**
-```
-1. Ask user:
-   - "What company are you meeting with?"
-   - "What type of meeting is this?"
-   - "Who's attending? (names and titles if you know)"
-   - "Any context you want me to know? (paste notes, emails, etc.)"
+- search recent messages and threads tied to attendee domains or company name
+- identify open loops, prior commitments, objections, and attachments referenced
+- note important unanswered messages or unresolved asks
 
-2. Accept whatever they provide and work with it
-```
+Use Drive next:
 
-### Step 2: Research Supplement
+- search for notes, decks, proposals, recap docs, and transcript files
+- extract the latest relevant context instead of listing every file
 
-**Always run (web search):**
-```
-1. "[Company] news" — last 30 days
-2. "[Company] funding" — recent announcements
-3. "[Company] leadership" — executive changes
-4. "[Company] + [industry] trends" — relevant context
-5. Attendee LinkedIn profiles — background research
-```
+Use `rag_query` for any tagged files:
 
-### Step 3: Synthesize & Generate
+- prefer tagged files before broad search
+- treat them as high-trust context for this ask
 
-```
-1. Combine all sources into unified context
-2. Identify gaps in understanding → generate discovery questions
-3. Anticipate objections based on stage and history
-4. Create suggested agenda tailored to meeting type
-5. Output formatted prep brief
-```
+Use Sheets if relevant:
 
----
+- account plans
+- pipeline trackers
+- next-step checklists
+
+### Step 3: Fill external gaps
+
+Only after internal context is reviewed:
+
+- search for recent news, funding, hiring, leadership changes, or product launches
+- look up attendee backgrounds when that helps the meeting plan
+- keep external enrichment short and decision-relevant
+
+### Step 4: Synthesize
+
+Combine all sources into a single prep brief:
+
+- what we know
+- what changed recently
+- what matters in this meeting
+- what to ask
+- what could go wrong
 
 ## Meeting Type Variations
 
 ### Discovery Call
-- Focus on: Understanding their world, pain points, priorities
-- Agenda emphasis: Questions > Talking
-- Key output: Qualification signals, next step proposal
+- Focus on understanding pain, priority, and process
+- Agenda emphasis: questions over talking
+- Key output: qualification signals and a next step
 
 ### Demo / Presentation
-- Focus on: Their specific use case, tailored examples
-- Agenda emphasis: Show relevant features, get feedback
-- Key output: Technical requirements, decision timeline
+- Focus on relevant use cases and proof points
+- Agenda emphasis: tailored walkthrough and feedback
+- Key output: technical requirements and decision timeline
 
 ### Negotiation / Proposal Review
-- Focus on: Addressing concerns, justifying value
-- Agenda emphasis: Handle objections, close gaps
-- Key output: Path to agreement, clear next steps
+- Focus on concerns, value justification, and path to agreement
+- Agenda emphasis: objection handling and next-step alignment
+- Key output: blockers and close plan
 
 ### Check-in / QBR
-- Focus on: Value delivered, expansion opportunities
-- Agenda emphasis: Review wins, surface new needs
-- Key output: Renewal confidence, upsell pipeline
+- Focus on value delivered and new opportunities
+- Agenda emphasis: outcomes, gaps, and expansion signals
+- Key output: follow-up plan and stakeholder map
 
----
+## Handoff Rules
+
+This skill should stay brief-first by default.
+
+Hand off only when the user clearly wants a bigger artifact:
+
+- use `research` for a deeper account, industry, or market deep dive
+- use `frontend-slides` when the user wants a call deck, QBR deck, or presentation
+
+The handoff package should include:
+
+- account and meeting summary
+- key contacts and roles
+- known priorities, objections, and goals
+- the specific deliverable requested
+- unresolved questions that still need input
+
+### Example handoff: deeper account research
+
+If the user says, "Prep me for tomorrow's Acme meeting and also give me a deeper view of their industry pressure," first produce the prep brief, then hand off the missing industry-depth portion to `research`.
+
+### Example handoff: meeting deck
+
+If the user says, "Prep me for the QBR and make a deck for it," first gather the Calendar, Gmail, Drive, and account context here, then pass the summary and audience goal into `frontend-slides`.
 
 ## Tips for Better Prep
 
-1. **More context = better prep** — Paste emails, notes, or transcript links if you already have them
-2. **Name the attendees** — Even just titles help me research
-3. **State your goal** — "I want to get them to agree to a pilot"
-4. **Flag concerns** — "They mentioned budget is tight"
+1. More context still helps. Pasted notes, emails, or transcript snippets improve the brief.
+2. Naming attendees improves the talking points and stakeholder analysis.
+3. Stating the meeting goal makes the agenda better.
+4. Flagging known concerns helps tailor the objection section.
 
----
+## Notes
 
-## Related Skills
-
-- **account-research** — Deep dive on a company before first contact
-- **call-summary** — Process call notes and execute post-call workflow
-- **draft-outreach** — Write personalized outreach after research
+- Transcript lookup should prefer Gmail recap emails, then Drive docs/files.
+- Do not assume direct Google Meet transcript APIs.
+- Do not jump straight to Google Search before checking internal context.

--- a/skills/sales/skills/call-summary/SKILL.md
+++ b/skills/sales/skills/call-summary/SKILL.md
@@ -1,18 +1,37 @@
 ---
 name: call-summary
-description: Process call notes or a transcript — extract action items, draft follow-up email, and generate an internal summary. Prefer Gmail, Drive, and Calendar context when available, especially for transcript lookup and follow-up drafts.
+description: Process call notes or a transcript to extract action items, draft a follow-up email, and generate an internal summary. Prefer Gmail, Drive, Calendar, and tagged files first, then hand off to proposal or presentation workflows only when the user actually needs them.
 argument-hint: "<call notes or transcript>"
 ---
 
 # /call-summary
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+Turn a meeting into clean next steps. This skill should summarize what happened, surface what changed, and prepare the follow-up path without overproducing documents by default.
 
-Process call notes or a transcript to extract action items, draft follow-up communications, and update records.
+## How It Works
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│                      CALL SUMMARY                               │
+├─────────────────────────────────────────────────────────────────┤
+│  STANDALONE (always works)                                      │
+│  ✓ Paste call notes or transcript                              │
+│  ✓ Extract decisions, action items, concerns, and next steps   │
+│  ✓ Draft a customer-facing follow-up                           │
+│  ✓ Generate internal recap for the team                        │
+├─────────────────────────────────────────────────────────────────┤
+│  GWS-FIRST (preferred path)                                     │
+│  + Calendar: match the meeting and attendees                   │
+│  + Gmail: find recap threads, transcript emails, draft follow-up│
+│  + Drive: find transcript docs/files, notes, decks             │
+│  + Tagged files: use workspace-specific context                │
+│  + CRM: optional update path                                   │
+└─────────────────────────────────────────────────────────────────┘
+```
 
 ## Usage
 
-```
+```text
 /call-summary <notes or transcript>
 ```
 
@@ -20,84 +39,66 @@ Process these call notes: $ARGUMENTS
 
 If a file is referenced: @$1
 
----
-
-## How It Works
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                      CALL SUMMARY                                │
-├─────────────────────────────────────────────────────────────────┤
-│  STANDALONE (always works)                                       │
-│  ✓ Paste call notes or transcript                               │
-│  ✓ Extract key discussion points and decisions                  │
-│  ✓ Identify action items with owners and due dates              │
-│  ✓ Surface objections, concerns, and open questions             │
-│  ✓ Draft customer-facing follow-up email                        │
-│  ✓ Generate internal summary for your team                      │
-├─────────────────────────────────────────────────────────────────┤
-│  SUPERCHARGED (when you connect your tools)                      │
-│  + Gmail: find recap threads, transcript emails, draft follow-up│
-│  + Drive: find transcript docs/files, notes, decks              │
-│  + Calendar: link to meeting, attendee context, meeting timing  │
-│  + CRM: update opportunity, log activity, create tasks          │
-└─────────────────────────────────────────────────────────────────┘
-```
-
----
-
 ## What I Need From You
 
-**Option 1: Paste your notes**
-Just paste whatever you have — bullet points, rough notes, stream of consciousness. I'll structure it.
+**Option 1: Paste notes**
+Use rough notes, bullets, or stream-of-consciousness text.
 
 **Option 2: Paste a transcript**
-If you have a full transcript from your meeting tool, Gemini recap email, or a transcript doc from Drive, paste it. I'll extract the key moments.
+Use a Gemini recap email, transcript doc, or call transcript text.
 
 **Option 3: Describe the call**
-Tell me what happened: "Had a discovery call with Acme Corp. Met with their VP Eng and CTO. They're evaluating us vs Competitor X. Main concern is integration timeline."
+Example: "Had a discovery call with Acme. Met with their CTO and VP Eng. They're evaluating us against Competitor X. Main concern is integration timeline."
 
----
+If likely transcript artifacts already exist in Gmail or Drive, use those before asking for more input.
+
+## Retrieval Order
+
+1. User-provided notes or transcript, if present
+2. Google Calendar to identify the meeting shell
+3. Gmail for recap emails, follow-up threads, and transcript emails
+4. Google Drive for transcript docs, notes, decks, and proposal files
+5. Tagged workspace files via `rag_query`
+6. CRM only if connected or explicitly requested
 
 ## Output
 
 ### Internal Summary
+
 ```markdown
 ## Call Summary: [Company] — [Date]
 
 **Attendees:** [Names and titles]
 **Call Type:** [Discovery / Demo / Negotiation / Check-in]
-**Duration:** [If known]
+**Source Reviewed:** [Notes / Gmail recap / Drive transcript / mixed]
 
 ### Key Discussion Points
 1. [Topic] — [What was discussed, decisions made]
 2. [Topic] — [Summary]
 
 ### Customer Priorities
-- [Priority 1 they expressed]
+- [Priority 1]
 - [Priority 2]
 
-### Objections / Concerns Raised
-- [Concern] — [How you addressed it / status]
+### Risks / Objections Raised
+- [Concern] — [Status or response]
 
 ### Competitive Intel
-- [Any competitor mentions, what was said]
+- [Any competitor mention]
 
 ### Action Items
 | Owner | Action | Due |
-|-------|--------|-----|
+|---|---|---|
 | [You] | [Task] | [Date] |
 | [Customer] | [Task] | [Date] |
 
-### Next Steps
+### Recommended Next Step
 - [Agreed next step with timeline]
-
-### Deal Impact
-- [How this call affects the opportunity — stage change, risk, acceleration]
 ```
 
 ### Customer Follow-Up Email
-```
+
+```text
 Subject: [Meeting recap + next steps]
 
 Hi [Name],
@@ -114,58 +115,98 @@ Best,
 [You]
 ```
 
----
-
 ## Email Style Guidelines
 
 When drafting customer-facing emails:
 
-1. **Be concise but informative** — Get to the point quickly. Customers are busy.
-2. **No markdown formatting** — Don't use asterisks, bold, or other markdown syntax. Write in plain text that looks natural in any email client.
-3. **Use simple structure** — Short paragraphs, line breaks between sections. No headers or bullet formatting unless the customer's email client will render it.
-4. **Keep it scannable** — If listing items, use plain dashes or numbers, not fancy formatting.
+1. Be concise but informative.
+2. Do not use markdown formatting.
+3. Use short paragraphs and simple lists.
+4. Keep the email easy to skim.
 
-**Good:**
-```
+**Good**
+
+```text
 Here's what we discussed:
 - Quote for 20 seats at $480/seat/year
 - W9 and supplier onboarding docs
 - Point of contact for the contract
 ```
 
-**Bad:**
-```
+**Bad**
+
+```text
 **What You Need from Us:**
 - Quote for 20 seats at $480/seat/year
 ```
 
----
+## Execution Flow
 
-## If Connectors Available
+### Step 1: Resolve the meeting context
 
-**Gmail or Drive connected:**
-- I'll search for transcript emails, recap threads, and transcript docs/files tied to the meeting
-- Pull relevant notes or transcript excerpts
-- Extract key moments, decisions, and follow-up commitments
+If the user pasted notes, use them. Then enrich with:
 
-**CRM connected:**
-- I'll offer to update the opportunity stage
-- Log the call as an activity
-- Create tasks for action items
-- Update next steps field
+- Calendar metadata for timing and attendees
+- Gmail recap or transcript emails
+- Drive notes or transcript files
+- tagged files already in the workspace
 
-**Email connected:**
-- I'll offer to create a draft in ~~email
-- Or send directly if you approve
+Transcript policy:
 
-**Calendar connected:**
-- I'll use the meeting title, time, and attendees to match the right thread or transcript artifact
+1. search Gmail first
+2. search Drive second
+3. use Calendar details to confirm the right meeting
+4. do not assume Meet-native transcript APIs
 
----
+### Step 2: Extract the business signal
+
+Always capture:
+
+- decisions made
+- customer priorities
+- risks or objections raised
+- competitor mentions
+- action items with owners and timing
+- what should happen next in the deal or account
+
+### Step 3: Draft the outputs
+
+- create the internal recap
+- draft the customer follow-up
+- create a Gmail draft when available; otherwise provide the plain-text draft inline
+
+## Handoff Rules
+
+Stay recap-first by default.
+
+If the meeting clearly creates a larger downstream task:
+
+- hand off to `proposal-writing` for proposals, SOWs, scopes, or commercials
+- hand off to `frontend-slides` for recap decks, exec summaries, or customer-facing presentation material
+
+The handoff brief should include:
+
+- the deal or account context
+- meeting outcomes and decisions
+- priorities, objections, and requested deliverable
+- any missing commercial or technical details
+
+### Example handoff: proposal follow-up
+
+If the meeting ends with "please send a proposal," first produce the recap and clear next-step summary here, then pass the commercial and scope context into `proposal-writing`.
+
+### Example handoff: executive recap deck
+
+If the user asks for a call summary plus an executive readout deck, first create the recap and action table here, then hand off the story, audience, and key outcomes to `frontend-slides`.
 
 ## Tips
 
-1. **More detail = better output** — Even rough notes help. "They seemed concerned about X" is useful context.
-2. **Name the attendees** — Helps me structure the summary and assign action items.
-3. **Flag what matters** — If something was important, tell me: "The big thing was..."
-4. **Tell me the deal stage** — Helps me tailor the follow-up tone and next steps.
+1. Rough notes are enough if they contain the signal.
+2. Attendee names make summaries and action items more accurate.
+3. If something mattered a lot, call it out explicitly.
+4. Deal stage helps tune the follow-up tone and next-step recommendation.
+
+## Notes
+
+- Do not ask for pasted notes if Gmail or Drive already contains likely transcript artifacts.
+- Do not claim CRM updates happened unless the CRM path actually exists and was used.

--- a/skills/sales/skills/competitive-intelligence/SKILL.md
+++ b/skills/sales/skills/competitive-intelligence/SKILL.md
@@ -1,401 +1,107 @@
 ---
 name: competitive-intelligence
-description: Research your competitors and build an interactive battlecard. Outputs an HTML artifact with clickable competitor cards and a comparison matrix. Trigger with "competitive intel", "research competitors", "how do we compare to [competitor]", "battlecard for [competitor]", or "what's new with [competitor]".
+description: Research competitors and build a seller-friendly brief or battlecard. Prefer internal docs and tagged workspace files first, then use current web research to refresh claims and market context.
 ---
 
 # Competitive Intelligence
 
-Research your competitors extensively and generate an **interactive HTML battlecard** you can use in deals. The output is a self-contained artifact with clickable competitor tabs and an overall comparison matrix.
+Help sellers position with evidence, not folklore. This skill should default to a concise competitive brief, while preserving the richer battlecard concepts from the original pack when the user explicitly wants them.
 
 ## How It Works
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
-│                  COMPETITIVE INTELLIGENCE                        │
+│                  COMPETITIVE INTELLIGENCE                       │
 ├─────────────────────────────────────────────────────────────────┤
-│  ALWAYS (works standalone via web search)                        │
-│  ✓ Competitor product deep-dive: features, pricing, positioning │
-│  ✓ Recent releases: what they've shipped in last 90 days        │
-│  ✓ Your company releases: what you've shipped to counter        │
-│  ✓ Differentiation matrix: where you win vs. where they win     │
-│  ✓ Sales talk tracks: how to position against each competitor   │
-│  ✓ Landmine questions: expose their weaknesses naturally        │
+│  ALWAYS                                                         │
+│  ✓ Competitor product and positioning research                 │
+│  ✓ Recent releases, pricing, and win/loss framing             │
+│  ✓ Talk tracks, objections, and landmine questions            │
 ├─────────────────────────────────────────────────────────────────┤
-│  OUTPUT: Interactive HTML Battlecard                             │
-│  ✓ Comparison matrix overview                                    │
-│  ✓ Clickable tabs for each competitor                           │
-│  ✓ Dark theme, professional styling                             │
-│  ✓ Self-contained HTML file — share or host anywhere            │
-├─────────────────────────────────────────────────────────────────┤
-│  SUPERCHARGED (when you connect your tools)                      │
-│  + CRM: Win/loss data, competitor mentions in closed deals      │
-│  + Docs: Existing battlecards, competitive playbooks            │
-│  + Chat: Internal intel, field reports from colleagues          │
-│  + Transcripts: Competitor mentions in customer calls           │
+│  INTERNAL-FIRST                                                 │
+│  + Drive battlecards, enablement docs, proposal material      │
+│  + Tagged files and account context                           │
+│  + Gmail notes only when competitor mentions matter           │
+│  + CRM, chat, or transcripts as optional enrichment           │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
----
+## Retrieval Order
 
-## Getting Started
+1. Tagged workspace files via `rag_query`
+2. Google Drive for battlecards, comparison docs, enablement notes, and proposal material
+3. Gmail or recap notes only when they contain direct competitor mentions
+4. Google Search for current pricing, releases, reviews, and positioning
+5. CRM or win/loss data if available
+6. Chat systems only if connected and relevant
 
-When you run this skill, I'll ask for context:
+## Default Output
 
-**Required:**
-- What company do you work for? (or I'll detect from your email)
-- Who are your main competitors? (1-5 names)
+Produce a brief-first artifact with:
 
-**Optional:**
-- Which competitor do you want to focus on first?
-- Any specific deals where you're competing against them?
-- Pain points you've heard from customers about competitors?
+- competitor summary
+- where they win
+- where we win
+- likely objections they trigger
+- suggested talk tracks
+- landmine questions or discovery prompts
 
-If I already have your seller context from a previous session, I'll confirm and skip the questions.
+## Expanded Output When Requested
 
----
+If the user explicitly wants a battlecard, preserve the richer structure from the original workflow:
 
-## Connectors (Optional)
+- comparison matrix
+- competitor-by-competitor sections
+- pricing intelligence
+- where they win versus where we win
+- talk tracks by scenario
+- objection handling and landmine questions
 
-| Connector | What It Adds |
-|-----------|--------------|
-| **CRM** | Win/loss history against each competitor, deal-level competitor tracking |
-| **Docs** | Existing battlecards, product comparison docs, competitive playbooks |
-| **Chat** | Internal chat intel (e.g. Slack) — what your team is hearing from the field |
-| **Transcripts** | Competitor mentions in customer calls, objections raised |
-
-> **No connectors?** Web research works great. I'll pull everything from public sources — product pages, pricing, blogs, release notes, reviews, job postings.
-
----
-
-## Output: Interactive HTML Battlecard
-
-The skill generates a **self-contained HTML file** with:
-
-### 1. Comparison Matrix (Landing View)
-Overview comparing you vs. all competitors at a glance:
-- Feature comparison grid
-- Pricing comparison
-- Market positioning
-- Win rate indicators (if CRM connected)
-
-### 2. Competitor Tabs (Click to Expand)
-Each competitor gets a clickable card that expands to show:
-- Company profile (size, funding, target market)
-- What they sell and how they position
-- Recent releases (last 90 days)
-- Where they win vs. where you win
-- Pricing intelligence
-- Talk tracks for different scenarios
-- Objection handling
-- Landmine questions
-
-### 3. Your Company Card
-- Your releases (last 90 days)
-- Your key differentiators
-- Proof points and customer quotes
-
----
-
-## HTML Structure
-
-```html
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Battlecard: [Your Company] vs Competitors</title>
-    <style>
-        /* Dark theme, professional styling */
-        /* Tabbed navigation */
-        /* Expandable cards */
-        /* Responsive design */
-    </style>
-</head>
-<body>
-    <!-- Header with your company + date -->
-    <header>
-        <h1>[Your Company] Competitive Battlecard</h1>
-        <p>Generated: [Date] | Competitors: [List]</p>
-    </header>
-
-    <!-- Tab Navigation -->
-    <nav class="tabs">
-        <button class="tab active" data-tab="matrix">Comparison Matrix</button>
-        <button class="tab" data-tab="competitor-1">[Competitor 1]</button>
-        <button class="tab" data-tab="competitor-2">[Competitor 2]</button>
-        <button class="tab" data-tab="competitor-3">[Competitor 3]</button>
-    </nav>
-
-    <!-- Comparison Matrix Tab -->
-    <section id="matrix" class="tab-content active">
-        <h2>Head-to-Head Comparison</h2>
-        <table class="comparison-matrix">
-            <!-- Feature rows with you vs each competitor -->
-        </table>
-
-        <h2>Quick Win/Loss Guide</h2>
-        <div class="win-loss-grid">
-            <!-- Per-competitor: when you win, when you lose -->
-        </div>
-    </section>
-
-    <!-- Individual Competitor Tabs -->
-    <section id="competitor-1" class="tab-content">
-        <div class="battlecard">
-            <div class="profile"><!-- Company info --></div>
-            <div class="differentiation"><!-- Where they win / you win --></div>
-            <div class="talk-tracks"><!-- Scenario-based positioning --></div>
-            <div class="objections"><!-- Common objections + responses --></div>
-            <div class="landmines"><!-- Questions to ask --></div>
-        </div>
-    </section>
-
-    <script>
-        // Tab switching logic
-        // Expand/collapse sections
-    </script>
-</body>
-</html>
-```
-
----
-
-## Visual Design
-
-### Color System
-```css
-:root {
-    /* Dark theme base */
-    --bg-primary: #0a0d14;
-    --bg-elevated: #0f131c;
-    --bg-surface: #161b28;
-    --bg-hover: #1e2536;
-
-    /* Text */
-    --text-primary: #ffffff;
-    --text-secondary: rgba(255, 255, 255, 0.7);
-    --text-muted: rgba(255, 255, 255, 0.5);
-
-    /* Accent (your brand or neutral) */
-    --accent: #3b82f6;
-    --accent-hover: #2563eb;
-
-    /* Status indicators */
-    --you-win: #10b981;
-    --they-win: #ef4444;
-    --tie: #f59e0b;
-}
-```
-
-### Card Design
-- Rounded corners (12px)
-- Subtle borders (1px, low opacity)
-- Hover states with slight elevation
-- Smooth transitions (200ms)
-
-### Comparison Matrix
-- Sticky header row
-- Color-coded winner indicators (green = you, red = them, yellow = tie)
-- Expandable rows for detail
-
----
-
-## Execution Flow
-
-### Phase 1: Gather Seller Context
-
-```
-If first time:
-1. Ask: "What company do you work for?"
-2. Ask: "What do you sell? (product/service in one line)"
-3. Ask: "Who are your main competitors? (up to 5)"
-4. Store context for future sessions
-
-If returning user:
-1. Confirm: "Still at [Company] selling [Product]?"
-2. Ask: "Same competitors, or any new ones to add?"
-```
-
-### Phase 2: Research Your Company (Always)
-
-```
-Web searches:
-1. "[Your company] product" — current offerings
-2. "[Your company] pricing" — pricing model
-3. "[Your company] news" — recent announcements (90 days)
-4. "[Your company] product updates OR changelog OR releases" — what you've shipped
-5. "[Your company] vs [competitor]" — existing comparisons
-```
-
-### Phase 3: Research Each Competitor (Always)
-
-```
-For each competitor, run:
-1. "[Competitor] product features" — what they offer
-2. "[Competitor] pricing" — how they charge
-3. "[Competitor] news" — recent announcements
-4. "[Competitor] product updates OR changelog OR releases" — what they've shipped
-5. "[Competitor] reviews G2 OR Capterra OR TrustRadius" — customer sentiment
-6. "[Competitor] vs [alternatives]" — how they position
-7. "[Competitor] customers" — who uses them
-8. "[Competitor] careers" — hiring signals (growth areas)
-```
-
-### Phase 4: Pull Connected Sources (If Available)
-
-```
-If CRM connected:
-1. Query closed-won deals with competitor field = [Competitor]
-2. Query closed-lost deals with competitor field = [Competitor]
-3. Extract win/loss patterns
-
-If docs connected:
-1. Search for "battlecard [competitor]"
-2. Search for "competitive [competitor]"
-3. Pull existing positioning docs
-
-If chat connected:
-1. Search for "[Competitor]" mentions (last 90 days)
-2. Extract field intel and colleague insights
-
-If transcripts connected:
-1. Search calls for "[Competitor]" mentions
-2. Extract objections and customer quotes
-```
-
-### Phase 5: Build HTML Artifact
-
-```
-1. Structure data for each competitor
-2. Build comparison matrix
-3. Generate individual battlecards
-4. Create talk tracks for each scenario
-5. Compile landmine questions
-6. Render as self-contained HTML
-7. Save as [YourCompany]-battlecard-[date].html
-```
-
----
-
-## Data Structure Per Competitor
-
-```yaml
-competitor:
-  name: "[Name]"
-  website: "[URL]"
-  profile:
-    founded: "[Year]"
-    funding: "[Stage + amount]"
-    employees: "[Count]"
-    target_market: "[Who they sell to]"
-    pricing_model: "[Per seat / usage / etc.]"
-    market_position: "[Leader / Challenger / Niche]"
-
-  what_they_sell: "[Product summary]"
-  their_positioning: "[How they describe themselves]"
-
-  recent_releases:
-    - date: "[Date]"
-      release: "[Feature/Product]"
-      impact: "[Why it matters]"
-
-  where_they_win:
-    - area: "[Area]"
-      advantage: "[Their strength]"
-      how_to_handle: "[Your counter]"
-
-  where_you_win:
-    - area: "[Area]"
-      advantage: "[Your strength]"
-      proof_point: "[Evidence]"
-
-  pricing:
-    model: "[How they charge]"
-    entry_price: "[Starting price]"
-    enterprise: "[Enterprise pricing]"
-    hidden_costs: "[Implementation, etc.]"
-    talk_track: "[How to discuss pricing]"
-
-  talk_tracks:
-    early_mention: "[Strategy if they come up early]"
-    displacement: "[Strategy if customer uses them]"
-    late_addition: "[Strategy if added late to eval]"
-
-  objections:
-    - objection: "[What customer says]"
-      response: "[How to handle]"
-
-  landmines:
-    - "[Question that exposes their weakness]"
-
-  win_loss: # If CRM connected
-    win_rate: "[X]%"
-    common_win_factors: "[What predicts wins]"
-    common_loss_factors: "[What predicts losses]"
-```
-
----
-
-## Delivery
+## Example Brief Structure
 
 ```markdown
-## ✓ Battlecard Created
+# Competitive Brief: [Competitor]
 
-[View your battlecard](file:///path/to/[YourCompany]-battlecard-[date].html)
+## Quick Take
+- Why they matter in deals:
+- Where they are strongest:
+- Where we should challenge them:
 
----
+## Where They Win
+- 
 
-**Summary**
-- **Your Company**: [Name]
-- **Competitors Analyzed**: [List]
-- **Data Sources**: Web research [+ CRM] [+ Docs] [+ Transcripts]
+## Where We Win
+- 
 
----
+## Objections They Trigger
+- 
 
-**How to Use**
-- **Before a call**: Open the relevant competitor tab, review talk tracks
-- **During a call**: Reference landmine questions
-- **After win/loss**: Update with new intel
+## Talk Tracks
+- Early mention:
+- Active bake-off:
+- Replacement / displacement:
 
----
-
-**Sharing Options**
-- **Local file**: Open in any browser
-- **Host it**: Upload to Netlify, Vercel, or internal wiki
-- **Share directly**: Send the HTML file to teammates
-
----
-
-**Keep it Fresh**
-Run this skill again to refresh with latest intel. Recommended: monthly or before major deals.
+## Landmine Questions
+1.
+2.
+3.
 ```
 
----
+## Execution Rules
 
-## Refresh Cadence
+- Reuse internal materials first so the output matches the team's current positioning.
+- Use Google Search to validate and refresh current competitor claims.
+- Treat CRM, transcript, and chat context as optional enrichment, not a requirement.
+- Keep claims time-aware when discussing releases, pricing, or market moves.
 
-Competitive intel gets stale. Recommended refresh:
+## Handoff Rules
 
-| Trigger | Action |
-|---------|--------|
-| **Monthly** | Quick refresh — new releases, news, pricing changes |
-| **Before major deal** | Deep refresh for specific competitor in that deal |
-| **After win/loss** | Update patterns with new data |
-| **Competitor announcement** | Immediate update on that competitor |
+When the ask turns into a customer-facing or exec-facing artifact:
 
----
+- hand off to `frontend-slides` for a competitor deck or presentation
+- hand off to `create-an-asset` for a customer-facing comparison asset
+- hand off to `research` if the user wants a deeper market landscape analysis
 
-## Tips for Better Intel
+### Example handoff
 
-1. **Be honest about weaknesses** — Credibility comes from acknowledging where competitors are strong
-2. **Focus on outcomes, not features** — "They have X feature" matters less than "customers achieve Y result"
-3. **Update from the field** — Best intel comes from actual customer conversations, not just websites
-4. **Plant landmines, don't badmouth** — Ask questions that expose weaknesses; never trash-talk
-5. **Track releases religiously** — What they ship tells you their strategy and your opportunity
-
----
-
-## Related Skills
-
-- **account-research** — Research a specific prospect before reaching out
-- **call-prep** — Prep for a call where you know competitor is involved
-- **create-an-asset** — Build a custom comparison page for a specific deal
+If the seller asks for "a battlecard deck for our exec review," first build the competitive brief here, then pass the comparison structure and storyline into `frontend-slides`.

--- a/skills/sales/skills/create-an-asset/SKILL.md
+++ b/skills/sales/skills/create-an-asset/SKILL.md
@@ -5,7 +5,14 @@ description: Generate tailored sales assets (landing pages, decks, one-pagers, w
 
 # Create an Asset
 
-Generate custom sales assets tailored to your prospect, audience, and goals. Supports interactive landing pages, presentation decks, executive one-pagers, and workflow/architecture demos.
+Generate custom sales assets tailored to your prospect, audience, and goals. Use this when the sales workflow has already identified the audience, purpose, and account context and the next step is a polished customer-facing asset.
+
+This skill should complement, not replace, the broader workflow:
+
+- use `call-prep`, `call-summary`, `draft-outreach`, or `account-research` to gather seller context first
+- use `frontend-slides` when the ask is specifically a presentation or slide deck workflow
+- use `proposal-writing` when the ask is specifically a proposal, SOW, or commercial document
+- use `create-an-asset` when the deliverable is a more custom customer-facing asset such as a one-pager, landing page, or interactive demo
 
 ---
 
@@ -27,6 +34,16 @@ This skill creates professional sales assets by gathering context about:
 - **(d) The Format** — landing page, deck, one-pager, or workflow demo
 
 The skill then researches, structures, and builds a polished, branded asset ready to share with customers.
+
+## Handoff Contract
+
+Before building, make sure the workflow has captured:
+
+- target account and audience
+- deal stage and purpose
+- pain points, objections, and priorities
+- desired call to action
+- any existing notes, transcripts, proposals, or decks worth reusing
 
 ---
 

--- a/skills/sales/skills/daily-briefing/SKILL.md
+++ b/skills/sales/skills/daily-briefing/SKILL.md
@@ -1,237 +1,163 @@
 ---
 name: daily-briefing
-description: Start your day with a prioritized sales briefing. Works standalone when you tell me your meetings and priorities, and becomes Google Workspace-first when Calendar, Gmail, Drive, and Sheets are connected. Trigger with "morning briefing", "daily brief", "what's on my plate today", "prep my day", or "start my day".
+description: Start your day with a prioritized sales briefing. Works standalone when you tell me your meetings and priorities, and becomes Google Workspace-first when Calendar, Gmail, Drive, Sheets, and tagged workspace files are connected.
 ---
 
 # Daily Sales Briefing
 
-Get a clear view of what matters most today. This skill works with whatever you tell me, and gets richer when you connect your tools.
+Get a clear view of what matters most today. This skill should work with whatever the seller gives you, but succeed best when Calendar and Gmail are available. Keep it operational, concise, and useful in under two minutes of reading.
 
 ## How It Works
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
-│                      DAILY BRIEFING                              │
+│                      DAILY BRIEFING                             │
 ├─────────────────────────────────────────────────────────────────┤
-│  ALWAYS (works standalone)                                       │
-│  ✓ You tell me: today's meetings, key deals, priorities         │
-│  ✓ I organize: prioritized action plan for your day             │
-│  ✓ Output: scannable 2-minute briefing                          │
+│  ALWAYS (works standalone)                                      │
+│  ✓ You tell me today's meetings, deals, and priorities         │
+│  ✓ I organize a prioritized action plan                        │
+│  ✓ Output is a scannable daily briefing                        │
 ├─────────────────────────────────────────────────────────────────┤
-│  SUPERCHARGED (when you connect your tools)                      │
-│  + Calendar: auto-pull today's meetings with attendees          │
-│  + Gmail: unread buyer messages, waiting on replies             │
-│  + Drive: today's prep docs, notes, proposal files              │
-│  + Sheets: pipeline trackers or account spreadsheets            │
-│  + CRM: pipeline alerts, tasks, deal health                     │
+│  GWS-FIRST (preferred path)                                     │
+│  + Calendar: today's meetings and attendees                    │
+│  + Gmail: urgent replies, no-reply threads, recap emails       │
+│  + Drive: prep docs, decks, notes, proposals                   │
+│  + Sheets: trackers and account plans                          │
+│  + Tagged files: workspace context via rag_query               │
+│  + CRM: optional pipeline alerts and task context              │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
----
-
 ## Getting Started
 
-When you run this skill, I'll ask for what I need:
+When you run this skill, only ask for what is still missing.
 
-**If no calendar connected:**
-> "What meetings do you have today? (Just paste your calendar or list them)"
+**If no calendar context exists:**
+"What meetings do you have today?"
 
-**If no CRM or Sheets connected:**
-> "What deals are you focused on this week? Any that need attention?"
+**If no Sheets or CRM context exists:**
+"What deals or accounts need attention this week?"
 
-**If you have connectors:**
-I'll pull everything automatically and just show you the briefing.
+**If tools are connected:**
+Pull the context automatically and produce the briefing.
 
----
+## Retrieval Order
 
-## Connectors (Optional)
-
-Connect your tools to supercharge this skill:
-
-| Connector | What It Adds |
-|-----------|--------------|
-| **Calendar** | Today's meetings with attendees, times, and context |
-| **Gmail** | Unread from opportunity contacts, emails waiting on replies, transcript recap emails |
-| **Drive** | Today's prep docs, decks, notes, proposals |
-| **Sheets** | Pipeline trackers, account plans, next-step sheets |
-| **CRM** | Open pipeline, deals closing soon, overdue tasks, stale deals |
-
-> **No connectors?** No problem. Tell me your meetings and deals, and I'll create your briefing.
-
----
+1. Google Calendar for today's meetings
+2. Gmail for urgent inbound and no-reply follow-ups
+3. Google Drive for prep docs, decks, and recap materials
+4. Tagged workspace files via `rag_query`
+5. Google Sheets for trackers or account plans
+6. CRM if connected
+7. Google Search only when a priority account needs same-day external context
 
 ## Output Format
 
 ```markdown
 # Daily Briefing | [Day, Month Date]
 
----
-
 ## #1 Priority
-
 **[Most important thing to do today]**
-[Why it matters and what to do about it]
-
----
+[Why it matters and what to do]
 
 ## Today's Numbers
-
 | Open Pipeline | Closing This Month | Meetings Today | Action Items |
-|---------------|-------------------|----------------|--------------|
+|---|---|---|---|
 | $[X] | $[X] | [N] | [N] |
 
----
-
 ## Today's Meetings
-
 ### [Time] — [Company] ([Meeting Type])
 **Attendees:** [Names]
-**Context:** [One-line: deal status, last touch, what's at stake]
-**Prep:** [Quick action before this meeting]
-
-### [Time] — [Company] ([Meeting Type])
-**Attendees:** [Names]
-**Context:** [One-line context]
+**Context:** [Deal status or last touch]
 **Prep:** [Quick action]
 
-*Run `call-prep [company]` for detailed meeting prep*
-
----
-
-## Pipeline Alerts
-
-### Needs Attention
-| Deal | Stage | Amount | Alert | Action |
-|------|-------|--------|-------|--------|
-| [Deal] | [Stage] | $[X] | [Why flagged] | [What to do] |
-
-### Closing This Week
-| Deal | Close Date | Amount | Confidence | Blocker |
-|------|------------|--------|------------|---------|
-| [Deal] | [Date] | $[X] | [H/M/L] | [If any] |
-
----
-
 ## Email Priorities
-
 ### Needs Response
 | From | Subject | Received |
-|------|---------|----------|
-| [Name @ Company] | [Subject] | [Time] |
+|---|---|---|
 
 ### Waiting On Reply
 | To | Subject | Sent | Days Waiting |
-|----|---------|------|--------------|
-| [Name @ Company] | [Subject] | [Date] | [N] |
+|---|---|---|---|
 
----
+## Prep Materials
+- [Doc / deck / note]
 
 ## Suggested Actions
-
 1. **[Action]** — [Why now]
 2. **[Action]** — [Why now]
 3. **[Action]** — [Why now]
-
----
-
-*Run `call-prep [company]` before your meetings*
-*Run `call-summary` after each call*
 ```
 
----
+Only include pipeline or forecast sections when Sheets or CRM data actually exists.
 
 ## Execution Flow
 
-### Step 1: Gather Context
+### Step 1: Gather the day's internal context
 
-**If connectors available:**
-```
-1. Calendar → Get today's events
-   - Filter to external meetings (non-company attendees)
-   - Pull: time, title, attendees, description
+Use Calendar:
 
-2. Gmail → Check priority messages
-   - Unread from opportunity contact domains
-   - Sent messages with no reply (3+ days)
+- list external-facing meetings
+- capture attendees, times, and short descriptions
 
-3. Drive → Search today's prep materials
-   - Pull: notes, decks, proposals, transcript docs/files tied to today's accounts
+Use Gmail:
 
-4. Sheets → Check trackers (if available)
-   - Pull: account plans, pipeline spreadsheets, next-step trackers
+- find unread buyer or stakeholder emails
+- identify sent-without-reply threads that matter today
+- find recap or transcript emails tied to today's accounts
 
-5. CRM → Query your pipeline
-   - Open opportunities owned by you
-   - Flag: closing this week, no activity 7+ days, slipped dates
-   - Get: overdue tasks, upcoming tasks
-```
+Use Drive:
 
-**If no connectors:**
-```
-Ask user:
-1. "What meetings do you have today?"
-2. "What deals are you focused on? Any closing soon or needing attention?"
-3. "Anything urgent I should know about?"
+- find decks, notes, proposals, or recap docs connected to today's meetings
 
-Work with whatever they provide.
-```
+Use Sheets or CRM only if they add real prioritization value:
+
+- pipeline trackers
+- account plans
+- close dates
+- overdue tasks
 
 ### Step 2: Prioritize
 
-```
-Priority ranking:
-1. URGENT: Deal closing today/tomorrow not yet won
-2. HIGH: Meeting today with high-value opportunity
-3. HIGH: Unread email from decision-maker
-4. MEDIUM: Deal closing this week
-5. MEDIUM: Stale deal (7+ days no activity)
-6. LOW: Tasks due this week
+Default ranking:
 
-Select #1 Priority:
-- If meeting with >$50K deal today → prep that
-- If deal closing today → focus on close
-- If urgent email from buyer → respond first
-- Else → highest-value stale deal
-```
+1. urgent meeting prep for a live account conversation
+2. urgent buyer reply or blocker
+3. close-date or next-step risk from Sheets or CRM
+4. stale follow-up that needs action today
 
-### Step 3: Generate Briefing
+### Step 3: Generate the briefing
 
-```
-Assemble sections based on available data:
+Assemble only the sections supported by real data:
 
-1. #1 Priority — Always include (even if simple)
-2. Today's Numbers — If CRM or Sheets connected, otherwise skip
-3. Today's Meetings — From calendar or user input
-4. Pipeline Alerts — If CRM connected
-5. Email Priorities — If Gmail connected
-6. Suggested Actions — Always include top 3 actions
-```
-
----
+1. #1 Priority
+2. Today's Meetings
+3. Email Priorities
+4. Prep Materials
+5. Suggested Actions
+6. Today's Numbers or Pipeline Alerts if Sheets or CRM adds them
 
 ## Quick Mode
 
-Say "quick brief" or "tldr my day" for abbreviated version:
+If the user asks for "quick brief" or "tl;dr my day", return:
 
 ```markdown
 # Quick Brief | [Date]
 
 **#1:** [Priority action]
 
-**Meetings:** [N] — [Company 1], [Company 2], [Company 3]
+**Meetings:** [N] — [Company 1], [Company 2]
 
 **Alerts:**
 - [Alert 1]
 - [Alert 2]
 
-**Do Now:** [Single most important action]
+**Do Now:** [Most important action]
 ```
 
----
+## End Of Day Mode
 
-## End of Day Mode
-
-Say "wrap up my day" or "end of day summary" after your last meeting:
+If the user asks for "wrap up my day" or "end of day summary":
 
 ```markdown
 # End of Day | [Date]
@@ -240,29 +166,29 @@ Say "wrap up my day" or "end of day summary" after your last meeting:
 - [Meeting 1] — [Outcome]
 - [Meeting 2] — [Outcome]
 
-**Pipeline Changes:**
-- [Deal] moved to [Stage]
-
 **Tomorrow's Focus:**
 - [Priority 1]
 - [Priority 2]
 
 **Open Loops:**
-- [ ] [Unfinished item needing follow-up]
+- [ ] [Follow-up item]
 ```
 
----
+## Handoff Rules
+
+Stay operational by default.
+
+If one account clearly needs deeper same-day context:
+
+- hand off to `research` for a focused account, market, or industry brief
+
+### Example handoff
+
+If the daily briefing reveals a high-stakes meeting with a fast-changing account, produce the daily brief first, then route the missing deep background to `research` rather than turning the daily brief into a long report.
 
 ## Tips
 
-1. **Connect Calendar and Gmail first** — Biggest time saver
-2. **Add Drive or Sheets next** — Unlocks prep docs and pipeline trackers
-3. **Add CRM if you have one** — Best for stage hygiene and forecast context
-
----
-
-## Related Skills
-
-- **call-prep** — Deep prep for any specific meeting
-- **call-summary** — Process notes after calls
-- **account-research** — Research a company before first meeting
+1. Calendar and Gmail are the biggest time savers.
+2. Drive and Sheets add useful prep and tracker context.
+3. CRM helps, but the workflow should still work well without it.
+4. Google Search is enrichment, not the starting point.

--- a/skills/sales/skills/draft-outreach/SKILL.md
+++ b/skills/sales/skills/draft-outreach/SKILL.md
@@ -1,443 +1,256 @@
 ---
 name: draft-outreach
-description: Research a prospect then draft personalized outreach. Uses web research by default, and becomes Google Workspace-first when Gmail, Drive, and Sheets are available for context and draft creation. Trigger with "draft outreach to [person/company]", "write cold email to [prospect]", "reach out to [name]".
+description: Research a prospect then draft personalized outreach. Prefer Gmail, Drive, Sheets, and tagged files before web search, and create a Gmail draft when possible.
 ---
 
 # Draft Outreach
 
-Research first, then draft. This skill never sends generic outreach - it always researches the prospect first to personalize the message. Works standalone with web search, supercharged when you connect your tools.
+Research first, then draft. This skill should never send generic outreach. Start with the seller's internal context, then enrich externally only where it improves the message.
 
 ## Connectors (Optional)
 
 | Connector | What It Adds |
 |-----------|--------------|
-| **Gmail** | Create a draft directly in your inbox and inspect prior threads |
-| **Drive** | Reuse notes, decks, or account plans related to the target |
-| **Sheets** | Pull territory or account-tracker context when relevant |
+| **Gmail** | Create a draft directly in the inbox and inspect prior threads |
+| **Drive** | Reuse notes, decks, battlecards, or account plans |
+| **Sheets** | Pull territory or account-tracker context |
 | **CRM** | Prior relationship context, existing contacts |
 | **Enrichment** | Verified email, phone, background details |
 
-> **No connectors?** Web research works great. I'll output the email text for you to copy.
-
----
+> No connectors? The workflow still works. Return the email text and LinkedIn fallback.
 
 ## How It Works
 
-```
+```text
 +------------------------------------------------------------------+
-|                      DRAFT OUTREACH                               |
-|                                                                   |
+|                      DRAFT OUTREACH                              |
+|                                                                  |
 |  Step 1: RESEARCH (always happens first)                         |
-|  - Web search (default)                                           |
-|  - + Drive / Sheets context (if connected)                       |
-|  - + CRM or enrichment (if connected)                            |
-|                                                                   |
-|  Step 2: DRAFT (based on research)                               |
-|  - Personalized opening (from research)                          |
-|  - Relevant hook (their priorities)                              |
-|  - Clear CTA                                                      |
-|                                                                   |
-|  Step 3: DELIVER (based on connectors)                           |
-|  - Gmail draft (if Gmail connected)                              |
-|  - Copy for LinkedIn (always)                                    |
-|  - Output to user (always)                                        |
+|  - Gmail, Drive, Sheets, tagged files                            |
+|  - Google Search only after internal review                      |
+|  - CRM or enrichment if available                                |
+|                                                                  |
+|  Step 2: DRAFT                                                   |
+|  - Personalized opening from real context                        |
+|  - Relevant hook tied to priorities                              |
+|  - Clear proof and CTA                                           |
+|                                                                  |
+|  Step 3: DELIVER                                                 |
+|  - Gmail draft if available                                      |
+|  - Plain-text output always                                      |
+|  - LinkedIn fallback if no email                                 |
 +------------------------------------------------------------------+
 ```
 
----
+## Retrieval Order
+
+1. Gmail for prior threads and open loops
+2. Google Drive for notes, decks, proposals, and account plans
+3. Tagged workspace files via `rag_query`
+4. Google Sheets for territory or account-tracker context
+5. Google Search for current company, role, or market updates
+6. CRM or enrichment only if available
 
 ## Output Format
 
 ```markdown
 # Outreach Draft: [Person] @ [Company]
-**Generated:** [Date] | **Research Sources:** [Web, Drive, Sheets, Enrichment, CRM]
-
----
+**Generated:** [Date] | **Research Sources:** [Gmail, Drive, Sheets, Web, CRM]
 
 ## Research Summary
-
 **Target:** [Name], [Title] at [Company]
-**Hook:** [Why reaching out now - the personalized angle]
-**Goal:** [What you want from this outreach]
+**Hook:** [Why reaching out now]
+**Goal:** [Desired outcome]
 
----
+## Outreach Brief
+- Relationship status:
+- Why now:
+- Proof points to reference:
+- Ask / CTA:
 
 ## Email Draft
-
-**To:** [email if known, or "find email" note]
+**To:** [email if known]
 **Subject:** [Personalized subject line]
-
----
 
 [Email body]
 
----
-
-**Subject Line Alternatives:**
+## Subject Line Alternatives
 1. [Option 2]
 2. [Option 3]
 
----
-
 ## LinkedIn Message (if no email)
+**Connection Request (<300 chars):**
+[Short connection request]
 
-**Connection Request (< 300 chars):**
-[Short, no-pitch connection request]
-
-**Follow-up Message (after connected):**
+**Follow-up Message:**
 [Value-first message]
 
----
-
 ## Why This Approach
-
 | Element | Based On |
-|---------|----------|
+|---|---|
 | Opening | [Research finding that makes it personal] |
-| Hook | [Their priority/pain point] |
+| Hook | [Their priority or pain point] |
 | Proof | [Relevant customer story] |
 | CTA | [Low-friction ask] |
-
----
-
-## Email Draft Status
-
-[Draft created - check ~~email]
-[Email not connected - copy email above]
-[No email found - use LinkedIn approach]
-
----
-
-## Follow-up Sequence (Optional)
-
-**Day 3 - Follow-up 1:**
-[Short, new angle]
-
-**Day 7 - Follow-up 2:**
-[Different value prop]
-
-**Day 14 - Break-up:**
-[Final attempt]
 ```
-
----
 
 ## Execution Flow
 
-### Step 1: Parse Request
+### Step 1: Check internal relationship context
 
-```
-Input patterns:
-- "draft outreach to John Smith at Acme" → Person + company
-- "write cold email to Acme's CTO" → Role + company
-- "reach out to sarah@acme.com" → Email provided
-- "LinkedIn message to [LinkedIn URL]" → Profile provided
-```
+Use Gmail first:
 
-### Step 2: Research First (Always)
+- search for prior conversations with the contact or domain
+- detect whether this is cold, warm, or reactivation outreach
+- note open loops or prior commitments
 
-**Use research-prospect skill internally:**
-```
-1. Web search for company + person
-2. If Drive or Sheets connected: Check account plans, notes, or territory trackers
-3. If CRM connected: Check for prior relationship
-4. If Enrichment connected: Get verified contact info, background
-```
+Use Drive and tagged files next:
 
-**Must find before drafting:**
-- Who they are (title, background)
-- What the company does
-- Recent news or trigger
-- Personalization hook
+- look for notes, battlecards, call summaries, decks, and proposal drafts
+- reuse the customer's language when it exists
 
-### Step 3: Identify Hook
+Use Sheets if relevant:
 
-```
-Priority order for hooks:
-1. Trigger event (funding, hiring, news) → Most timely
-2. Mutual connection → Social proof
-3. Their content (post, article, talk) → Shows you did research
-4. Company initiative → Relevant to their priorities
-5. Role-based pain point → Least personal but still relevant
-```
+- territory notes
+- account status
+- next-step tracker rows
 
-### Step 4: Draft Message
+### Step 2: Enrich externally only when useful
 
-**Email Structure (AIDA):**
-```
-SUBJECT: [Personalized, <50 chars, no spam words]
+Use Google Search after internal review:
 
-[Opening: Personal hook - shows you researched them]
+- recent company news
+- leadership or org change
+- initiative or launch tied to the outreach angle
 
-[Interest: Their problem/opportunity in 1-2 sentences]
+Keep external research short and specific. Do not pad the message with generic facts.
 
-[Desire: Brief proof point - similar company result]
+### Step 3: Identify the hook
 
-[Action: Clear, low-friction CTA]
+Priority order:
 
-[Signature]
-```
+1. Trigger event such as funding, hiring, or launch
+2. Prior thread or warm relationship context
+3. Their content or public statement
+4. Company initiative
+5. Role-based pain point
 
-**LinkedIn Connection Request (<300 chars):**
-```
-Hi [Name], [Mutual connection/shared interest/genuine compliment].
-Would love to connect. [No pitch]
+### Step 4: Draft the message
+
+**Email structure**
+
+```text
+SUBJECT: [Personalized, short, non-spammy]
+
+[Opening: personal hook]
+
+[Interest: likely problem or opportunity]
+
+[Desire: brief proof point]
+
+[Action: clear CTA]
 ```
 
-**LinkedIn Follow-up Message:**
-```
-Thanks for connecting! [Value-first: insight, article, observation]
+**LinkedIn connection request**
 
-[Soft transition to why you reached out]
-
-[Question, not pitch]
+```text
+Hi [Name], [genuine context]. Would love to connect.
 ```
 
-### Step 5: Create Email Draft
+## Message Templates By Scenario
 
-```
-If Gmail connector available:
-1. Create draft with to, subject, body
-2. Return draft link
-3. Note: "Draft created - review and send"
+### Cold Outreach
 
-If not available:
-1. Output email text
-2. Note: "Copy to your email client"
-```
-
----
-
-## Capability by Connector
-
-| Capability | Web Only | + Enrichment | + CRM | + Email |
-|------------|----------|--------------|-------|---------|
-| Personalized opening | Basic | Deep | With history | Same |
-| Verified email | No | Yes | Yes | Yes |
-| Background details | Public only | Full | Full | Full |
-| Prior relationship | No | No | Yes | Yes |
-| Auto-create draft | No | No | No | Yes |
-
----
-
-## Message Templates by Scenario
-
-### Cold Outreach (No Prior Relationship)
-
-```
+```text
 Subject: [Their initiative] + [your angle]
 
 Hi [Name],
 
-[Personal hook based on research - news, content, mutual connection].
+[Personal hook based on research].
 
-[1 sentence on their likely challenge based on role/company].
+[1 sentence on likely challenge].
 
-[Brief proof: "We helped [Similar Company] achieve [Result]".]
+[Brief proof point].
 
 Worth a 15-min call to see if relevant?
-
-[Signature]
 ```
 
-### Warm Outreach (Have Met / Mutual Connection)
+### Warm Outreach
 
-```
+```text
 Subject: Following up from [context]
 
 Hi [Name],
 
-[Reference to how you know them / who connected you].
+[Reference to how you know them].
 
-[Why reaching out now - their trigger].
+[Why reaching out now].
 
 [Specific value you can offer].
 
 [CTA]
 ```
 
-### Re-Engagement (Went Dark)
+### Re-Engagement
 
-```
+```text
 Subject: [Short, curiosity-driven]
 
 Hi [Name],
 
-[Acknowledge time passed without being guilt-trippy].
+[Acknowledge time passed].
 
-[New reason to reconnect - their news or your news].
+[New reason to reconnect].
 
-[Simple question to re-open dialogue].
-
-[Signature]
+[Simple question to reopen dialogue].
 ```
 
-### Post-Event Follow-up
+### Post-Event Follow-Up
 
-```
+```text
 Subject: Great meeting you at [Event]
 
 Hi [Name],
 
 [Specific memory from conversation].
 
-[Value-add: article, intro, resource related to what you discussed].
+[Value-add or resource].
 
 [Soft CTA for next conversation].
 ```
 
----
-
 ## Email Style Guidelines
 
-1. **Be concise but informative** — Get to the point quickly. Busy people skim.
-2. **No markdown formatting** — Never use asterisks, bold (**text**), or other markdown. Write plain text that looks natural in any email client.
-3. **Short paragraphs** — 2-3 sentences max per paragraph. White space is your friend.
-4. **Simple lists** — If listing items, use plain dashes. No fancy formatting.
+1. Be concise but informative.
+2. No markdown formatting.
+3. Use short paragraphs.
+4. Keep the CTA low-friction.
 
-**Good:**
-```
-Here's what I can share:
-- Case study from a similar company
-- 15-min intro call this week
-- Quick demo if helpful
-```
+## Handoff Rules
 
-**Bad:**
-```
-**What I Can Offer:**
-- **Case study** from a similar company
-- **Intro call** this week
-```
+Stay outreach-first by default.
 
----
+Escalate only when the ask clearly becomes a larger asset:
 
-## What NOT to Do
+- hand off to `proposal-writing` if the outreach is really a proposal or commercial follow-up
+- hand off to `frontend-slides` if the user needs a pitch deck, visual narrative, or presentation asset
 
-**Generic openers:**
-- "I hope this email finds you well"
-- "I'm reaching out because..."
-- "I wanted to introduce myself"
+When handing off, include:
 
-**Feature dumps:**
-- Long paragraphs about your product
-- Multiple value props at once
-- No clear CTA
+- target account and contact
+- deal stage or outreach objective
+- proof points and pain points
+- desired call to action
 
-**Fake personalization:**
-- "I noticed you work at [Company]" (obviously)
-- "Congrats on your role" (without context)
+### Example handoff: proposal-led outreach
 
-**Markdown in emails:**
-- Using **bold** or *italic* asterisks
-- Headers or formatted lists that won't render
+If the seller says, "Write the follow-up and include a proposal next step," draft the outreach here first, then hand off the commercial document creation to `proposal-writing`.
 
-**Instead:**
-- Lead with something specific you learned
-- One clear value prop
-- One clear ask
-- Plain text formatting only
+### Example handoff: pitch narrative
 
----
+If the seller says, "Draft outreach and make me a deck for the meeting," draft the message here, then pass the story, audience, and hook into `frontend-slides`.
 
-## Channel Selection
+## Notes
 
-```
-IF verified email available:
-  → Email preferred (higher response rate)
-  → Also provide LinkedIn backup
-
-IF no email:
-  → LinkedIn connection request
-  → Follow-up message template for after connection
-
-IF warm intro possible:
-  → Suggest mutual connection outreach first
-```
-
----
-
-## Company Configuration [CUSTOMIZE]
-
-```markdown
-## Outreach Settings
-
-- My name: [Your Name]
-- My title: [Your Title]
-- My company: [Company Name]
-- Value prop: [One sentence - what you help with]
-
-## Signature
-[Your preferred email signature]
-
-## Proof Points
-- [Customer 1]: [Result]
-- [Customer 2]: [Result]
-- [Customer 3]: [Result]
-
-## CTA Options
-- Default: "Worth a 15-min call?"
-- Softer: "Open to learning more?"
-- Specific: "Can I send over a quick demo?"
-
-## Tone
-- [Professional / Casual / Direct]
-- Industry-specific language: [Yes/No]
-```
-
----
-
-## Example
-
-**Input:** "draft outreach to the Head of Engineering at Notion"
-
-**Research finds:**
-- Name: David Tibbitts
-- Recent news: Notion launched AI features
-- Hiring: 5 ML engineer roles open
-- Background: Ex-Facebook, Stanford CS
-
-**Output:**
-
-```markdown
-# Outreach Draft: David Tibbitts @ Notion
-
-## Research Summary
-**Target:** David Tibbitts, Head of Engineering at Notion
-**Hook:** They're scaling AI features and hiring ML talent
-**Goal:** Intro call about AI infrastructure
-
----
-
-## Email Draft
-
-**To:** david@notion.so
-**Subject:** Notion's AI scaling + a thought
-
----
-
-Hi David,
-
-Saw Notion's AI rollout is gaining serious traction - congrats.
-With 5 ML roles open, seems like you're scaling fast.
-
-Curious how you're thinking about inference infrastructure
-as usage grows. We helped [Similar Company] cut their AI
-serving costs 40% while improving latency.
-
-Worth a 15-min call to see if relevant to your roadmap?
-
-Best,
-[Name]
-
----
-
-**Subject Alternatives:**
-1. Notion AI + scaling question
-2. Quick thought on Notion's ML hiring
-
----
-
-## Email Draft Status
-Draft created - check ~~email
-```
+- Gmail drafts are preferred, but plain-text output is an acceptable fallback.
+- Do not default to Google Search before checking internal context.

--- a/skills/sales/skills/forecast/SKILL.md
+++ b/skills/sales/skills/forecast/SKILL.md
@@ -1,18 +1,16 @@
 ---
 name: forecast
-description: Generate a weighted sales forecast with best/likely/worst scenarios, commit vs. upside breakdown, and gap analysis. Use when preparing a quarterly forecast call, assessing gap-to-quota from a pipeline CSV, deciding which deals to commit vs. call upside, or checking pipeline coverage against your number.
+description: Generate a weighted sales forecast from CSV, Sheets, or CRM data. This skill remains CRM-ready, but should succeed with Sheets or pasted pipeline context instead of assuming a connected CRM.
 argument-hint: "<period>"
 ---
 
 # /forecast
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
-
-Generate a weighted sales forecast with risk analysis and commit recommendations.
+Use this skill for forecast reviews, gap-to-quota analysis, and commit versus upside planning.
 
 ## Usage
 
-```
+```text
 /forecast [period]
 ```
 
@@ -20,195 +18,33 @@ Generate a forecast for: $ARGUMENTS
 
 If a file is referenced: @$1
 
----
+## Operating Rules
 
-## How It Works
+- Prefer Google Sheets or uploaded CSV data first.
+- Use CRM as enrichment when present, not as a prerequisite.
+- Keep the output analytical and brief-first.
+- If the user tagged a pipeline file, use that before asking for more data.
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                        FORECAST                                  │
-├─────────────────────────────────────────────────────────────────┤
-│  STANDALONE (always works)                                       │
-│  ✓ Upload CSV export from your CRM                              │
-│  ✓ Or paste/describe your pipeline deals                        │
-│  ✓ Set your quota and timeline                                  │
-│  ✓ Get weighted forecast with stage probabilities               │
-│  ✓ Risk-adjusted projections (best/likely/worst case)           │
-│  ✓ Commit vs. upside breakdown                                  │
-│  ✓ Gap analysis and recommendations                             │
-├─────────────────────────────────────────────────────────────────┤
-│  SUPERCHARGED (when you connect your tools)                      │
-│  + CRM: Pull pipeline automatically, real-time data             │
-│  + Historical win rates by stage, segment, deal size            │
-│  + Activity signals for risk scoring                            │
-│  + Automatic refresh and tracking over time                     │
-└─────────────────────────────────────────────────────────────────┘
-```
+## Data Preference Order
 
----
-
-## What I Need From You
-
-### Step 1: Your Pipeline Data
-
-**Option A: Upload a CSV**
-Export your pipeline from your CRM (e.g. Salesforce, HubSpot). I need at minimum:
-- Deal/Opportunity name
-- Amount
-- Stage
-- Close date
-
-Helpful if you have:
-- Owner (if team forecast)
-- Last activity date
-- Created date
-- Account name
-
-**Option B: Paste your deals**
-```
-Acme Corp - $50K - Negotiation - closes Jan 31
-TechStart - $25K - Demo scheduled - closes Feb 15
-BigCo - $100K - Discovery - closes Mar 30
-```
-
-**Option C: Describe your territory**
-"I have 8 deals in pipeline totaling $400K. Two are in negotiation ($120K), three in evaluation ($180K), three in discovery ($100K)."
-
-### Step 2: Your Targets
-
-- **Quota**: What's your number? (e.g., "$500K this quarter")
-- **Timeline**: When does the period end? (e.g., "Q1 ends March 31")
-- **Already closed**: How much have you already booked this period?
-
----
+1. Tagged pipeline files
+2. Google Sheets trackers or exports
+3. Uploaded CSV exports
+4. Pasted deal lists
+5. CRM data when available
 
 ## Output
 
-```markdown
-# Sales Forecast: [Period]
+Produce:
 
-**Generated:** [Date]
-**Data Source:** [CSV upload / Manual input / CRM]
+- quota and attainment summary
+- weighted forecast
+- best, likely, and worst cases
+- commit versus upside breakdown
+- gap analysis
+- top recommendations
 
----
+## Notes
 
-## Summary
-
-| Metric | Value |
-|--------|-------|
-| **Quota** | $[X] |
-| **Closed to Date** | $[X] ([X]% of quota) |
-| **Open Pipeline** | $[X] |
-| **Weighted Forecast** | $[X] |
-| **Gap to Quota** | $[X] |
-| **Coverage Ratio** | [X]x |
-
----
-
-## Forecast Scenarios
-
-| Scenario | Amount | % of Quota | Assumptions |
-|----------|--------|------------|-------------|
-| **Best Case** | $[X] | [X]% | All deals close as expected |
-| **Likely Case** | $[X] | [X]% | Stage-weighted probabilities |
-| **Worst Case** | $[X] | [X]% | Only commit deals close |
-
----
-
-## Pipeline by Stage
-
-| Stage | # Deals | Total Value | Probability | Weighted Value |
-|-------|---------|-------------|-------------|----------------|
-| Negotiation | [X] | $[X] | 80% | $[X] |
-| Proposal | [X] | $[X] | 60% | $[X] |
-| Evaluation | [X] | $[X] | 40% | $[X] |
-| Discovery | [X] | $[X] | 20% | $[X] |
-| **Total** | [X] | $[X] | — | $[X] |
-
----
-
-## Commit vs. Upside
-
-### Commit (High Confidence)
-Deals you'd stake your forecast on:
-
-| Deal | Amount | Stage | Close Date | Why Commit |
-|------|--------|-------|------------|------------|
-| [Deal] | $[X] | [Stage] | [Date] | [Reason] |
-
-**Total Commit:** $[X]
-
-### Upside (Lower Confidence)
-Deals that could close but have risk:
-
-| Deal | Amount | Stage | Close Date | Risk Factor |
-|------|--------|-------|------------|-------------|
-| [Deal] | $[X] | [Stage] | [Date] | [Risk] |
-
-**Total Upside:** $[X]
-
----
-
-## Risk Flags
-
-| Deal | Amount | Risk | Recommendation |
-|------|--------|------|----------------|
-| [Deal] | $[X] | Close date passed | Update close date or move to lost |
-| [Deal] | $[X] | No activity in 14+ days | Re-engage or downgrade stage |
-| [Deal] | $[X] | Close date this week, still in discovery | Unlikely to close — push out |
-
----
-
-## Gap Analysis
-
-**To hit quota, you need:** $[X] more
-
-**Options to close the gap:**
-1. **Accelerate [Deal]** — Currently [stage], worth $[X]. If you can close by [date], you're at [X]% of quota.
-2. **Revive [Stalled Deal]** — Last active [date]. Worth $[X]. Reach out to [contact].
-3. **New pipeline needed** — You need $[X] in new opportunities at [X]x coverage to be safe.
-
----
-
-## Recommendations
-
-1. [ ] [Specific action for highest-impact deal]
-2. [ ] [Action for at-risk deal]
-3. [ ] [Pipeline generation recommendation if gap exists]
-```
-
----
-
-## Stage Probabilities (Default)
-
-If you don't provide custom probabilities, I'll use:
-
-| Stage | Default Probability |
-|-------|---------------------|
-| Closed Won | 100% |
-| Negotiation / Contract | 80% |
-| Proposal / Quote | 60% |
-| Evaluation / Demo | 40% |
-| Discovery / Qualification | 20% |
-| Prospecting / Lead | 10% |
-
-Tell me if your stages or probabilities are different.
-
----
-
-## If CRM Connected
-
-- I'll pull your pipeline automatically
-- Use your actual historical win rates
-- Factor in activity recency for risk scoring
-- Track forecast changes over time
-- Compare to previous forecasts
-
----
-
-## Tips
-
-1. **Be honest about commit** — Only commit deals you'd bet on. Upside is for everything else.
-2. **Update close dates** — Stale close dates kill forecast accuracy. Push out deals that won't close in time.
-3. **Coverage matters** — 3x pipeline coverage is healthy. Below 2x is risky.
-4. **Activity = signal** — Deals with no recent activity are at higher risk than stage suggests.
+- This skill is secondary to the GWS-first seller workflows.
+- Keep the workflow usable for teams whose pipeline currently lives in Sheets rather than a CRM.

--- a/skills/sales/skills/pipeline-review/SKILL.md
+++ b/skills/sales/skills/pipeline-review/SKILL.md
@@ -1,18 +1,16 @@
 ---
 name: pipeline-review
-description: Analyze pipeline health — prioritize deals, flag risks, get a weekly action plan. Use when running a weekly pipeline review, deciding which deals to focus on this week, spotting stale or stuck opportunities, auditing for hygiene issues like bad close dates, or identifying single-threaded deals.
+description: Analyze pipeline health from CSV, Sheets, or CRM data. This skill should stay usable for weekly reviews even when the team operates from Sheets or exports rather than a live CRM.
 argument-hint: "<segment or rep>"
 ---
 
 # /pipeline-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
-
-Analyze your pipeline health, prioritize deals, and get actionable recommendations for where to focus.
+Use this skill to review pipeline hygiene, prioritize deals, and generate a weekly action plan.
 
 ## Usage
 
-```
+```text
 /pipeline-review [segment or rep]
 ```
 
@@ -20,226 +18,31 @@ Review pipeline for: $ARGUMENTS
 
 If a file is referenced: @$1
 
----
+## Operating Rules
 
-## How It Works
+- Prefer tagged files, Sheets, or CSV exports before assuming CRM access.
+- Keep the review focused on actions and risk, not just reporting.
+- Use Calendar context only if it sharpens the action plan for live deals.
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                     PIPELINE REVIEW                              │
-├─────────────────────────────────────────────────────────────────┤
-│  STANDALONE (always works)                                       │
-│  ✓ Upload CSV export from your CRM                              │
-│  ✓ Or paste/describe your deals                                 │
-│  ✓ Health check: flag stale, stuck, and at-risk deals          │
-│  ✓ Prioritization: rank deals by impact and closability        │
-│  ✓ Hygiene audit: missing data, bad close dates, single-thread │
-│  ✓ Weekly action plan: what to focus on                        │
-├─────────────────────────────────────────────────────────────────┤
-│  SUPERCHARGED (when you connect your tools)                      │
-│  + CRM: Pull pipeline automatically, update records             │
-│  + Activity data for engagement scoring                         │
-│  + Historical patterns for risk prediction                      │
-│  + Calendar: See upcoming meetings per deal                     │
-└─────────────────────────────────────────────────────────────────┘
-```
+## Data Preference Order
 
----
-
-## What I Need From You
-
-**Option A: Upload a CSV**
-Export your pipeline from your CRM (e.g. Salesforce, HubSpot). Helpful fields:
-- Deal/Opportunity name
-- Account name
-- Amount
-- Stage
-- Close date
-- Created date
-- Last activity date
-- Owner (if reviewing a team)
-- Primary contact
-
-**Option B: Paste your deals**
-```
-Acme Corp - $50K - Negotiation - closes Jan 31 - last activity Jan 20
-TechStart - $25K - Demo scheduled - closes Feb 15 - no activity in 3 weeks
-BigCo - $100K - Discovery - closes Mar 30 - created last week
-```
-
-**Option C: Describe your pipeline**
-"I have 12 deals. Two big ones in negotiation that I'm confident about. Three stuck in discovery for over a month. The rest are mid-stage but I haven't talked to some of them in a while."
-
----
+1. Tagged pipeline files
+2. Google Sheets trackers or review tabs
+3. Uploaded CSV exports
+4. Pasted deal summaries
+5. CRM data when available
 
 ## Output
 
-```markdown
-# Pipeline Review: [Date]
+Produce:
 
-**Data Source:** [CSV upload / Manual input / CRM]
-**Deals Analyzed:** [X]
-**Total Pipeline Value:** $[X]
+- pipeline health summary
+- top weekly priorities
+- stale or stuck deal flags
+- hygiene issues
+- recommended actions by deal
 
----
+## Notes
 
-## Pipeline Health Score: [X/100]
-
-| Dimension | Score | Issue |
-|-----------|-------|-------|
-| **Stage Progression** | [X]/25 | [X] deals stuck in same stage 30+ days |
-| **Activity Recency** | [X]/25 | [X] deals with no activity in 14+ days |
-| **Close Date Accuracy** | [X]/25 | [X] deals with close date in past |
-| **Contact Coverage** | [X]/25 | [X] deals single-threaded |
-
----
-
-## Priority Actions This Week
-
-### 1. [Highest Priority Deal]
-**Why:** [Reason — large, closing soon, at risk, etc.]
-**Action:** [Specific next step]
-**Impact:** $[X] if you close it
-
-### 2. [Second Priority]
-**Why:** [Reason]
-**Action:** [Next step]
-
-### 3. [Third Priority]
-**Why:** [Reason]
-**Action:** [Next step]
-
----
-
-## Deal Prioritization Matrix
-
-### Close This Week (Focus Time Here)
-| Deal | Amount | Stage | Close Date | Next Action |
-|------|--------|-------|------------|-------------|
-| [Deal] | $[X] | [Stage] | [Date] | [Action] |
-
-### Close This Month (Keep Warm)
-| Deal | Amount | Stage | Close Date | Status |
-|------|--------|-------|------------|--------|
-| [Deal] | $[X] | [Stage] | [Date] | [Status] |
-
-### Nurture (Check-in Periodically)
-| Deal | Amount | Stage | Close Date | Status |
-|------|--------|-------|------------|--------|
-| [Deal] | $[X] | [Stage] | [Date] | [Status] |
-
----
-
-## Risk Flags
-
-### Stale Deals (No Activity 14+ Days)
-| Deal | Amount | Last Activity | Days Silent | Recommendation |
-|------|--------|---------------|-------------|----------------|
-| [Deal] | $[X] | [Date] | [X] | [Re-engage / Downgrade / Remove] |
-
-### Stuck Deals (Same Stage 30+ Days)
-| Deal | Amount | Stage | Days in Stage | Recommendation |
-|------|--------|-------|---------------|----------------|
-| [Deal] | $[X] | [Stage] | [X] | [Push / Multi-thread / Qualify out] |
-
-### Past Close Date
-| Deal | Amount | Close Date | Days Overdue | Recommendation |
-|------|--------|------------|--------------|----------------|
-| [Deal] | $[X] | [Date] | [X] | [Update date / Push to next quarter / Close lost] |
-
-### Single-Threaded (Only One Contact)
-| Deal | Amount | Contact | Risk | Recommendation |
-|------|--------|---------|------|----------------|
-| [Deal] | $[X] | [Name] | Champion leaves = deal dies | [Identify additional stakeholders] |
-
----
-
-## Hygiene Issues
-
-| Issue | Count | Deals | Action |
-|-------|-------|-------|--------|
-| Missing close date | [X] | [List] | Add realistic close dates |
-| Missing amount | [X] | [List] | Estimate or qualify |
-| Missing next step | [X] | [List] | Define next action |
-| No primary contact | [X] | [List] | Assign contact |
-
----
-
-## Pipeline Shape
-
-### By Stage
-| Stage | # Deals | Value | % of Pipeline |
-|-------|---------|-------|---------------|
-| [Stage] | [X] | $[X] | [X]% |
-
-### By Close Month
-| Month | # Deals | Value |
-|-------|---------|-------|
-| [Month] | [X] | $[X] |
-
-### By Deal Size
-| Size | # Deals | Value |
-|------|---------|-------|
-| $100K+ | [X] | $[X] |
-| $50K-100K | [X] | $[X] |
-| $25K-50K | [X] | $[X] |
-| <$25K | [X] | $[X] |
-
----
-
-## Recommendations
-
-### This Week
-1. [ ] [Specific action for priority deal 1]
-2. [ ] [Action for at-risk deal]
-3. [ ] [Hygiene task]
-
-### This Month
-1. [ ] [Strategic action]
-2. [ ] [Pipeline building if needed]
-
----
-
-## Deals to Consider Removing
-
-These deals may be dead weight:
-
-| Deal | Amount | Reason | Recommendation |
-|------|--------|--------|----------------|
-| [Deal] | $[X] | [No activity 60+ days, no response] | Mark closed-lost |
-| [Deal] | $[X] | [Pushed 3+ times, no champion] | Qualify out |
-```
-
----
-
-## Prioritization Framework
-
-I'll rank your deals using this framework:
-
-| Factor | Weight | What I Look For |
-|--------|--------|-----------------|
-| **Close Date** | 30% | Deals closing soonest get priority |
-| **Deal Size** | 25% | Bigger deals = more focus |
-| **Stage** | 20% | Later stage = more focus |
-| **Activity** | 15% | Active deals get prioritized |
-| **Risk** | 10% | Lower risk = safer bet |
-
-You can tell me to weight differently: "Focus on big deals over soon deals" or "I need quick wins, prioritize close dates."
-
----
-
-## If CRM Connected
-
-- I'll pull your pipeline automatically
-- Update records with new close dates, stages, next steps
-- Create follow-up tasks
-- Track hygiene improvements over time
-
----
-
-## Tips
-
-1. **Review weekly** — Pipeline health decays fast. Weekly reviews catch issues early.
-2. **Kill dead deals** — Stale opportunities inflate your pipeline and distort forecasts. Be ruthless.
-3. **Multi-thread everything** — If one person goes dark, you need a backup contact.
-4. **Close dates should mean something** — A close date is when you expect signature, not when you hope for one.
+- This skill remains CRM-aware, but the success path should still work for Sheets and CSV users.
+- It should complement `daily-briefing`, not replace it.


### PR DESCRIPTION
## Summary
- reframe the sales pack as the seller workflow entrypoint for HelpUDoc
- make Gmail, Calendar, Drive, Sheets, and tagged workspace files the default source order
- restore richer examples, templates, and sample outputs in the core skills
- add explicit handoff rules and examples for proposal-writing, frontend-slides, research, and create-an-asset
- keep forecast and pipeline-review CRM-ready while making Sheets and CSV the default success path

## Testing
- reviewed the rewritten skill docs for consistency across the sales pack
- verified the diff is scoped to \
