### PR TITLE
Add workspace search and inline rename

### DIFF
--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -5,7 +5,11 @@ import { UserService } from '../services/userService';
 import { HttpError } from '../errors';
 
 const createWorkspaceSchema = z.object({
-  name: z.string().min(1).max(255),
+  name: z.string().trim().max(255).optional(),
+});
+
+const renameWorkspaceSchema = z.object({
+  name: z.string().trim().min(1).max(255),
 });
 
 const collaboratorSchema = z.object({
@@ -57,6 +61,20 @@ export default function workspaceRoutes(workspaceService: WorkspaceService, user
         return res.status(400).json({ error: 'Invalid input' });
       }
       handleError(res, error, 'Failed to create workspace');
+    }
+  });
+
+  router.patch('/:workspaceId', async (req, res) => {
+    try {
+      const user = requireUserContext(req);
+      const payload = renameWorkspaceSchema.parse(req.body);
+      const workspace = await workspaceService.renameWorkspace(req.params.workspaceId, user.userId, payload.name);
+      res.json(workspace);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: 'Invalid workspace payload' });
+      }
+      handleError(res, error, 'Failed to rename workspace');
     }
   });
 

--- a/backend/src/services/workspaceService.ts
+++ b/backend/src/services/workspaceService.ts
@@ -89,13 +89,14 @@ export class WorkspaceService {
     }));
   }
 
-  async createWorkspace(user: UserContext, name: string): Promise<WorkspaceRecord> {
+  async createWorkspace(user: UserContext, name?: string): Promise<WorkspaceRecord> {
     const workspaceId = uuidv4();
-    const slug = await this.generateUniqueSlug(name);
+    const resolvedName = await this.resolveWorkspaceNameForCreate(user.userId, name);
+    const slug = await this.generateUniqueSlug(resolvedName);
     const [workspace] = await this.db<WorkspaceRecord>('workspaces')
       .insert({
         id: workspaceId,
-        name,
+        name: resolvedName,
         slug,
         ownerId: user.userId,
         lastModifiedBy: user.userId,
@@ -112,6 +113,28 @@ export class WorkspaceService {
 
     await this.createWorkspaceDirectory(workspaceId);
 
+    return workspace;
+  }
+
+  async renameWorkspace(workspaceId: string, userId: string, name: string): Promise<WorkspaceRecord> {
+    await this.ensureMembership(workspaceId, userId, { requireEdit: true });
+    const normalizedName = this.normalizeWorkspaceName(name);
+    if (!normalizedName) {
+      throw new Error('Workspace name cannot be empty');
+    }
+
+    await this.db<WorkspaceRecord>('workspaces')
+      .where({ id: workspaceId })
+      .update({
+        name: normalizedName,
+        updatedAt: this.db.fn.now(),
+        lastModifiedBy: userId,
+      });
+
+    const workspace = await this.db<WorkspaceRecord>('workspaces').where({ id: workspaceId }).first();
+    if (!workspace) {
+      throw new NotFoundError('Workspace not found');
+    }
     return workspace;
   }
 
@@ -306,6 +329,37 @@ export class WorkspaceService {
   private async createWorkspaceDirectory(workspaceId: string): Promise<void> {
     const workspacePath = path.join(WORKSPACE_DIR, workspaceId);
     await fs.mkdir(workspacePath, { recursive: true });
+  }
+
+  private normalizeWorkspaceName(name?: string | null): string {
+    return String(name ?? '').trim().slice(0, 255);
+  }
+
+  private async resolveWorkspaceNameForCreate(userId: string, name?: string): Promise<string> {
+    const normalized = this.normalizeWorkspaceName(name);
+    if (normalized) {
+      return normalized;
+    }
+    return this.generateNextUntitledName(userId);
+  }
+
+  private async generateNextUntitledName(userId: string): Promise<string> {
+    const rows = await this.db('workspace_members')
+      .join('workspaces', 'workspace_members.workspaceId', 'workspaces.id')
+      .select('workspaces.name')
+      .where('workspace_members.userId', userId)
+      .andWhere('workspaces.name', 'like', 'Untitled-%');
+
+    let maxSuffix = 0;
+    for (const row of rows as Array<{ name?: string }>) {
+      const match = /^Untitled-(\d+)$/.exec(String(row?.name || '').trim());
+      if (!match) continue;
+      const value = Number.parseInt(match[1], 10);
+      if (Number.isFinite(value)) {
+        maxSuffix = Math.max(maxSuffix, value);
+      }
+    }
+    return `Untitled-${maxSuffix + 1}`;
   }
 
   private slugify(name: string): string {

--- a/frontend/e2e/frontend-slides-clarification.spec.ts
+++ b/frontend/e2e/frontend-slides-clarification.spec.ts
@@ -24,8 +24,6 @@ const REPORT_CONTENT = `# Operation Epic Fury
 
 test('frontend-slides pauses on clarification instead of approval', async ({ page, baseURL }) => {
   const resolvedBaseUrl = baseURL || 'https://lc-demo.com';
-  const workspaceName = `e2e-slides-${Date.now()}`;
-
   page.on('console', (message) => {
     console.log(`[browser:${message.type()}] ${message.text()}`);
   });
@@ -52,10 +50,8 @@ test('frontend-slides pauses on clarification instead of approval', async ({ pag
   // Open the workspace drawer.
   await page.getByRole('button').first().click();
 
-  // Create and select a disposable workspace.
-  await page.getByPlaceholder('New workspace').fill(workspaceName);
-  await page.getByRole('button', { name: /^Create$/ }).click();
-  await page.getByRole('button', { name: new RegExp(workspaceName) }).click();
+  // Create and auto-select a disposable workspace.
+  await page.getByRole('button', { name: /\+ Create/i }).click();
   await page.getByRole('button').first().click();
 
   // Upload the source markdown through the workspace file input.

--- a/frontend/e2e/no-localhost-assets.spec.ts
+++ b/frontend/e2e/no-localhost-assets.spec.ts
@@ -75,10 +75,9 @@ test('does not generate localhost:9000 public URLs (no mixed content)', async ({
 
     await page.goto(resolvedBaseUrl, { waitUntil: 'domcontentloaded' });
 
-    // Open workspace list and select our workspace (create via UI to ensure list refreshes).
+    // Open workspace list, search for our existing workspace, and select it.
     await page.getByRole('button').first().click();
-    await page.getByPlaceholder('New workspace').fill(workspaceName);
-    await page.getByRole('button', { name: /^Create$/ }).click();
+    await page.getByPlaceholder('Search workspaces').fill(workspaceName);
     await page.getByRole('button', { name: new RegExp(workspaceName) }).click();
 
     // Click the media file in the file pane (displayed by basename).

--- a/frontend/src/components/CollapsibleDrawer.tsx
+++ b/frontend/src/components/CollapsibleDrawer.tsx
@@ -10,8 +10,8 @@ interface CollapsibleDrawerProps {
   handleDrawerClose: () => void;
   workspaces: Workspace[];
   selectedWorkspace: Workspace | null;
-  newWorkspaceName: string;
-  setNewWorkspaceName: (name: string) => void;
+  workspaceSearchQuery: string;
+  setWorkspaceSearchQuery: (name: string) => void;
   handleCreateWorkspace: () => void;
   handleDeleteWorkspace: (id: string) => void;
   onSelectWorkspace: (workspace: Workspace) => void;
@@ -30,8 +30,8 @@ const CollapsibleDrawer: React.FC<CollapsibleDrawerProps> = ({
   handleDrawerClose,
   workspaces,
   selectedWorkspace,
-  newWorkspaceName,
-  setNewWorkspaceName,
+  workspaceSearchQuery,
+  setWorkspaceSearchQuery,
   handleCreateWorkspace,
   handleDeleteWorkspace,
   onSelectWorkspace,
@@ -89,12 +89,12 @@ const CollapsibleDrawer: React.FC<CollapsibleDrawerProps> = ({
 
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, flexShrink: 0 }}>
           <TextField
-            placeholder="New workspace"
+            placeholder="Search workspaces"
             variant="outlined"
             fullWidth
             size="small"
-            value={newWorkspaceName}
-            onChange={(e) => setNewWorkspaceName(e.target.value)}
+            value={workspaceSearchQuery}
+            onChange={(e) => setWorkspaceSearchQuery(e.target.value)}
             InputProps={{
               sx: {
                 borderRadius: 2,
@@ -110,7 +110,7 @@ const CollapsibleDrawer: React.FC<CollapsibleDrawerProps> = ({
             startIcon={<Add />}
             sx={{ borderRadius: 2, textTransform: 'none', fontWeight: 600 }}
           >
-            Create
+            + Create
           </Button>
         </Box>
 

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -12,7 +12,7 @@ import {
 import { CheckSquare, Copy, Edit, Trash, Plus, Minus, ChevronLeft, RotateCcw, X, Printer, Download, Link as LinkIcon, Loader2 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { getWorkspaces, createWorkspace, deleteWorkspace, updateWorkspaceSettings } from '../services/workspaceApi';
+import { getWorkspaces, createWorkspace, deleteWorkspace, renameWorkspace, updateWorkspaceSettings } from '../services/workspaceApi';
 import {
   getFiles,
   createFile,
@@ -200,6 +200,32 @@ const generateTurnId = () => {
 
 const DEFAULT_PLAN_FILE_PATH = 'research_plan.md';
 
+const formatWorkspaceLastUsed = (updatedAt?: string) => {
+  if (!updatedAt) {
+    return 'Recently';
+  }
+  const timestamp = new Date(updatedAt).getTime();
+  if (Number.isNaN(timestamp)) {
+    return 'Recently';
+  }
+  const diffMs = Date.now() - timestamp;
+  if (diffMs < 60_000) {
+    return 'Just now';
+  }
+  if (diffMs < 86_400_000) {
+    return 'Today';
+  }
+  if (diffMs < 172_800_000) {
+    return 'Yesterday';
+  }
+  return new Date(updatedAt).toLocaleDateString();
+};
+
+const hydrateWorkspace = (workspace: Omit<Workspace, 'lastUsed'> & { lastUsed?: string }): Workspace => ({
+  ...workspace,
+  lastUsed: workspace.lastUsed ?? formatWorkspaceLastUsed(workspace.updatedAt),
+});
+
 const normalizeWorkspaceRelativePath = (value?: string): string =>
   String(value || '')
     .replace(/\\/g, '/')
@@ -288,12 +314,15 @@ export default function WorkspacePage() {
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [selectedWorkspace, setSelectedWorkspace] = useState<Workspace | null>(null);
   const [workspaceSettingsBusy, setWorkspaceSettingsBusy] = useState(false);
+  const [workspaceSearchQuery, setWorkspaceSearchQuery] = useState('');
+  const [isWorkspaceRenameActive, setIsWorkspaceRenameActive] = useState(false);
+  const [workspaceNameDraft, setWorkspaceNameDraft] = useState('');
+  const [workspaceRenameBusy, setWorkspaceRenameBusy] = useState(false);
   const [files, setFiles] = useState<WorkspaceFile[]>([]);
   const [selectedFile, setSelectedFile] = useState<WorkspaceFile | null>(null);
   const [selectedFileDetails, setSelectedFileDetails] = useState<WorkspaceFile | null>(null);
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
   const [fileContent, setFileContent] = useState('');
-  const [newWorkspaceName, setNewWorkspaceName] = useState('');
   const [conversationMessages, setConversationMessages] = useState<Record<string, ConversationMessage[]>>({});
   const [chatMessage, setChatMessage] = useState('');
   const [chatAttachments, setChatAttachments] = useState<File[]>([]);
@@ -343,6 +372,7 @@ export default function WorkspacePage() {
   const stopRequestedRef = useRef(false);
   const chatInputRef = useRef<HTMLTextAreaElement | null>(null);
   const attachmentInputRef = useRef<HTMLInputElement | null>(null);
+  const workspaceNameInputRef = useRef<HTMLInputElement | null>(null);
   const autoSaveTimerRef = useRef<number | null>(null);
   const lastAutoSavedContentRef = useRef<string>('');
   const [isMentionOpen, setIsMentionOpen] = useState(false);
@@ -358,6 +388,14 @@ export default function WorkspacePage() {
   const [expandedToolMessages, setExpandedToolMessages] = useState<Set<ConversationMessage['id']>>(new Set());
   const [expandedThinkingMessages, setExpandedThinkingMessages] = useState<Set<ConversationMessage['id']>>(new Set());
   const [copiedCodeBlockId, setCopiedCodeBlockId] = useState<string | null>(null);
+
+  const filteredWorkspaces = useMemo(() => {
+    const query = workspaceSearchQuery.trim().toLowerCase();
+    if (!query) {
+      return workspaces;
+    }
+    return workspaces.filter((workspace) => workspace.name.toLowerCase().includes(query));
+  }, [workspaceSearchQuery, workspaces]);
   const [copiedImageUrl, setCopiedImageUrl] = useState(false);
   const [copiedFileUrlId, setCopiedFileUrlId] = useState<string | null>(null);
   const [ragStatuses, setRagStatuses] = useState<Record<string, { status?: string; updatedAt?: string; error?: string }>>({});
@@ -1886,15 +1924,27 @@ export default function WorkspacePage() {
 
   useEffect(() => {
     const fetchWorkspaces = async () => {
-      const workspaces = await getWorkspaces();
-      const workspacesWithMockData = workspaces.map((ws: Omit<Workspace, 'lastUsed'>) => ({
-        ...ws,
-        lastUsed: 'Yesterday',
-      }));
-      setWorkspaces(workspacesWithMockData);
+      const fetchedWorkspaces = await getWorkspaces();
+      setWorkspaces((fetchedWorkspaces || []).map((ws: Omit<Workspace, 'lastUsed'>) => hydrateWorkspace(ws)));
     };
     fetchWorkspaces();
   }, []);
+
+  useEffect(() => {
+    if (!selectedWorkspace) {
+      setWorkspaceNameDraft('');
+      setIsWorkspaceRenameActive(false);
+      return;
+    }
+    setWorkspaceNameDraft(selectedWorkspace.name);
+  }, [selectedWorkspace]);
+
+  useEffect(() => {
+    if (isWorkspaceRenameActive && workspaceNameInputRef.current) {
+      workspaceNameInputRef.current.focus();
+      workspaceNameInputRef.current.select();
+    }
+  }, [isWorkspaceRenameActive]);
 
   const applyWorkspacePlanApprovalSetting = useCallback((workspaceId: string, skipPlanApprovals: boolean) => {
     setWorkspaces((prev) => prev.map((workspace) => (
@@ -1904,6 +1954,42 @@ export default function WorkspacePage() {
       prev && prev.id === workspaceId ? { ...prev, skipPlanApprovals } : prev
     ));
   }, []);
+
+  const commitWorkspaceRename = useCallback(async () => {
+    if (!selectedWorkspace || !selectedWorkspace.canEdit || workspaceRenameBusy) {
+      return;
+    }
+
+    const nextName = workspaceNameDraft.trim();
+    if (!nextName || nextName === selectedWorkspace.name) {
+      setWorkspaceNameDraft(selectedWorkspace.name);
+      setIsWorkspaceRenameActive(false);
+      return;
+    }
+
+    setWorkspaceRenameBusy(true);
+    try {
+      const renamedWorkspace = hydrateWorkspace(await renameWorkspace(selectedWorkspace.id, nextName));
+      setWorkspaces((prev) => prev.map((workspace) => (
+        workspace.id === renamedWorkspace.id ? { ...workspace, ...renamedWorkspace } : workspace
+      )));
+      setSelectedWorkspace((prev) => (
+        prev && prev.id === renamedWorkspace.id ? { ...prev, ...renamedWorkspace } : prev
+      ));
+      setWorkspaceNameDraft(renamedWorkspace.name);
+    } catch (error) {
+      console.error('Failed to rename workspace:', error);
+      setWorkspaceNameDraft(selectedWorkspace.name);
+    } finally {
+      setWorkspaceRenameBusy(false);
+      setIsWorkspaceRenameActive(false);
+    }
+  }, [selectedWorkspace, workspaceNameDraft, workspaceRenameBusy]);
+
+  const cancelWorkspaceRename = useCallback(() => {
+    setWorkspaceNameDraft(selectedWorkspace?.name || '');
+    setIsWorkspaceRenameActive(false);
+  }, [selectedWorkspace]);
 
   const handleUpdateWorkspacePlanApprovalSetting = useCallback(
     async (skipPlanApprovals: boolean, requireConfirm = false) => {
@@ -2022,14 +2108,19 @@ export default function WorkspacePage() {
   }, [selectedFile, selectedWorkspace]);
 
   const handleCreateWorkspace = async () => {
-    if (newWorkspaceName.trim()) {
-      const newWorkspaceData = await createWorkspace(newWorkspaceName);
-      const newWorkspace: Workspace = {
-        ...newWorkspaceData,
-        lastUsed: 'Just now',
+    try {
+      const newWorkspace = {
+        ...hydrateWorkspace(await createWorkspace()),
+        canEdit: true,
+        role: 'owner' as const,
       };
-      setWorkspaces([...workspaces, newWorkspace]);
-      setNewWorkspaceName('');
+      setWorkspaces((prev) => [newWorkspace, ...prev]);
+      setSelectedWorkspace(newWorkspace);
+      setWorkspaceSearchQuery('');
+      setWorkspaceNameDraft(newWorkspace.name);
+      setIsWorkspaceRenameActive(true);
+    } catch (error) {
+      console.error('Failed to create workspace:', error);
     }
   };
 
@@ -4797,10 +4888,10 @@ export default function WorkspacePage() {
         <CollapsibleDrawer
           open={drawerOpen}
           handleDrawerClose={handleDrawerToggle}
-          workspaces={workspaces}
+          workspaces={filteredWorkspaces}
           selectedWorkspace={selectedWorkspace}
-          newWorkspaceName={newWorkspaceName}
-          setNewWorkspaceName={setNewWorkspaceName}
+          workspaceSearchQuery={workspaceSearchQuery}
+          setWorkspaceSearchQuery={setWorkspaceSearchQuery}
           handleCreateWorkspace={handleCreateWorkspace}
           handleDeleteWorkspace={handleDeleteWorkspace}
           onSelectWorkspace={setSelectedWorkspace}
@@ -4851,9 +4942,47 @@ export default function WorkspacePage() {
             >
               {/* Workspace Header */}
               <div className="p-4 border-b border-gray-200 flex justify-between items-center">
-                <h2 className="text-xl font-semibold text-gray-800">
-                  {selectedWorkspace ? selectedWorkspace.name : 'No workspace selected'}
-                </h2>
+                {selectedWorkspace ? (
+                  isWorkspaceRenameActive && selectedWorkspace.canEdit ? (
+                    <input
+                      ref={workspaceNameInputRef}
+                      value={workspaceNameDraft}
+                      onChange={(event) => setWorkspaceNameDraft(event.target.value)}
+                      onBlur={() => {
+                        void commitWorkspaceRename();
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                          event.preventDefault();
+                          void commitWorkspaceRename();
+                        } else if (event.key === 'Escape') {
+                          event.preventDefault();
+                          cancelWorkspaceRename();
+                        }
+                      }}
+                      disabled={workspaceRenameBusy}
+                      aria-label="Workspace name"
+                      className="w-full max-w-[28rem] rounded-lg border border-blue-200 bg-white px-3 py-1.5 text-xl font-semibold text-gray-800 outline-none ring-2 ring-blue-100 disabled:cursor-wait"
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (!selectedWorkspace.canEdit) return;
+                        setWorkspaceNameDraft(selectedWorkspace.name);
+                        setIsWorkspaceRenameActive(true);
+                      }}
+                      className={`flex items-center gap-2 text-left text-xl font-semibold ${
+                        selectedWorkspace.canEdit ? 'text-gray-800 hover:text-blue-700' : 'cursor-default text-gray-800'
+                      }`}
+                    >
+                      <span>{selectedWorkspace.name}</span>
+                      {selectedWorkspace.canEdit ? <Edit size={16} className="text-gray-400" /> : null}
+                    </button>
+                  )
+                ) : (
+                  <h2 className="text-xl font-semibold text-gray-800">No workspace selected</h2>
+                )}
               </div>
               <div className="flex-1 flex min-h-0">
                 {/* File Explorer */}

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -1991,6 +1991,12 @@ export default function WorkspacePage() {
     setIsWorkspaceRenameActive(false);
   }, [selectedWorkspace]);
 
+  const handleSelectWorkspace = useCallback((workspace: Workspace) => {
+    setIsWorkspaceRenameActive(false);
+    setWorkspaceNameDraft(workspace.name);
+    setSelectedWorkspace(workspace);
+  }, []);
+
   const handleUpdateWorkspacePlanApprovalSetting = useCallback(
     async (skipPlanApprovals: boolean, requireConfirm = false) => {
       if (!selectedWorkspace || workspaceSettingsBusy) {
@@ -4894,7 +4900,7 @@ export default function WorkspacePage() {
           setWorkspaceSearchQuery={setWorkspaceSearchQuery}
           handleCreateWorkspace={handleCreateWorkspace}
           handleDeleteWorkspace={handleDeleteWorkspace}
-          onSelectWorkspace={setSelectedWorkspace}
+          onSelectWorkspace={handleSelectWorkspace}
           onOpenSettings={handleOpenAgentSettings}
           colorMode={colorMode}
           onToggleColorMode={toggleColorMode}

--- a/frontend/src/services/workspaceApi.ts
+++ b/frontend/src/services/workspaceApi.ts
@@ -24,16 +24,30 @@ export const getWorkspaceSettings = async (workspaceId: string) => {
 };
 
 
-export const createWorkspace = async (name: string) => {
+export const createWorkspace = async (name?: string) => {
   const response = await apiFetch(`${API_URL}/workspaces`, {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(name !== undefined ? { name } : {}),
+  });
+  if (!response.ok) {
+    throw new Error('Failed to create workspace');
+  }
+  return response.json();
+};
+
+export const renameWorkspace = async (workspaceId: string, name: string) => {
+  const response = await apiFetch(`${API_URL}/workspaces/${workspaceId}`, {
+    method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ name }),
   });
   if (!response.ok) {
-    throw new Error('Failed to create workspace');
+    throw new Error('Failed to rename workspace');
   }
   return response.json();
 };

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2,7 +2,12 @@ export interface Workspace {
   id: string;
   name: string;
   lastUsed: string;
+  slug?: string;
+  role?: 'owner' | 'editor' | 'viewer';
+  canEdit?: boolean;
   skipPlanApprovals?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface File {


### PR DESCRIPTION
## Summary
- replace the workspace drawer input with a live search field and make `+ Create` create a default untitled workspace immediately
- add safe inline workspace renaming in the main header without changing workspace ids, filesystem paths, or other workspace-rooted identifiers
- add backend support for optional workspace names on create plus a rename endpoint, and update shared types and e2e flows

## Verification
- `cd frontend && npm run build`
- `cd backend && npx tsc --noEmit -p tsconfig.json`

## Notes
- backend dependency install required `npm ci --legacy-peer-deps` in this worktree because of an existing `connect-redis` / `redis` peer dependency conflict
