### PR TITLE
Add user deletion and group RBAC

### DIFF
--- a/agent/helpudoc_agent/app.py
+++ b/agent/helpudoc_agent/app.py
@@ -30,6 +30,7 @@ from .skills_registry import (
     build_loaded_skill_text,
     collect_tool_names,
     find_skill,
+    is_skill_allowed,
     load_skills,
     read_skill_content,
 )
@@ -450,6 +451,11 @@ def create_app() -> FastAPI:
                 f"The user explicitly selected skill '{skill_id}', but it was not found in the configured skills registry.\n\n"
                 f"User request:\n{fallback_request}"
             )
+        if not is_skill_allowed(skill, runtime.workspace_state.context):
+            return (
+                f"The user explicitly selected skill '{skill.skill_id}', but it is not allowed for this user.\n\n"
+                f"User request:\n{fallback_request}"
+            )
         try:
             content = read_skill_content(skill)
         except Exception as exc:
@@ -525,6 +531,9 @@ def create_app() -> FastAPI:
         user_id = payload.get("userId") or payload.get("sub")
         if isinstance(user_id, str) and user_id.strip():
             context["user_id"] = user_id.strip()
+        skill_allow_ids = payload.get("skillAllowIds") or []
+        if isinstance(skill_allow_ids, list):
+            context["skill_allow_ids"] = [str(x).strip() for x in skill_allow_ids if str(x).strip()]
         allow_ids = payload.get("mcpServerAllowIds") or []
         deny_ids = payload.get("mcpServerDenyIds") or []
         is_admin = bool(payload.get("isAdmin", False))

--- a/agent/helpudoc_agent/skills_registry.py
+++ b/agent/helpudoc_agent/skills_registry.py
@@ -352,6 +352,25 @@ def _coerce_active_skill_scope(active_skill: SkillMetadata | dict[str, Any] | No
     return None
 
 
+def is_skill_allowed(
+    skill: SkillMetadata | str,
+    context: dict[str, Any] | None,
+) -> bool:
+    if not isinstance(context, dict):
+        return True
+    mcp_policy = context.get("mcp_policy")
+    if isinstance(mcp_policy, dict) and bool(mcp_policy.get("isAdmin", False)):
+        return True
+    allowed_skill_ids = context.get("skill_allow_ids")
+    if not isinstance(allowed_skill_ids, list):
+        return True
+    normalized_allowed = {str(item).strip() for item in allowed_skill_ids if str(item).strip()}
+    if not normalized_allowed:
+        return False
+    skill_id = skill.skill_id if isinstance(skill, SkillMetadata) else str(skill).strip()
+    return skill_id in normalized_allowed
+
+
 def is_tool_allowed(
     tool_name: str,
     active_skill: SkillMetadata | dict[str, Any] | None,

--- a/agent/helpudoc_agent/tools_and_schemas.py
+++ b/agent/helpudoc_agent/tools_and_schemas.py
@@ -32,6 +32,7 @@ from .skills_registry import (
     activate_skill_context,
     build_loaded_skill_text,
     find_skill,
+    is_skill_allowed,
     load_skills,
     read_skill_content,
 )
@@ -328,7 +329,7 @@ class ToolFactory:
                 return "Tool disabled: tagged files were provided, use rag_query only."
             if skills_root is None or not skills_root.exists():
                 return "No skills directory configured."
-            skills = load_skills(skills_root)
+            skills = [skill for skill in load_skills(skills_root) if is_skill_allowed(skill, workspace_state.context)]
             if not skills:
                 return "No skills found."
             lines = []
@@ -352,12 +353,14 @@ class ToolFactory:
                 return "Tool disabled: tagged files were provided, use rag_query only."
             if skills_root is None or not skills_root.exists():
                 return "No skills directory configured."
-            skills = load_skills(skills_root)
+            skills = [skill for skill in load_skills(skills_root) if is_skill_allowed(skill, workspace_state.context)]
             if not skills:
                 return "No skills found."
             normalized = skill_id.strip()
             skill = find_skill(skills_root, normalized)
             if skill is not None:
+                if not is_skill_allowed(skill, workspace_state.context):
+                    return f"Skill '{skill.skill_id}' is not allowed for this user."
                 try:
                     content = read_skill_content(skill)
                 except Exception as exc:  # pragma: no cover - filesystem guard

--- a/backend/src/api/agent.ts
+++ b/backend/src/api/agent.ts
@@ -29,6 +29,7 @@ import {
 import { blockingRedisClient } from '../services/redisService';
 import { signAgentContextToken } from '../services/agentToken';
 import { GoogleOAuthService, GoogleOAuthTokenMissingError } from '../services/googleOAuthService';
+import { UserService } from '../services/userService';
 
 const DEFAULT_PRESENTATION_PERSONA = 'fast';
 const IMAGE_NAME_PATTERN = /\.(png|jpe?g|gif|bmp|webp|svg)$/i;
@@ -61,6 +62,15 @@ type SlashSkillMetadata = {
   error?: string;
   warning?: string;
 };
+
+type EffectiveAgentPolicy = {
+  isAdmin: boolean;
+  skillAllowIds: string[];
+  mcpServerAllowIds: string[];
+  mcpServerDenyIds: string[];
+};
+
+const normalizeUniqueIds = (values: string[]) => Array.from(new Set(values.map((value) => value.trim()).filter(Boolean))).sort((a, b) => a.localeCompare(b));
 
 const extractFrontmatterString = (frontmatter: Record<string, unknown>, key: string): string | undefined => {
   const value = frontmatter[key];
@@ -188,6 +198,7 @@ export default function(
   workspaceService: WorkspaceService,
   fileService: FileService,
   googleOAuthService: GoogleOAuthService,
+  userService: UserService,
 ) {
   const router = Router();
   const paper2SlidesService = new Paper2SlidesService(fileService);
@@ -253,11 +264,19 @@ export default function(
 
   router.get('/slash-metadata', async (req, res) => {
     try {
-      requireUserContext(req);
+      const user = requireUserContext(req);
+      const promptAccess = await userService.getEffectivePromptAccess(user.userId);
+      if (!promptAccess) {
+        throw new HttpError(401, 'User not found');
+      }
       await fs.mkdir(skillsRoot, { recursive: true });
       const skillIds = await collectSkillIds(skillsRoot);
       const skills: SlashSkillMetadata[] = [];
+      const allowedSkillIds = new Set(promptAccess.skillIds);
       for (const skillId of skillIds) {
+        if (!promptAccess.isAdmin && !allowedSkillIds.has(skillId)) {
+          continue;
+        }
         try {
           skills.push(await getSkillMetadata(skillId));
         } catch (error) {
@@ -271,11 +290,13 @@ export default function(
         }
       }
 
+      const allowedMcpServerIds = new Set(promptAccess.mcpServerIds);
       const mcpServers = (await loadRuntimeMcpServers())
         .map((server) => ({
           name: typeof server.name === 'string' ? server.name.trim() : '',
           description: undefined as string | undefined,
         }))
+        .filter((server) => promptAccess.isAdmin || allowedMcpServerIds.has(server.name))
         .filter((server) => server.name);
 
       res.json({ skills, mcpServers });
@@ -342,11 +363,7 @@ export default function(
   const buildAgentAuthToken = async (input: {
     userId: string;
     workspaceId: string;
-    policy: {
-      isAdmin: boolean;
-      mcpServerAllowIds: string[];
-      mcpServerDenyIds: string[];
-    };
+    policy: EffectiveAgentPolicy;
     skipPlanApprovals?: boolean;
   }): Promise<string | null> => {
     const payload: Record<string, unknown> = {
@@ -400,6 +417,61 @@ export default function(
     }
 
     return signAgentContextToken(payload);
+  };
+
+  const resolveEffectiveAgentPolicy = async (
+    userId: string,
+    workspacePolicy: {
+      mcpServerAllowIds: string[];
+      mcpServerDenyIds: string[];
+    },
+  ): Promise<EffectiveAgentPolicy> => {
+    const promptAccess = await userService.getEffectivePromptAccess(userId);
+    if (!promptAccess) {
+      throw new HttpError(401, 'User not found');
+    }
+    if (promptAccess.isAdmin) {
+      return {
+        isAdmin: true,
+        skillAllowIds: [],
+        mcpServerAllowIds: [],
+        mcpServerDenyIds: [],
+      };
+    }
+
+    const configuredServers = await loadRuntimeMcpServers();
+    const groupAllowedServerIds = new Set(promptAccess.mcpServerIds);
+    const workspaceAllowIds = new Set(normalizeUniqueIds(workspacePolicy.mcpServerAllowIds || []));
+    const workspaceDenyIds = new Set(normalizeUniqueIds(workspacePolicy.mcpServerDenyIds || []));
+    const finalAllowIds = new Set<string>();
+    const finalDenyIds = new Set<string>(workspaceDenyIds);
+
+    configuredServers.forEach((server) => {
+      const serverId = typeof server.name === 'string' ? server.name.trim() : '';
+      if (!serverId) {
+        return;
+      }
+      if (!groupAllowedServerIds.has(serverId)) {
+        finalDenyIds.add(serverId);
+        return;
+      }
+      if (workspaceDenyIds.has(serverId)) {
+        finalDenyIds.add(serverId);
+        return;
+      }
+      if (normalizeDefaultAccess(server.default_access ?? server.defaultAccess) === 'deny' && !workspaceAllowIds.has(serverId)) {
+        finalDenyIds.add(serverId);
+        return;
+      }
+      finalAllowIds.add(serverId);
+    });
+
+    return {
+      isAdmin: false,
+      skillAllowIds: normalizeUniqueIds(promptAccess.skillIds),
+      mcpServerAllowIds: Array.from(finalAllowIds).sort((a, b) => a.localeCompare(b)),
+      mcpServerDenyIds: Array.from(finalDenyIds).sort((a, b) => a.localeCompare(b)),
+    };
   };
 
   router.post('/paper2slides/jobs', async (req, res) => {
@@ -538,7 +610,8 @@ export default function(
     try {
       const user = requireUserContext(req);
       const { persona, prompt, workspaceId, history, forceReset } = runAgentSchema.parse(req.body);
-      const policy = await workspaceService.getMcpServerPolicy(workspaceId, user.userId, { requireEdit: true });
+      const workspacePolicy = await workspaceService.getMcpServerPolicy(workspaceId, user.userId, { requireEdit: true });
+      const policy = await resolveEffectiveAgentPolicy(user.userId, workspacePolicy);
       const settings = await workspaceService.getWorkspaceSettings(workspaceId, user.userId, { requireEdit: true });
       const enrichedPrompt = await injectTaggedFileUrls(prompt, workspaceId, user.userId);
       const authToken = await buildAgentAuthToken({
@@ -583,7 +656,8 @@ export default function(
     try {
       const user = requireUserContext(req);
       const { persona, prompt, workspaceId, history, forceReset } = runAgentSchema.parse(req.body);
-      const policy = await workspaceService.getMcpServerPolicy(workspaceId, user.userId, { requireEdit: true });
+      const workspacePolicy = await workspaceService.getMcpServerPolicy(workspaceId, user.userId, { requireEdit: true });
+      const policy = await resolveEffectiveAgentPolicy(user.userId, workspacePolicy);
       const settings = await workspaceService.getWorkspaceSettings(workspaceId, user.userId, { requireEdit: true });
       const enrichedPrompt = await injectTaggedFileUrls(prompt, workspaceId, user.userId);
       const authToken = await buildAgentAuthToken({
@@ -640,7 +714,8 @@ export default function(
       const user = requireUserContext(req);
       const { persona, prompt, workspaceId, history, forceReset, turnId } = runAgentSchema.parse(req.body);
       await workspaceService.ensureMembership(workspaceId, user.userId, { requireEdit: true });
-      const policy = await workspaceService.getMcpServerPolicy(workspaceId, user.userId, { requireEdit: true });
+      const workspacePolicy = await workspaceService.getMcpServerPolicy(workspaceId, user.userId, { requireEdit: true });
+      const policy = await resolveEffectiveAgentPolicy(user.userId, workspacePolicy);
       const settings = await workspaceService.getWorkspaceSettings(workspaceId, user.userId, { requireEdit: true });
       const enrichedPrompt = await injectTaggedFileUrls(prompt, workspaceId, user.userId);
       const authToken = await buildAgentAuthToken({
@@ -705,7 +780,8 @@ export default function(
         return res.status(404).json({ error: 'Run not found' });
       }
       await workspaceService.ensureMembership(meta.workspaceId, user.userId, { requireEdit: true });
-      const policy = await workspaceService.getMcpServerPolicy(meta.workspaceId, user.userId, { requireEdit: true });
+      const workspacePolicy = await workspaceService.getMcpServerPolicy(meta.workspaceId, user.userId, { requireEdit: true });
+      const policy = await resolveEffectiveAgentPolicy(user.userId, workspacePolicy);
       const settings = await workspaceService.getWorkspaceSettings(meta.workspaceId, user.userId, { requireEdit: true });
       const authToken = await buildAgentAuthToken({
         userId: user.userId,
@@ -761,7 +837,8 @@ export default function(
         return res.status(404).json({ error: 'Run not found' });
       }
       await workspaceService.ensureMembership(meta.workspaceId, user.userId, { requireEdit: true });
-      const policy = await workspaceService.getMcpServerPolicy(meta.workspaceId, user.userId, { requireEdit: true });
+      const workspacePolicy = await workspaceService.getMcpServerPolicy(meta.workspaceId, user.userId, { requireEdit: true });
+      const policy = await resolveEffectiveAgentPolicy(user.userId, workspacePolicy);
       const settings = await workspaceService.getWorkspaceSettings(meta.workspaceId, user.userId, { requireEdit: true });
       const authToken = await buildAgentAuthToken({
         userId: user.userId,
@@ -805,7 +882,8 @@ export default function(
         return res.status(404).json({ error: 'Run not found' });
       }
       await workspaceService.ensureMembership(meta.workspaceId, user.userId, { requireEdit: true });
-      const policy = await workspaceService.getMcpServerPolicy(meta.workspaceId, user.userId, { requireEdit: true });
+      const workspacePolicy = await workspaceService.getMcpServerPolicy(meta.workspaceId, user.userId, { requireEdit: true });
+      const policy = await resolveEffectiveAgentPolicy(user.userId, workspacePolicy);
       const settings = await workspaceService.getWorkspaceSettings(meta.workspaceId, user.userId, { requireEdit: true });
       const authToken = await buildAgentAuthToken({
         userId: user.userId,

--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -30,9 +30,9 @@ export default function(dbService: DatabaseService, userService: UserService) {
   const googleOAuthService = new GoogleOAuthService(userOAuthTokenService);
 
   router.use('/auth', authRoutes(userService, googleOAuthService));
-  router.use('/agent', agentRoutes(workspaceService, fileService, googleOAuthService));
+  router.use('/agent', agentRoutes(workspaceService, fileService, googleOAuthService, userService));
   router.use('/settings', requireSystemAdmin(userService), settingsRoutes(workspaceService));
-  router.use('/users', requireSystemAdmin(userService), usersRoutes(userService));
+  router.use('/users', requireSystemAdmin(userService), usersRoutes(userService, workspaceService));
   router.use('/workspaces', workspaceRoutes(workspaceService, userService));
   router.use('/workspaces/:workspaceId/files', fileRoutes(fileService));
   router.use('/workspaces/:workspaceId/knowledge', knowledgeRoutes(knowledgeService));

--- a/backend/src/api/users.ts
+++ b/backend/src/api/users.ts
@@ -78,11 +78,16 @@ export default function usersRoutes(userService: UserService, workspaceService: 
       }
 
       const ownedWorkspaces = await userService.listOwnedWorkspaces(user.id);
+      await userService.deleteUser(user.id);
+
       for (const workspace of ownedWorkspaces) {
-        await workspaceService.deleteWorkspaceForCleanup(workspace.id);
+        try {
+          await workspaceService.cleanupWorkspaceArtifacts(workspace.id);
+        } catch (error) {
+          console.error(`Failed to clean up workspace artifacts for deleted user workspace: ${workspace.id}`, error);
+        }
       }
 
-      await userService.deleteUser(user.id);
       res.status(204).send();
     } catch (error) {
       console.error('Failed to delete user', error);

--- a/backend/src/api/users.ts
+++ b/backend/src/api/users.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { UserService } from '../services/userService';
+import { WorkspaceService } from '../services/workspaceService';
 
 const updateAdminSchema = z.object({
   isAdmin: z.boolean(),
@@ -14,7 +15,12 @@ const groupMemberSchema = z.object({
   userId: z.string().uuid(),
 });
 
-export default function usersRoutes(userService: UserService) {
+const groupPromptAccessSchema = z.object({
+  skillIds: z.array(z.string().min(1)).default([]),
+  mcpServerIds: z.array(z.string().min(1)).default([]),
+});
+
+export default function usersRoutes(userService: UserService, workspaceService: WorkspaceService) {
   const router = Router();
 
   router.get('/', async (_req, res) => {
@@ -41,6 +47,46 @@ export default function usersRoutes(userService: UserService) {
       }
       console.error('Failed to update admin role', error);
       res.status(500).json({ error: 'Failed to update admin role' });
+    }
+  });
+
+  router.get('/:userId/deletion-impact', async (req, res) => {
+    try {
+      const impact = await userService.getUserDeletionImpact(req.params.userId);
+      if (!impact) {
+        return res.status(404).json({ error: 'User not found' });
+      }
+      res.json(impact);
+    } catch (error) {
+      console.error('Failed to load user deletion impact', error);
+      res.status(500).json({ error: 'Failed to load user deletion impact' });
+    }
+  });
+
+  router.delete('/:userId', async (req, res) => {
+    try {
+      if (!req.userContext) {
+        return res.status(401).json({ error: 'Missing user context' });
+      }
+      if (req.userContext.userId === req.params.userId) {
+        return res.status(400).json({ error: 'You cannot delete your own account from the admin portal' });
+      }
+
+      const user = await userService.getUserById(req.params.userId);
+      if (!user) {
+        return res.status(404).json({ error: 'User not found' });
+      }
+
+      const ownedWorkspaces = await userService.listOwnedWorkspaces(user.id);
+      for (const workspace of ownedWorkspaces) {
+        await workspaceService.deleteWorkspaceForCleanup(workspace.id);
+      }
+
+      await userService.deleteUser(user.id);
+      res.status(204).send();
+    } catch (error) {
+      console.error('Failed to delete user', error);
+      res.status(500).json({ error: 'Failed to delete user' });
     }
   });
 
@@ -78,6 +124,36 @@ export default function usersRoutes(userService: UserService) {
     } catch (error) {
       console.error('Failed to delete group', error);
       res.status(500).json({ error: 'Failed to delete group' });
+    }
+  });
+
+  router.get('/groups/:groupId/access', async (req, res) => {
+    try {
+      const access = await userService.getGroupPromptAccess(req.params.groupId);
+      if (!access) {
+        return res.status(404).json({ error: 'Group not found' });
+      }
+      res.json(access);
+    } catch (error) {
+      console.error('Failed to load group access', error);
+      res.status(500).json({ error: 'Failed to load group access' });
+    }
+  });
+
+  router.put('/groups/:groupId/access', async (req, res) => {
+    try {
+      const payload = groupPromptAccessSchema.parse(req.body);
+      const access = await userService.replaceGroupPromptAccess(req.params.groupId, payload);
+      if (!access) {
+        return res.status(404).json({ error: 'Group not found' });
+      }
+      res.json(access);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: error.issues[0]?.message || 'Invalid payload' });
+      }
+      console.error('Failed to update group access', error);
+      res.status(500).json({ error: 'Failed to update group access' });
     }
   });
 

--- a/backend/src/services/agentToken.ts
+++ b/backend/src/services/agentToken.ts
@@ -26,6 +26,7 @@ export type AgentContextTokenPayload = {
   sub?: string;
   userId?: string;
   workspaceId?: string;
+  skillAllowIds?: string[];
   mcpServerAllowIds?: string[];
   mcpServerDenyIds?: string[];
   mcpAuth?: Record<string, Record<string, string>>;

--- a/backend/src/services/databaseService.ts
+++ b/backend/src/services/databaseService.ts
@@ -26,6 +26,7 @@ export class DatabaseService {
     await this.createGroupsTable();
     await this.createGroupMembersTable();
     await this.createSkillGrantsTable();
+    await this.createMcpServerGroupGrantsTable();
     await this.createWorkspacesTable();
     await this.createWorkspaceMembersTable();
     await this.createMcpServerGrantsTable();
@@ -189,6 +190,24 @@ export class DatabaseService {
       await this.ensureColumn('workspaces', 'ownerId', (table) => table.uuid('ownerId'));
       await this.ensureColumn('workspaces', 'lastModifiedBy', (table) => table.uuid('lastModifiedBy'));
       await this.ensureColumn('workspaces', 'skipPlanApprovals', (table) => table.boolean('skipPlanApprovals').notNullable().defaultTo(false));
+    }
+  }
+
+  private async createMcpServerGroupGrantsTable(): Promise<void> {
+    const exists = await this.db.schema.hasTable('mcp_server_group_grants');
+    if (!exists) {
+      await this.db.schema.createTable('mcp_server_group_grants', (table) => {
+        table.uuid('groupId').notNullable().references('id').inTable('groups').onDelete('CASCADE');
+        table.string('serverId').notNullable();
+        table.timestamp('createdAt').notNullable().defaultTo(this.db.fn.now());
+        table.timestamp('updatedAt').notNullable().defaultTo(this.db.fn.now());
+        table.primary(['groupId', 'serverId']);
+      });
+      console.log('Created "mcp_server_group_grants" table.');
+    } else {
+      await this.ensureColumn('mcp_server_group_grants', 'serverId', (table) => table.string('serverId').notNullable());
+      await this.ensureColumn('mcp_server_group_grants', 'createdAt', (table) => table.timestamp('createdAt').defaultTo(this.db.fn.now()));
+      await this.ensureColumn('mcp_server_group_grants', 'updatedAt', (table) => table.timestamp('updatedAt').defaultTo(this.db.fn.now()));
     }
   }
 

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -19,6 +19,27 @@ export interface GroupRecord {
   updatedAt: string;
 }
 
+export interface GroupPromptAccess {
+  skillIds: string[];
+  mcpServerIds: string[];
+}
+
+export interface EffectivePromptAccess extends GroupPromptAccess {
+  isAdmin: boolean;
+}
+
+export interface UserDeletionImpact {
+  user: Pick<UserRecord, 'id' | 'displayName' | 'email' | 'externalId' | 'isAdmin'>;
+  ownedWorkspaces: Array<{ id: string; name: string }>;
+  sharedWorkspaceCount: number;
+  groupMembershipCount: number;
+  oauthTokenCount: number;
+  authoredFileCount: number;
+  authoredKnowledgeCount: number;
+  authoredConversationCount: number;
+  authoredMessageCount: number;
+}
+
 interface UserProfileInput {
   externalId: string;
   displayName?: string | null;
@@ -26,6 +47,7 @@ interface UserProfileInput {
 }
 
 const normalizeEmail = (email?: string | null) => email?.trim().toLowerCase() || null;
+const normalizeUniqueStrings = (values: string[]) => Array.from(new Set(values.map((value) => value.trim()).filter(Boolean))).sort((a, b) => a.localeCompare(b));
 
 const parseAdminEmails = () => new Set(
   (process.env.ADMIN_EMAILS || '')
@@ -98,6 +120,7 @@ export class UserService {
     const user = await this.db<UserRecord>('users').where({ id: userId }).first();
     return user || null;
   }
+
   async setUserAdmin(userId: string, isAdmin: boolean): Promise<UserRecord | null> {
     const [updated] = await this.db<UserRecord>('users')
       .where({ id: userId })
@@ -116,6 +139,11 @@ export class UserService {
       .orderBy('name', 'asc');
   }
 
+  async getGroupById(groupId: string): Promise<GroupRecord | null> {
+    const group = await this.db<GroupRecord>('groups').where({ id: groupId }).first();
+    return group || null;
+  }
+
   async createGroup(name: string): Promise<GroupRecord> {
     const [group] = await this.db<GroupRecord>('groups')
       .insert({
@@ -127,7 +155,12 @@ export class UserService {
   }
 
   async deleteGroup(groupId: string): Promise<number> {
-    return this.db<GroupRecord>('groups').where({ id: groupId }).del();
+    return this.db.transaction(async (tx) => {
+      await tx('skill_grants').where({ principalType: 'group', principalId: groupId }).del();
+      await tx('mcp_server_group_grants').where({ groupId }).del();
+      const deleted = await tx<GroupRecord>('groups').where({ id: groupId }).del();
+      return Number(deleted || 0);
+    });
   }
 
   async listGroupMembers(groupId: string): Promise<UserRecord[]> {
@@ -150,5 +183,220 @@ export class UserService {
 
   async removeGroupMember(groupId: string, userId: string): Promise<number> {
     return this.db('group_members').where({ groupId, userId }).del();
+  }
+
+  async getGroupPromptAccess(groupId: string): Promise<GroupPromptAccess | null> {
+    const group = await this.getGroupById(groupId);
+    if (!group) {
+      return null;
+    }
+    const [skillRows, mcpRows] = await Promise.all([
+      this.db('skill_grants')
+        .select('skillId')
+        .where({ principalType: 'group', principalId: groupId, effect: 'allow' }),
+      this.db('mcp_server_group_grants')
+        .select('serverId')
+        .where({ groupId }),
+    ]);
+
+    return {
+      skillIds: normalizeUniqueStrings((skillRows as Array<{ skillId?: string }>).map((row) => String(row.skillId || ''))),
+      mcpServerIds: normalizeUniqueStrings((mcpRows as Array<{ serverId?: string }>).map((row) => String(row.serverId || ''))),
+    };
+  }
+
+  async replaceGroupPromptAccess(groupId: string, access: GroupPromptAccess): Promise<GroupPromptAccess | null> {
+    const skillIds = normalizeUniqueStrings(access.skillIds || []);
+    const mcpServerIds = normalizeUniqueStrings(access.mcpServerIds || []);
+
+    return this.db.transaction(async (tx) => {
+      const group = await tx<GroupRecord>('groups').where({ id: groupId }).first();
+      if (!group) {
+        return null;
+      }
+
+      await tx('skill_grants').where({ principalType: 'group', principalId: groupId }).del();
+      if (skillIds.length) {
+        await tx('skill_grants').insert(
+          skillIds.map((skillId) => ({
+            principalType: 'group',
+            principalId: groupId,
+            skillId,
+            effect: 'allow',
+          })),
+        );
+      }
+
+      await tx('mcp_server_group_grants').where({ groupId }).del();
+      if (mcpServerIds.length) {
+        await tx('mcp_server_group_grants').insert(
+          mcpServerIds.map((serverId) => ({
+            groupId,
+            serverId,
+          })),
+        );
+      }
+
+      return {
+        skillIds,
+        mcpServerIds,
+      };
+    });
+  }
+
+  async getEffectivePromptAccess(userId: string): Promise<EffectivePromptAccess | null> {
+    const user = await this.getUserById(userId);
+    if (!user) {
+      return null;
+    }
+    if (user.isAdmin) {
+      return {
+        isAdmin: true,
+        skillIds: [],
+        mcpServerIds: [],
+      };
+    }
+
+    const memberships = await this.db('group_members').select('groupId').where({ userId });
+    const groupIds = normalizeUniqueStrings((memberships as Array<{ groupId?: string }>).map((row) => String(row.groupId || '')));
+    if (!groupIds.length) {
+      return {
+        isAdmin: false,
+        skillIds: [],
+        mcpServerIds: [],
+      };
+    }
+
+    const [skillRows, mcpRows] = await Promise.all([
+      this.db('skill_grants')
+        .select('skillId')
+        .where({ principalType: 'group', effect: 'allow' })
+        .whereIn('principalId', groupIds),
+      this.db('mcp_server_group_grants')
+        .select('serverId')
+        .whereIn('groupId', groupIds),
+    ]);
+
+    return {
+      isAdmin: false,
+      skillIds: normalizeUniqueStrings((skillRows as Array<{ skillId?: string }>).map((row) => String(row.skillId || ''))),
+      mcpServerIds: normalizeUniqueStrings((mcpRows as Array<{ serverId?: string }>).map((row) => String(row.serverId || ''))),
+    };
+  }
+
+  async listOwnedWorkspaces(userId: string): Promise<Array<{ id: string; name: string }>> {
+    const rows = await this.db('workspaces')
+      .select('id', 'name')
+      .where({ ownerId: userId })
+      .orderBy('name', 'asc');
+    return (rows as Array<{ id: string; name: string }>).map((row) => ({ id: row.id, name: row.name }));
+  }
+
+  async getUserDeletionImpact(userId: string): Promise<UserDeletionImpact | null> {
+    const user = await this.getUserById(userId);
+    if (!user) {
+      return null;
+    }
+
+    const ownedWorkspaces = await this.listOwnedWorkspaces(userId);
+    const [sharedWorkspaceCount, groupMembershipCount, oauthTokenCount, authoredFileCount, authoredKnowledgeCount, authoredConversationCount, authoredMessageCount] = await Promise.all([
+      this.countSharedWorkspaceMemberships(userId),
+      this.countRows('group_members', { userId }),
+      this.countRows('user_oauth_tokens', { userId }),
+      this.countDistinctReferences('files', 'id', ['createdBy', 'updatedBy'], userId),
+      this.countDistinctReferences('knowledge_sources', 'id', ['createdBy', 'updatedBy'], userId),
+      this.countDistinctReferences('conversations', 'id', ['createdBy', 'updatedBy'], userId),
+      this.countDistinctReferences('conversation_messages', 'id', ['authorId'], userId),
+    ]);
+
+    return {
+      user: {
+        id: user.id,
+        displayName: user.displayName,
+        email: user.email,
+        externalId: user.externalId,
+        isAdmin: user.isAdmin,
+      },
+      ownedWorkspaces,
+      sharedWorkspaceCount,
+      groupMembershipCount,
+      oauthTokenCount,
+      authoredFileCount,
+      authoredKnowledgeCount,
+      authoredConversationCount,
+      authoredMessageCount,
+    };
+  }
+
+  async deleteUser(userId: string): Promise<boolean> {
+    const user = await this.getUserById(userId);
+    if (!user) {
+      return false;
+    }
+
+    await this.db.transaction(async (tx) => {
+      await this.detachUserReferences(tx, userId);
+      await tx('group_members').where({ userId }).del();
+      await tx('workspace_members').where({ userId }).del();
+      await tx('user_oauth_tokens').where({ userId }).del();
+      await tx('mcp_server_grants').where({ userId }).del();
+      await tx('skill_grants').where({ principalType: 'user', principalId: userId }).del();
+      await tx('mcp_connection_grants').where({ principalType: 'user', principalId: userId }).del();
+      await tx<UserRecord>('users').where({ id: userId }).del();
+    });
+
+    return true;
+  }
+
+  private async detachUserReferences(tx: Knex.Transaction, userId: string): Promise<void> {
+    await Promise.all([
+      tx('workspaces').where({ lastModifiedBy: userId }).update({ lastModifiedBy: null, updatedAt: this.db.fn.now() }),
+      tx('files').where({ createdBy: userId }).update({ createdBy: null, updatedAt: this.db.fn.now() }),
+      tx('files').where({ updatedBy: userId }).update({ updatedBy: null, updatedAt: this.db.fn.now() }),
+      tx('knowledge_sources').where({ createdBy: userId }).update({ createdBy: null, updatedAt: this.db.fn.now() }),
+      tx('knowledge_sources').where({ updatedBy: userId }).update({ updatedBy: null, updatedAt: this.db.fn.now() }),
+      tx('conversations').where({ createdBy: userId }).update({ createdBy: null, updatedAt: this.db.fn.now() }),
+      tx('conversations').where({ updatedBy: userId }).update({ updatedBy: null, updatedAt: this.db.fn.now() }),
+      tx('conversation_messages').where({ authorId: userId }).update({ authorId: null, updatedAt: this.db.fn.now() }),
+    ]);
+  }
+
+  private async countRows(tableName: string, where: Record<string, unknown>): Promise<number> {
+    const row = await this.db(tableName).where(where).count<{ count: string }>('count(*) as count').first();
+    return Number(row?.count || 0);
+  }
+
+  private async countSharedWorkspaceMemberships(userId: string): Promise<number> {
+    const row = await this.db('workspace_members as wm')
+      .join('workspaces as w', 'wm.workspaceId', 'w.id')
+      .where('wm.userId', userId)
+      .andWhere('w.ownerId', '<>', userId)
+      .count<{ count: string }>('wm.workspaceId as count')
+      .first();
+    return Number(row?.count || 0);
+  }
+
+  private async countDistinctReferences(
+    tableName: string,
+    idColumn: string,
+    referenceColumns: string[],
+    userId: string,
+  ): Promise<number> {
+    if (!referenceColumns.length) {
+      return 0;
+    }
+
+    const query = this.db(tableName).where((builder) => {
+      referenceColumns.forEach((column, index) => {
+        if (index === 0) {
+          builder.where(column, userId);
+        } else {
+          builder.orWhere(column, userId);
+        }
+      });
+    });
+
+    const row = await query.countDistinct<{ count: string }>(`${idColumn} as count`).first();
+    return Number(row?.count || 0);
   }
 }

--- a/backend/src/services/workspaceService.ts
+++ b/backend/src/services/workspaceService.ts
@@ -245,20 +245,16 @@ export class WorkspaceService {
       throw new AccessDeniedError('Only workspace owners can delete a workspace');
     }
 
-    await this.db('workspaces').where({ id: workspace.id }).del();
+    await this.performWorkspaceDeletion(workspace);
+  }
 
-    const workspacePath = path.join(WORKSPACE_DIR, workspace.id);
-    await fs.rm(workspacePath, { recursive: true, force: true });
-    try {
-      await this.s3Service.deletePrefix(`${workspace.id}/`);
-    } catch (error) {
-      console.error(`Failed to delete S3 objects for workspace: ${workspace.id}`, error);
+  async deleteWorkspaceForCleanup(workspaceId: string): Promise<boolean> {
+    const workspace = await this.db<WorkspaceRecord>('workspaces').where({ id: workspaceId }).first();
+    if (!workspace) {
+      return false;
     }
-    try {
-      await this.ragQueueService?.enqueueWorkspaceDelete({ workspaceId: workspace.id });
-    } catch (error) {
-      console.error(`Failed to enqueue RAG workspace delete job: ${workspace.id}`, error);
-    }
+    await this.performWorkspaceDeletion(workspace);
+    return true;
   }
 
   async addCollaborator(
@@ -329,6 +325,23 @@ export class WorkspaceService {
   private async createWorkspaceDirectory(workspaceId: string): Promise<void> {
     const workspacePath = path.join(WORKSPACE_DIR, workspaceId);
     await fs.mkdir(workspacePath, { recursive: true });
+  }
+
+  private async performWorkspaceDeletion(workspace: WorkspaceRecord): Promise<void> {
+    await this.db('workspaces').where({ id: workspace.id }).del();
+
+    const workspacePath = path.join(WORKSPACE_DIR, workspace.id);
+    await fs.rm(workspacePath, { recursive: true, force: true });
+    try {
+      await this.s3Service.deletePrefix(`${workspace.id}/`);
+    } catch (error) {
+      console.error(`Failed to delete S3 objects for workspace: ${workspace.id}`, error);
+    }
+    try {
+      await this.ragQueueService?.enqueueWorkspaceDelete({ workspaceId: workspace.id });
+    } catch (error) {
+      console.error(`Failed to enqueue RAG workspace delete job: ${workspace.id}`, error);
+    }
   }
 
   private normalizeWorkspaceName(name?: string | null): string {

--- a/backend/src/services/workspaceService.ts
+++ b/backend/src/services/workspaceService.ts
@@ -245,7 +245,7 @@ export class WorkspaceService {
       throw new AccessDeniedError('Only workspace owners can delete a workspace');
     }
 
-    await this.performWorkspaceDeletion(workspace);
+    await this.performWorkspaceDeletion(workspace.id);
   }
 
   async deleteWorkspaceForCleanup(workspaceId: string): Promise<boolean> {
@@ -253,7 +253,7 @@ export class WorkspaceService {
     if (!workspace) {
       return false;
     }
-    await this.performWorkspaceDeletion(workspace);
+    await this.performWorkspaceDeletion(workspace.id);
     return true;
   }
 
@@ -327,20 +327,27 @@ export class WorkspaceService {
     await fs.mkdir(workspacePath, { recursive: true });
   }
 
-  private async performWorkspaceDeletion(workspace: WorkspaceRecord): Promise<void> {
-    await this.db('workspaces').where({ id: workspace.id }).del();
+  async cleanupWorkspaceArtifacts(workspaceId: string): Promise<void> {
+    await this.performWorkspaceCleanup(workspaceId);
+  }
 
-    const workspacePath = path.join(WORKSPACE_DIR, workspace.id);
+  private async performWorkspaceDeletion(workspaceId: string): Promise<void> {
+    await this.db('workspaces').where({ id: workspaceId }).del();
+    await this.performWorkspaceCleanup(workspaceId);
+  }
+
+  private async performWorkspaceCleanup(workspaceId: string): Promise<void> {
+    const workspacePath = path.join(WORKSPACE_DIR, workspaceId);
     await fs.rm(workspacePath, { recursive: true, force: true });
     try {
-      await this.s3Service.deletePrefix(`${workspace.id}/`);
+      await this.s3Service.deletePrefix(`${workspaceId}/`);
     } catch (error) {
-      console.error(`Failed to delete S3 objects for workspace: ${workspace.id}`, error);
+      console.error(`Failed to delete S3 objects for workspace: ${workspaceId}`, error);
     }
     try {
-      await this.ragQueueService?.enqueueWorkspaceDelete({ workspaceId: workspace.id });
+      await this.ragQueueService?.enqueueWorkspaceDelete({ workspaceId });
     } catch (error) {
-      console.error(`Failed to enqueue RAG workspace delete job: ${workspace.id}`, error);
+      console.error(`Failed to enqueue RAG workspace delete job: ${workspaceId}`, error);
     }
   }
 

--- a/docs/rbac-skills-plan.md
+++ b/docs/rbac-skills-plan.md
@@ -1,334 +1,92 @@
-# RBAC For Skills and MCP Servers (Single-Tenant, In-App Groups, OIDC)
+# RBAC For Skills and MCP Servers
 
 ## Summary
-Implement enforceable RBAC for both the repo-wide skills registry (the `SKILL.md` folders under `/Users/cmtest/Documents/HelpUDoc/skills`) AND MCP servers (defined in `runtime.yaml` and managed via the Admin Portal) by:
-1. Upgrading identity to production-grade OIDC on the Node backend (no more trusting `X-User-*` headers for auth).
-2. Adding in-app groups and per-skill/per-MCP-server allow/deny grants stored in Postgres.
-3. Enforcing skill and MCP server visibility/access inside the Python agent service, using a backend-signed internal token so RBAC cannot be bypassed by calling the agent directly.
-4. Locking down the existing "Admin Portal" settings endpoints and UI (skills + MCP servers + runtime config editing) to system admins.
+This document describes the current, preferred RBAC model for HelpUDoc:
 
-## Goals And Non-Goals
-- **Goal**: Admin can control which users/groups can see/use specific skills (global per-user/group, not per-workspace).
-- **Goal**: Admin can control which users/groups can use specific MCP servers.
-- **Goal**: RBAC is enforced server-side (not spoofable by client headers).
-- **Goal**: Admin UI exists for users/groups/skill grants/MCP server grants.
-- **Non-goal**: Restrict tool usage globally (tools remain broadly available); tool allowlists are enforced only as part of skill governance where a skill declares `tools:`.
+1. Admins manage users and in-app groups from the Admin Portal.
+2. Groups control which skills and MCP servers are available to prompting users.
+3. The backend computes effective access from group membership and signs it into the agent token.
+4. The Python agent enforces the policy when listing or loading skills and when exposing MCP servers.
 
----
+This is intentionally simpler than a full deny/default-access model. The goal is to keep the admin experience easy to reason about: "Sales" can get sales skills, "HR" can get HR skills, and a user gets the union of all groups they belong to.
 
-## Authorization Model (Decision Complete)
+## Goals
+- Admin can create multiple groups for different functions or teams.
+- Admin can assign users to one or more groups.
+- Admin can tie relevant skills to each group.
+- Admin can tie relevant MCP servers to each group.
+- The policy is enforced server-side and inside the agent runtime.
+
+## Current Model
 
 ### Principals
-- **User**: authenticated via OIDC, stored in `users` table.
-- **Group**: in-app managed group, stored in `groups` + `group_members`.
-
-### Roles
-- `system_admin`: can manage skills registry, MCP servers, runtime config, users/groups, and grants.
-- Regular users: can use skills/MCP servers subject to grants.
-
-**Bootstrap rule (admin seed)**:
-- Backend env var `ADMIN_EMAILS` (comma-separated) grants `system_admin` on first login, and can be changed later via admin UI.
-
-### Skill Access Rules (Allow-By-Default With Overrides)
-Define a `default_access` per skill:
-- Source of truth: `SKILL.md` frontmatter field `default_access: allow|deny` (missing means `allow`).
-
-Compute effective access for a given user and skill:
-1. If `user.isAdmin == true`: ALLOW.
-2. If any explicit DENY exists for the user (direct) or any of their groups: DENY.
-3. If `default_access == deny`:
-   - ALLOW only if any explicit ALLOW exists for the user or any group.
-   - Otherwise DENY.
-4. If `default_access == allow`:
-   - ALLOW.
-
-Store explicit grants as `(principal, skillId, effect)` where `effect` is `allow|deny`.
-
-### MCP Access Rules (Servers vs Connections)
-We split MCP into two layers:
-- **MCP servers**: endpoint definitions (transport + URL) in `runtime.yaml` (non-secret).
-- **MCP connections**: per-workspace (and optionally per-user) auth bindings stored in Postgres.
-
-RBAC is enforced primarily on **connections** so we do not need to create duplicate MCP
-servers per role/credential.
-
-Companion doc:
-- [`docs/mcp-connections-auth-plan.md`](./mcp-connections-auth-plan.md)
-
-#### MCP Connection Access Rules (Allow-By-Default With Overrides)
-Define `default_access` per MCP connection:
-- Source of truth: `mcp_connections.defaultAccess` (missing means `allow`).
-
-Compute effective access for a given user and MCP connection:
-1. If `user.isAdmin == true`: ALLOW.
-2. If any explicit DENY exists for the user (direct) or any of their groups: DENY.
-3. If `default_access == deny`:
-   - ALLOW only if any explicit ALLOW exists for the user or any group.
-   - Otherwise DENY.
-4. If `default_access == allow`: ALLOW.
-
-Store explicit grants as `(principal, connectionId, effect)` where `effect` is `allow|deny`.
-
-### Tool Allowlist Per Skill (Only When Declared)
-- If a skill declares `tools:` in frontmatter, treat that as its allowed tool set while executing that skill.
-- If a skill does not declare `tools:`, do not enforce a tool allowlist (compatibility with existing skills like `proposal-writing`).
-
----
-
-## Data Model Changes (Backend Postgres)
-Implement via `/Users/cmtest/Documents/HelpUDoc/backend/src/services/databaseService.ts` (this repo uses "create tables on startup", not migrations).
-
-Add tables and columns:
-
-### 1. `users`
-- Add `isAdmin boolean not null default false`
-- Add `oidcIssuer text` and `oidcSubject text` (or store them combined in `externalId`; recommended is `externalId = issuer|sub` and keep these optional for debugging/audit)
-
-### 2. `groups`
-- `id uuid pk`
-- `name text unique not null`
-- `createdAt`, `updatedAt`
-
-### 3. `group_members`
-- `groupId uuid fk -> groups(id) on delete cascade`
-- `userId uuid fk -> users(id) on delete cascade`
-- `createdAt`, `updatedAt`
-- PK `(groupId, userId)`
-
-### 4. `skill_grants`
-- `id bigserial pk` (or composite PK; bigserial is simplest for updates)
-- `principalType text not null` enum-like: `user|group`
-- `principalId uuid not null` (references users/groups by type)
-- `skillId text not null`
-- `effect text not null` enum-like: `allow|deny`
-- `createdAt`, `updatedAt`
-- Unique index on `(principalType, principalId, skillId)`
-
-### 5. `mcp_connection_grants` (NEW)
-- `id bigserial pk`
-- `principalType text not null` enum-like: `user|group`
-- `principalId uuid not null` (references users/groups by type)
-- `connectionId uuid not null` (references `mcp_connections.id`)
-- `effect text not null` enum-like: `allow|deny`
-- `createdAt`, `updatedAt`
-- Unique index on `(principalType, principalId, connectionId)`
-
-### 6. `mcp_connections` (NEW)
-- `id uuid pk`
-- `workspaceId uuid fk -> workspaces(id) on delete cascade`
-- `name text not null`
-- `serverId text not null` (references `runtime.yaml` server `name`)
-- `authType text not null` (`none|static_header|oauth_delegated|oidc_federation|custom`)
-- `defaultAccess text not null default 'allow'`
-- `createdAt`, `updatedAt`
-
----
-
-## Backend API Changes (Node)
-
-### Authentication (OIDC)
-Add routes under `/api/auth/*` in a new file, e.g. `/Users/cmtest/Documents/HelpUDoc/backend/src/api/auth.ts`, and mount from `/Users/cmtest/Documents/HelpUDoc/backend/src/api/routes.ts`.
-
-Use `openid-client` (recommended) and `express-session` (already present in `/Users/cmtest/Documents/HelpUDoc/backend/src/index.ts`) to implement:
-- `GET /api/auth/login`: redirect to IdP authorize endpoint (PKCE).
-- `GET /api/auth/callback`: exchange code, validate ID token, upsert user, set `req.session.userContext`.
-- `POST /api/auth/logout`: destroy session.
-- `GET /api/auth/me`: return current user context + `isAdmin`.
-
-Config env vars:
-- `OIDC_ISSUER_URL`
-- `OIDC_CLIENT_ID`
-- `OIDC_CLIENT_SECRET` (if needed by IdP)
-- `OIDC_REDIRECT_URL`
-- `OIDC_POST_LOGOUT_REDIRECT_URL`
-- `ADMIN_EMAILS`
-
-Keep current header-based user context only for dev via a flag:
-- `AUTH_MODE=oidc|headers` (default `oidc` in production, `headers` for local dev if desired).
-- In `headers` mode, continue honoring `X-User-*` in `/Users/cmtest/Documents/HelpUDoc/backend/src/middleware/userContext.ts`.
-- In `oidc` mode, ignore headers and require session user.
-
-### Admin Enforcement Middleware
-Add:
-- `requireAuth(req)` ensures `req.userContext` exists.
-- `requireAdmin(req)` ensures current user has `isAdmin`.
-
-Apply `requireAdmin` to all existing settings endpoints in `/Users/cmtest/Documents/HelpUDoc/backend/src/api/settings.ts`:
-- `/settings/agent-config` read/write
-- `/settings/skills` CRUD and file edits
-- `/settings/mcp-servers` CRUD (NEW section below)
-
-### RBAC Admin APIs (Groups + Grants)
-Add routes under `/api/admin/*` (new router file, mounted in `/Users/cmtest/Documents/HelpUDoc/backend/src/api/routes.ts`), all protected by `requireAdmin`:
-
-#### Users
-- `GET /api/admin/users` list users
-- `PATCH /api/admin/users/:userId` set `isAdmin` true/false
-
-#### Groups
-- `GET /api/admin/groups` list groups with member counts
-- `POST /api/admin/groups` create group
-- `DELETE /api/admin/groups/:groupId` delete group
-- `GET /api/admin/groups/:groupId/members` list members
-- `POST /api/admin/groups/:groupId/members` add member by userId (and optionally by email lookup)
-- `DELETE /api/admin/groups/:groupId/members/:userId` remove member
-
-#### Skill Grants
-- `GET /api/admin/skill-grants?skillId=...` list grants for a skill
-- `PUT /api/admin/skill-grants` upsert a grant (principalType, principalId, skillId, effect)
-- `DELETE /api/admin/skill-grants` delete a grant
-
-#### MCP Connections (NEW)
-- `GET /api/admin/mcp-connections?workspaceId=...` list connections
-- `POST /api/admin/mcp-connections` create connection (workspaceId, name, serverId, authType, defaultAccess)
-- `PATCH /api/admin/mcp-connections/:id` update
-- `DELETE /api/admin/mcp-connections/:id` delete
-
-#### MCP Connection Grants (NEW)
-- `GET /api/admin/mcp-connection-grants?connectionId=...` list grants
-- `PUT /api/admin/mcp-connection-grants` upsert a grant (principalType, principalId, connectionId, effect)
-- `DELETE /api/admin/mcp-connection-grants` delete a grant
-
-### Effective Access Endpoint (Non-Admin)
-Add a non-admin endpoint for runtime use:
-- `GET /api/access/effective` returns the caller's effective skill and MCP server access:
-  - `deniedSkillIds`
-  - `allowedSkillIdsForDefaultDeny`
-  - `deniedMcpConnectionIds`
-  - `allowedMcpConnectionIdsForDefaultDeny`
-
-This supports UI hints and backend→agent policy generation.
-
----
-
-## Agent Service Enforcement (Python FastAPI)
-
-### Internal Auth Between Backend And Agent
-Goal: prevent bypass by direct calls to the agent service.
-
-Add an internal bearer token that the backend attaches to every request to the agent:
-- Backend signs a JWT with `AGENT_INTERNAL_JWT_SECRET` (HS256) including:
-  - `userExternalId` (or backend userId)
-  - `workspaceId`
-  - `isAdmin`
-  - `skillDenyIds` (array of skill ids)
-  - `skillAllowIds` (array of skill ids; only needed for default_access=deny skills)
-  - Transitional (server-level only): `mcpServerDenyIds` / `mcpServerAllowIds`
-  - Preferred (connection-level): `mcpConnectionDenyIds` / `mcpConnectionAllowIds`
-  - `iat`, `exp` short TTL (5 minutes)
-
-Agent service verifies this JWT on:
-- `/agents/{agent_name}/workspace/{workspace_id}/chat`
-- `/agents/{agent_name}/workspace/{workspace_id}/chat/stream`
-- (Optional but recommended) `/rag/workspaces/{workspace_id}/query` and `/rag/workspaces/{workspace_id}/status` if those are reachable outside the cluster.
-
-Implementation touchpoints:
-- `/Users/cmtest/Documents/HelpUDoc/backend/src/services/agentService.ts` to attach `Authorization: Bearer <jwt>` to axios requests.
-- `/Users/cmtest/Documents/HelpUDoc/agent/helpudoc_agent/app.py` to validate the JWT and extract the policy into `runtime.workspace_state.context`, for example:
-  - `runtime.workspace_state.context["skill_policy"] = {...}`
-  - `runtime.workspace_state.context["mcp_policy"] = {...}`
-
-Dependencies:
-- Add `pyjwt` to `/Users/cmtest/Documents/HelpUDoc/agent/requirements.txt`.
-
-### Skill RBAC Enforcement Inside Tools
-Modify `/Users/cmtest/Documents/HelpUDoc/agent/helpudoc_agent/tools_and_schemas.py`:
-- In `_build_list_skills_tool`:
-  - Load skills from disk as today.
-  - Filter to skills the current user is allowed to access using `skill_policy` from context plus per-skill `default_access` parsed from SKILL.md frontmatter.
-- In `_build_load_skill_tool`:
-  - Deny loading content for disallowed skills (return a clear "Access denied" message).
-  - If allowed, return the content.
-
-This is the core enforcement point that prevents non-admins from discovering/loading restricted skills.
-
-### MCP Connections RBAC + Credential Enforcement (NEW)
-See:
-- [`docs/mcp-server-registry-plan.md`](./mcp-server-registry-plan.md) (server registry + tool attachment)
-- [`docs/mcp-connections-auth-plan.md`](./mcp-connections-auth-plan.md) (connections + auth broker)
-
-The long-term enforcement happens by:
-1. Backend computing allowed **connectionIds** via grants + defaultAccess.
-2. Backend minting per-request auth headers/tokens for each allowed connection.
-3. Agent using only the allowed connections and only ephemeral credentials.
-
----
-
-## Frontend Changes (Admin UI + OIDC)
-
-### Auth UI
-Update `/Users/cmtest/Documents/HelpUDoc/frontend/src/auth/AuthProvider.tsx` and `/Users/cmtest/Documents/HelpUDoc/frontend/src/pages/LoginPage.tsx`:
-- Replace localStorage-based "user identity" with cookie session:
-  - On app load, call `/api/auth/me` via `/Users/cmtest/Documents/HelpUDoc/frontend/src/services/apiClient.ts`.
-  - If 401, show LoginPage with a "Continue" button that navigates to `/api/auth/login`.
-- Keep a dev-only bypass if desired behind `import.meta.env.DEV`.
-
-Update `/Users/cmtest/Documents/HelpUDoc/frontend/src/services/apiClient.ts`:
-- Remove `X-User-*` headers in OIDC mode (or keep only when `AUTH_MODE=headers`).
-
-### Admin Pages
-Implement the previously "coming soon" Users page and add group/grant management.
-
-Recommended placement:
-- Keep `/settings/agents` for skill registry editing (admin-only anyway).
-- Implement `/settings/users` as "Access Control":
-  - Users table: email, display name, isAdmin toggle.
-  - Groups panel: create/delete group, add/remove members.
-  - Skill access panel: select skill, view current grants, add allow/deny grants for groups/users.
-  - MCP server access panel: select MCP server, view current grants, add allow/deny grants for groups/users. **NEW**
-
-Frontend touchpoints:
-- `/Users/cmtest/Documents/HelpUDoc/frontend/src/pages/UsersPage.tsx` (replace placeholder).
-- Add new service module `/Users/cmtest/Documents/HelpUDoc/frontend/src/services/adminRbacApi.ts` for the new endpoints.
-
-Also add route guards:
-- If user is not admin and tries to navigate to `/settings/*`, show a 403 page or redirect to `/`.
-
----
-
-## Tests
-
-### Backend (Node)
-Add unit tests for skill/MCP server access evaluation logic (pure function):
-- Cases:
-  - admin overrides everything
-  - default allow + deny grant denies
-  - default deny + allow grant allows
-  - user grant overrides group grant (deny wins if both present)
-
-If no Node test runner exists yet, add a minimal one (recommended: `vitest`) or keep tests as lightweight TypeScript scripts invoked by CI.
-
-### Agent (Python)
-Add tests under `/Users/cmtest/Documents/HelpUDoc/tests`:
-- `list_skills` filters restricted skills when policy denies
-- `load_skill` denies restricted skill
-- `load_skill` allows permitted skill
-- MCP server filtering respects policy
-- JWT verification rejects missing/expired/invalid token (for chat endpoints)
-
-### E2E (Frontend)
-Extend Playwright spec(s) to validate:
-- Non-admin cannot open `/settings/agents` and cannot fetch `/api/settings/skills`.
-- Admin can open and edit skills.
-- Non-admin cannot see restricted MCP servers in agent responses.
-
----
-
-## Rollout Plan
-1. Land OIDC auth + `AUTH_MODE` toggle (keep headers mode for local dev).
-2. Add `isAdmin` and admin enforcement on existing settings endpoints.
-3. Add groups + grants tables and admin APIs (skills + MCP servers).
-4. Add Admin UI for users/groups/grants (including MCP servers).
-5. Add backend→agent internal JWT + skill filtering in agent tools.
-6. Implement MCP server registry with `langchain-mcp-adapters` integration.
-7. Add MCP server filtering based on `mcp_policy` in agent.
-8. Harden: optionally require internal JWT for RAG endpoints too, if externally reachable.
-
----
-
-## Assumptions And Defaults
-- Single-tenant instance, so no `tenantId` column is required.
-- Skills live on a shared filesystem across users (current behavior).
-- Default skill access is `allow` unless `default_access: deny` is set in SKILL.md frontmatter.
-- Default MCP server access is `allow` unless `default_access: deny` is set in runtime.yaml config.
-- Tools are globally allowed; RBAC is primarily about skill visibility/access, MCP server access, and admin-only skill/MCP registry editing.
+- `user`: stored in `users`
+- `group`: stored in `groups`
+- `group_members`: joins users to groups
+
+### Access Rules
+- If `users.isAdmin == true`, the user can access all skills and all MCP servers.
+- Otherwise, the effective access is the union of all skill grants and MCP server grants attached to the user’s groups.
+- There are no deny rules in the current implementation.
+- A user with no grants sees no restricted skills or MCP servers.
+
+### Storage
+- `skill_grants` stores group skill allowlists using `principalType = 'group'`.
+- `mcp_server_group_grants` stores group MCP server allowlists.
+- Grants are normalized and deduplicated before save.
+
+## Backend Flow
+
+### Effective Access
+- `UserService.getEffectivePromptAccess(userId)` resolves:
+  - whether the user is a system admin
+  - allowed skill ids from all group memberships
+  - allowed MCP server ids from all group memberships
+
+### Slash Metadata
+- `/api/agent/slash-metadata` filters available skills and MCP servers by the caller’s effective access.
+- Admins see the full catalog.
+- Non-admins see only what their groups allow.
+
+### Runtime Token
+- The backend signs the effective access into the agent JWT.
+- The token includes `skillAllowIds` plus the resolved MCP policy.
+- The agent does not infer RBAC from client headers.
+
+### User Deletion
+- Admins can delete users from `/settings/users`.
+- Deletion removes owned workspaces, memberships, OAuth tokens, and authored references.
+- Shared records keep history, but user references are detached where needed.
+
+## Agent Enforcement
+
+### Skills
+- `list_skills` only returns allowed skills.
+- `load_skill` denies loading a skill that is not allowed for the current user.
+- Embedded `/skill` directives are rejected if the selected skill is not allowed.
+
+### MCP Servers
+- The runtime only exposes MCP servers that the backend marked as allowed for the user.
+- The Python agent uses the signed policy from the backend, not raw request headers.
+
+## Admin UI
+- `/settings/users` is the control surface for:
+  - system admin toggles
+  - user deletion
+  - group creation/deletion
+  - group membership
+  - group skill allowlists
+  - group MCP server allowlists
+- `/settings/agents` remains the skill registry and tools settings area.
+
+## Assumptions
+- Single-tenant deployment.
+- Group-based allowlists are enough for v1.
+- Skills are global across the workspace and are not workspace-specific.
+- MCP server access is also global for prompting users in this implementation.
+- Existing workspace-level MCP policies remain separate from group-based prompt RBAC.
+
+## Follow-Up Ideas
+- Add deny rules later only if we have a concrete product need.
+- Add audit events for grant changes and user deletion.
+- Consider a read-only "effective access" view for debugging group membership and grant issues.

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -105,10 +105,11 @@ const UsersPage = () => {
       setUsers(loadedUsers);
       setGroups(loadedGroups);
       if (loadedGroups.length) {
-        const nextGroupId = selectedGroupId && loadedGroups.some((group) => group.id === selectedGroupId)
-          ? selectedGroupId
-          : loadedGroups[0].id;
-        setSelectedGroupId(nextGroupId);
+        setSelectedGroupId((currentGroupId) => (
+          currentGroupId && loadedGroups.some((group) => group.id === currentGroupId)
+            ? currentGroupId
+            : loadedGroups[0].id
+        ));
       } else {
         setSelectedGroupId('');
         setGroupMembers([]);
@@ -120,7 +121,7 @@ const UsersPage = () => {
     } finally {
       setLoading(false);
     }
-  }, [selectedGroupId]);
+  }, []);
 
   const loadPromptCatalog = useCallback(async () => {
     setCatalogLoading(true);

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Plus, ShieldCheck, ShieldOff, Trash2, Users2 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { KeyRound, Loader2, Plus, Search, ShieldCheck, ShieldOff, Trash2, Users2 } from 'lucide-react';
 import SettingsShell from '../components/settings/SettingsShell';
 import {
   SettingsEmptyState,
@@ -8,35 +8,96 @@ import {
   SettingsSectionHeader,
   SettingsSurface,
 } from '../components/settings/SettingsScaffold';
+import { getAuthUser } from '../auth/authStore';
+import { fetchSlashMetadata } from '../services/agentApi';
 import {
   addGroupMember,
   createGroup,
   deleteGroup,
+  deleteUser,
   fetchGroupMembers,
+  fetchGroupPromptAccess,
   fetchGroups,
+  fetchUserDeletionImpact,
   fetchUsers,
   removeGroupMember,
+  saveGroupPromptAccess,
   setUserAdmin,
+  type GroupPromptAccess,
   type ManagedGroup,
   type ManagedUser,
+  type UserDeletionImpact,
 } from '../services/settingsApi';
+import type { SkillDefinition } from '../types';
+
+const cx = (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' ');
+
+const sortStrings = (values: string[]) => [...values].sort((a, b) => a.localeCompare(b));
+
+const toggleSelection = (items: string[], value: string) => (
+  items.includes(value) ? items.filter((item) => item !== value) : sortStrings([...items, value])
+);
 
 const UsersPage = () => {
+  const currentUser = getAuthUser();
+
   const [users, setUsers] = useState<ManagedUser[]>([]);
   const [groups, setGroups] = useState<ManagedGroup[]>([]);
   const [selectedGroupId, setSelectedGroupId] = useState<string>('');
   const [groupMembers, setGroupMembers] = useState<ManagedUser[]>([]);
+  const [groupAccess, setGroupAccess] = useState<GroupPromptAccess>({ skillIds: [], mcpServerIds: [] });
+  const [savedGroupAccess, setSavedGroupAccess] = useState<GroupPromptAccess>({ skillIds: [], mcpServerIds: [] });
+  const [availableSkills, setAvailableSkills] = useState<SkillDefinition[]>([]);
+  const [availableMcpServers, setAvailableMcpServers] = useState<Array<{ name: string; description?: string }>>([]);
   const [newGroupName, setNewGroupName] = useState('');
   const [selectedUserId, setSelectedUserId] = useState('');
+  const [skillSearch, setSkillSearch] = useState('');
+  const [mcpSearch, setMcpSearch] = useState('');
+  const [pendingDeleteUser, setPendingDeleteUser] = useState<ManagedUser | null>(null);
+  const [deletionImpact, setDeletionImpact] = useState<UserDeletionImpact | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [catalogLoading, setCatalogLoading] = useState(true);
+  const [accessLoading, setAccessLoading] = useState(false);
+  const [accessSaving, setAccessSaving] = useState(false);
+  const [deletionImpactLoading, setDeletionImpactLoading] = useState(false);
+  const [deletingUserId, setDeletingUserId] = useState<string | null>(null);
 
   const selectedGroup = useMemo(
-    () => groups.find((group) => group.id === selectedGroupId),
+    () => groups.find((group) => group.id === selectedGroupId) || null,
     [groups, selectedGroupId],
   );
 
-  const loadBaseData = async () => {
+  const selectableUsers = useMemo(
+    () => users.filter((user) => !groupMembers.some((member) => member.id === user.id)),
+    [groupMembers, users],
+  );
+
+  const filteredSkills = useMemo(() => {
+    const query = skillSearch.trim().toLowerCase();
+    return availableSkills.filter((skill) => {
+      if (!query) return true;
+      return skill.id.toLowerCase().includes(query)
+        || (skill.name || '').toLowerCase().includes(query)
+        || (skill.description || '').toLowerCase().includes(query);
+    });
+  }, [availableSkills, skillSearch]);
+
+  const filteredMcpServers = useMemo(() => {
+    const query = mcpSearch.trim().toLowerCase();
+    return availableMcpServers.filter((server) => {
+      if (!query) return true;
+      return server.name.toLowerCase().includes(query)
+        || (server.description || '').toLowerCase().includes(query);
+    });
+  }, [availableMcpServers, mcpSearch]);
+
+  const isAccessDirty = useMemo(() => (
+    JSON.stringify(sortStrings(groupAccess.skillIds)) !== JSON.stringify(sortStrings(savedGroupAccess.skillIds))
+      || JSON.stringify(sortStrings(groupAccess.mcpServerIds)) !== JSON.stringify(sortStrings(savedGroupAccess.mcpServerIds))
+  ), [groupAccess, savedGroupAccess]);
+
+  const loadBaseData = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
@@ -51,34 +112,66 @@ const UsersPage = () => {
       } else {
         setSelectedGroupId('');
         setGroupMembers([]);
+        setGroupAccess({ skillIds: [], mcpServerIds: [] });
+        setSavedGroupAccess({ skillIds: [], mcpServerIds: [] });
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load user management data');
     } finally {
       setLoading(false);
     }
-  };
+  }, [selectedGroupId]);
 
-  const loadGroupMembers = async (groupId: string) => {
+  const loadPromptCatalog = useCallback(async () => {
+    setCatalogLoading(true);
+    try {
+      const { skills, mcpServers } = await fetchSlashMetadata();
+      setAvailableSkills(skills);
+      setAvailableMcpServers(mcpServers);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load prompt access catalog');
+    } finally {
+      setCatalogLoading(false);
+    }
+  }, []);
+
+  const loadGroupDetails = useCallback(async (groupId: string) => {
     if (!groupId) {
       setGroupMembers([]);
+      setGroupAccess({ skillIds: [], mcpServerIds: [] });
+      setSavedGroupAccess({ skillIds: [], mcpServerIds: [] });
       return;
     }
-    try {
-      const members = await fetchGroupMembers(groupId);
-      setGroupMembers(members);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load members');
-    }
-  };
 
-  useEffect(() => {
-    void loadBaseData();
+    setAccessLoading(true);
+    try {
+      const [members, access] = await Promise.all([
+        fetchGroupMembers(groupId),
+        fetchGroupPromptAccess(groupId),
+      ]);
+      const normalizedAccess = {
+        skillIds: sortStrings(access.skillIds),
+        mcpServerIds: sortStrings(access.mcpServerIds),
+      };
+      setGroupMembers(members);
+      setGroupAccess(normalizedAccess);
+      setSavedGroupAccess(normalizedAccess);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load group details');
+    } finally {
+      setAccessLoading(false);
+    }
   }, []);
 
   useEffect(() => {
-    void loadGroupMembers(selectedGroupId);
-  }, [selectedGroupId]);
+    void loadBaseData();
+    void loadPromptCatalog();
+  }, [loadBaseData, loadPromptCatalog]);
+
+  useEffect(() => {
+    void loadGroupDetails(selectedGroupId);
+  }, [loadGroupDetails, selectedGroupId]);
 
   const handleToggleAdmin = async (user: ManagedUser) => {
     try {
@@ -124,7 +217,7 @@ const UsersPage = () => {
     try {
       await addGroupMember(selectedGroupId, selectedUserId);
       setSelectedUserId('');
-      await loadGroupMembers(selectedGroupId);
+      await loadGroupDetails(selectedGroupId);
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to add member');
@@ -137,14 +230,75 @@ const UsersPage = () => {
     }
     try {
       await removeGroupMember(selectedGroupId, userId);
-      await loadGroupMembers(selectedGroupId);
+      await loadGroupDetails(selectedGroupId);
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to remove member');
     }
   };
 
-  const selectableUsers = users.filter((user) => !groupMembers.some((member) => member.id === user.id));
+  const handleOpenDeleteModal = async (user: ManagedUser) => {
+    setPendingDeleteUser(user);
+    setDeletionImpact(null);
+    setDeletionImpactLoading(true);
+    try {
+      const impact = await fetchUserDeletionImpact(user.id);
+      setDeletionImpact(impact);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load deletion impact');
+    } finally {
+      setDeletionImpactLoading(false);
+    }
+  };
+
+  const handleConfirmDeleteUser = async () => {
+    if (!pendingDeleteUser) {
+      return;
+    }
+    setDeletingUserId(pendingDeleteUser.id);
+    try {
+      await deleteUser(pendingDeleteUser.id);
+      setUsers((prev) => prev.filter((user) => user.id !== pendingDeleteUser.id));
+      setGroupMembers((prev) => prev.filter((member) => member.id !== pendingDeleteUser.id));
+      setPendingDeleteUser(null);
+      setDeletionImpact(null);
+      setError(null);
+      await loadBaseData();
+      if (selectedGroupId) {
+        await loadGroupDetails(selectedGroupId);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete user');
+    } finally {
+      setDeletingUserId(null);
+    }
+  };
+
+  const handleSaveGroupAccess = async () => {
+    if (!selectedGroupId) {
+      return;
+    }
+    setAccessSaving(true);
+    try {
+      const saved = await saveGroupPromptAccess(selectedGroupId, {
+        skillIds: sortStrings(groupAccess.skillIds),
+        mcpServerIds: sortStrings(groupAccess.mcpServerIds),
+      });
+      const normalized = {
+        skillIds: sortStrings(saved.skillIds),
+        mcpServerIds: sortStrings(saved.mcpServerIds),
+      };
+      setGroupAccess(normalized);
+      setSavedGroupAccess(normalized);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save group access');
+    } finally {
+      setAccessSaving(false);
+    }
+  };
+
   const usersSummary = `${users.length} user${users.length === 1 ? '' : 's'}`;
   const groupsSummary = `${groups.length} group${groups.length === 1 ? '' : 's'}`;
 
@@ -152,17 +306,17 @@ const UsersPage = () => {
     <SettingsShell
       eyebrow="Users"
       title="User & Group Management"
-      description="Manage system administrators and in-app user groups for RBAC rollout."
+      description="Manage system administrators, destructive user cleanup, and group-based prompt access."
     >
       <div className="space-y-6">
         {error ? <SettingsNotice variant="error">{error}</SettingsNotice> : null}
 
-        <div className="grid gap-6 xl:grid-cols-[1.05fr_1.15fr]">
+        <div className="grid gap-6 xl:grid-cols-[1.02fr_1.18fr]">
           <SettingsSurface>
             <SettingsSectionHeader
               eyebrow="Access"
               title="Users"
-              description="Promote administrators and review who currently has access to this workspace."
+              description="Promote administrators, inspect identities, and remove users with owned resources."
               actions={<span className="text-sm font-medium text-slate-500">{loading ? 'Loading...' : usersSummary}</span>}
             />
 
@@ -177,37 +331,61 @@ const UsersPage = () => {
                 />
               ) : null}
 
-              {!loading &&
-                users.map((user) => (
+              {!loading && users.map((user) => {
+                const isCurrentUser = currentUser?.id === user.id;
+                const isDeleting = deletingUserId === user.id;
+                return (
                   <div
                     key={user.id}
                     className="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3"
                   >
-                    <div>
-                      <p className="text-sm font-medium text-slate-900">{user.displayName}</p>
-                      <p className="text-xs text-slate-500">{user.email || user.externalId}</p>
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-slate-900">{user.displayName}</p>
+                      <p className="truncate text-xs text-slate-500">{user.email || user.externalId}</p>
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => handleToggleAdmin(user)}
-                      className={`inline-flex items-center gap-2 rounded-xl px-3 py-2 text-xs font-semibold transition ${user.isAdmin
-                        ? 'bg-emerald-100 text-emerald-800 hover:bg-emerald-200'
-                        : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
-                        }`}
-                    >
-                      {user.isAdmin ? <ShieldCheck size={14} /> : <ShieldOff size={14} />}
-                      {user.isAdmin ? 'Admin' : 'Member'}
-                    </button>
+
+                    <div className="flex shrink-0 items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleToggleAdmin(user)}
+                        className={cx(
+                          'inline-flex items-center gap-2 rounded-xl px-3 py-2 text-xs font-semibold transition',
+                          user.isAdmin
+                            ? 'bg-emerald-100 text-emerald-800 hover:bg-emerald-200'
+                            : 'bg-slate-100 text-slate-700 hover:bg-slate-200',
+                        )}
+                      >
+                        {user.isAdmin ? <ShieldCheck size={14} /> : <ShieldOff size={14} />}
+                        {user.isAdmin ? 'Admin' : 'Member'}
+                      </button>
+
+                      <button
+                        type="button"
+                        disabled={isCurrentUser || isDeleting}
+                        onClick={() => handleOpenDeleteModal(user)}
+                        className={cx(
+                          'inline-flex items-center gap-2 rounded-xl px-3 py-2 text-xs font-semibold transition',
+                          isCurrentUser || isDeleting
+                            ? 'cursor-not-allowed bg-slate-100 text-slate-400'
+                            : 'bg-rose-50 text-rose-700 hover:bg-rose-100',
+                        )}
+                        title={isCurrentUser ? 'Self-delete is blocked in the admin portal' : 'Delete user'}
+                      >
+                        {isDeleting ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+                        Delete
+                      </button>
+                    </div>
                   </div>
-                ))}
+                );
+              })}
             </div>
           </SettingsSurface>
 
           <SettingsSurface>
             <SettingsSectionHeader
               eyebrow="Groups"
-              title="Group membership"
-              description="Create RBAC groups, inspect membership, and keep assignments up to date."
+              title="Group membership & prompt access"
+              description="Create groups, manage members, and define which skills or MCP servers each group can use while prompting."
               actions={<span className="text-sm font-medium text-slate-500">{groupsSummary}</span>}
             />
 
@@ -232,7 +410,7 @@ const UsersPage = () => {
               {groups.length === 0 ? (
                 <SettingsEmptyState
                   title="No groups created yet"
-                  description="Create your first group to start organizing users for permissions and rollout controls."
+                  description="Create your first group to start organizing prompt access."
                   icon={Plus}
                   align="left"
                 />
@@ -241,10 +419,12 @@ const UsersPage = () => {
                   {groups.map((group) => (
                     <div
                       key={group.id}
-                      className={`flex items-center justify-between rounded-2xl border px-4 py-3 transition ${group.id === selectedGroupId
-                        ? 'border-slate-900 bg-slate-100'
-                        : 'border-slate-200 bg-slate-50/70'
-                        }`}
+                      className={cx(
+                        'flex items-center justify-between rounded-2xl border px-4 py-3 transition',
+                        group.id === selectedGroupId
+                          ? 'border-slate-900 bg-slate-100'
+                          : 'border-slate-200 bg-slate-50/70',
+                      )}
                     >
                       <button
                         type="button"
@@ -266,68 +446,291 @@ const UsersPage = () => {
               )}
 
               {selectedGroup ? (
-                <div className="rounded-[24px] border border-slate-200 bg-slate-50/80 p-5">
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-                    <div>
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">Selected group</p>
-                      <p className="mt-1 text-base font-semibold text-slate-900">{selectedGroup.name}</p>
-                    </div>
-                    <p className="text-sm text-slate-500">
-                      {groupMembers.length} member{groupMembers.length === 1 ? '' : 's'}
-                    </p>
-                  </div>
+                <div className="space-y-5 rounded-[24px] border border-slate-200 bg-slate-50/80 p-5">
+                  {accessLoading ? <SettingsLoadingState label="Loading group details..." /> : null}
 
-                  <div className="mt-4 flex flex-col gap-3 sm:flex-row">
-                    <select
-                      className="flex-1 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm shadow-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-900/5"
-                      value={selectedUserId}
-                      onChange={(event) => setSelectedUserId(event.target.value)}
-                    >
-                      <option value="">Select user</option>
-                      {selectableUsers.map((user) => (
-                        <option key={user.id} value={user.id}>{user.displayName}</option>
-                      ))}
-                    </select>
-                    <button
-                      type="button"
-                      onClick={handleAddMember}
-                      className="rounded-2xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
-                    >
-                      Add member
-                    </button>
-                  </div>
+                  {!accessLoading ? (
+                    <>
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                        <div>
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">Selected group</p>
+                          <p className="mt-1 text-base font-semibold text-slate-900">{selectedGroup.name}</p>
+                        </div>
+                        <p className="text-sm text-slate-500">
+                          {groupMembers.length} member{groupMembers.length === 1 ? '' : 's'}
+                        </p>
+                      </div>
 
-                  <div className="mt-4 space-y-2">
-                    {groupMembers.length === 0 ? (
-                      <SettingsEmptyState
-                        title="No members yet"
-                        description="Add users to this group to start testing or enforcing access boundaries."
-                        align="left"
-                      />
-                    ) : (
-                      groupMembers.map((member) => (
-                        <div
-                          key={member.id}
-                          className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white px-4 py-3"
-                        >
-                          <span className="text-sm text-slate-800">{member.displayName}</span>
+                      <div className="space-y-4">
+                        <div className="flex flex-col gap-3 sm:flex-row">
+                          <select
+                            className="flex-1 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm shadow-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-900/5"
+                            value={selectedUserId}
+                            onChange={(event) => setSelectedUserId(event.target.value)}
+                          >
+                            <option value="">Select user</option>
+                            {selectableUsers.map((user) => (
+                              <option key={user.id} value={user.id}>{user.displayName}</option>
+                            ))}
+                          </select>
                           <button
                             type="button"
-                            onClick={() => handleRemoveMember(member.id)}
-                            className="text-xs font-semibold text-rose-600 transition hover:text-rose-700"
+                            onClick={handleAddMember}
+                            className="rounded-2xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
                           >
-                            Remove
+                            Add member
                           </button>
                         </div>
-                      ))
-                    )}
-                  </div>
+
+                        <div className="space-y-2">
+                          {groupMembers.length === 0 ? (
+                            <SettingsEmptyState
+                              title="No members yet"
+                              description="Add users to this group before assigning prompt access."
+                              align="left"
+                            />
+                          ) : (
+                            groupMembers.map((member) => (
+                              <div
+                                key={member.id}
+                                className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white px-4 py-3"
+                              >
+                                <span className="text-sm text-slate-800">{member.displayName}</span>
+                                <button
+                                  type="button"
+                                  onClick={() => handleRemoveMember(member.id)}
+                                  className="text-xs font-semibold text-rose-600 transition hover:text-rose-700"
+                                >
+                                  Remove
+                                </button>
+                              </div>
+                            ))
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4">
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                          <div>
+                            <p className="text-sm font-semibold text-slate-900">Prompt access</p>
+                            <p className="text-xs leading-5 text-slate-500">
+                              Members of this group can access the union of the skills and MCP servers selected here.
+                            </p>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <button
+                              type="button"
+                              onClick={() => setGroupAccess(savedGroupAccess)}
+                              disabled={!isAccessDirty || accessSaving}
+                              className={cx(
+                                'rounded-xl px-3 py-2 text-xs font-semibold transition',
+                                !isAccessDirty || accessSaving
+                                  ? 'cursor-not-allowed bg-slate-100 text-slate-400'
+                                  : 'bg-slate-100 text-slate-700 hover:bg-slate-200',
+                              )}
+                            >
+                              Reset
+                            </button>
+                            <button
+                              type="button"
+                              onClick={handleSaveGroupAccess}
+                              disabled={!isAccessDirty || accessSaving}
+                              className={cx(
+                                'inline-flex items-center gap-2 rounded-xl px-3 py-2 text-xs font-semibold transition',
+                                !isAccessDirty || accessSaving
+                                  ? 'cursor-not-allowed bg-slate-200 text-slate-500'
+                                  : 'bg-slate-900 text-white hover:bg-slate-800',
+                              )}
+                            >
+                              {accessSaving ? <Loader2 size={14} className="animate-spin" /> : <KeyRound size={14} />}
+                              Save access
+                            </button>
+                          </div>
+                        </div>
+
+                        <div className="grid gap-4 xl:grid-cols-2">
+                          <div className="space-y-3">
+                            <label className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Skills</label>
+                            <div className="relative">
+                              <Search size={14} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+                              <input
+                                value={skillSearch}
+                                onChange={(event) => setSkillSearch(event.target.value)}
+                                placeholder="Filter skills"
+                                className="w-full rounded-xl border border-slate-300 bg-white py-2 pl-9 pr-3 text-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-900/5"
+                              />
+                            </div>
+                            <div className="max-h-80 space-y-2 overflow-y-auto rounded-2xl border border-slate-200 bg-slate-50 p-2">
+                              {catalogLoading ? <SettingsLoadingState label="Loading skills..." /> : null}
+                              {!catalogLoading && filteredSkills.length === 0 ? (
+                                <SettingsEmptyState
+                                  title="No skills found"
+                                  description="Adjust the filter or add skills from the registry."
+                                  align="left"
+                                />
+                              ) : null}
+                              {!catalogLoading && filteredSkills.map((skill) => {
+                                const selected = groupAccess.skillIds.includes(skill.id);
+                                return (
+                                  <button
+                                    key={skill.id}
+                                    type="button"
+                                    onClick={() => setGroupAccess((prev) => ({ ...prev, skillIds: toggleSelection(prev.skillIds, skill.id) }))}
+                                    className={cx(
+                                      'w-full rounded-2xl border px-3 py-3 text-left transition',
+                                      selected
+                                        ? 'border-slate-900 bg-slate-900 text-white'
+                                        : 'border-slate-200 bg-white text-slate-900 hover:border-slate-300',
+                                    )}
+                                  >
+                                    <p className="text-sm font-semibold">{skill.name || skill.id}</p>
+                                    <p className={cx('mt-1 text-xs leading-5', selected ? 'text-slate-200' : 'text-slate-500')}>
+                                      {skill.description || skill.id}
+                                    </p>
+                                  </button>
+                                );
+                              })}
+                            </div>
+                          </div>
+
+                          <div className="space-y-3">
+                            <label className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">MCP servers</label>
+                            <div className="relative">
+                              <Search size={14} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+                              <input
+                                value={mcpSearch}
+                                onChange={(event) => setMcpSearch(event.target.value)}
+                                placeholder="Filter MCP servers"
+                                className="w-full rounded-xl border border-slate-300 bg-white py-2 pl-9 pr-3 text-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-900/5"
+                              />
+                            </div>
+                            <div className="max-h-80 space-y-2 overflow-y-auto rounded-2xl border border-slate-200 bg-slate-50 p-2">
+                              {catalogLoading ? <SettingsLoadingState label="Loading MCP servers..." /> : null}
+                              {!catalogLoading && filteredMcpServers.length === 0 ? (
+                                <SettingsEmptyState
+                                  title="No MCP servers found"
+                                  description="Adjust the filter or add MCP servers from the agent settings."
+                                  align="left"
+                                />
+                              ) : null}
+                              {!catalogLoading && filteredMcpServers.map((server) => {
+                                const selected = groupAccess.mcpServerIds.includes(server.name);
+                                return (
+                                  <button
+                                    key={server.name}
+                                    type="button"
+                                    onClick={() => setGroupAccess((prev) => ({ ...prev, mcpServerIds: toggleSelection(prev.mcpServerIds, server.name) }))}
+                                    className={cx(
+                                      'w-full rounded-2xl border px-3 py-3 text-left transition',
+                                      selected
+                                        ? 'border-slate-900 bg-slate-900 text-white'
+                                        : 'border-slate-200 bg-white text-slate-900 hover:border-slate-300',
+                                    )}
+                                  >
+                                    <p className="text-sm font-semibold">{server.name}</p>
+                                    <p className={cx('mt-1 text-xs leading-5', selected ? 'text-slate-200' : 'text-slate-500')}>
+                                      {server.description || 'Allow prompts in this group to target this MCP server.'}
+                                    </p>
+                                  </button>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </>
+                  ) : null}
                 </div>
               ) : null}
             </div>
           </SettingsSurface>
         </div>
       </div>
+
+      {pendingDeleteUser ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/35 px-4">
+          <div className="w-full max-w-2xl rounded-[28px] border border-slate-200 bg-white p-6 shadow-[0_24px_80px_rgba(15,23,42,0.2)]">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-rose-500">Destructive action</p>
+                <h3 className="mt-2 text-xl font-semibold text-slate-950">Delete {pendingDeleteUser.displayName}?</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  This removes the user account, deletes any workspaces they own, and detaches authorship metadata from shared records.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  setPendingDeleteUser(null);
+                  setDeletionImpact(null);
+                }}
+                className="rounded-lg px-2 py-1 text-sm text-slate-500 hover:bg-slate-100 hover:text-slate-900"
+              >
+                Close
+              </button>
+            </div>
+
+            <div className="mt-5 space-y-3">
+              {deletionImpactLoading ? <SettingsLoadingState label="Loading deletion impact..." /> : null}
+              {!deletionImpactLoading && deletionImpact ? (
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800">
+                    <p className="font-semibold">{deletionImpact.ownedWorkspaces.length} owned workspaces will be deleted</p>
+                    <p className="mt-1 text-xs">
+                      {deletionImpact.ownedWorkspaces.length
+                        ? deletionImpact.ownedWorkspaces.map((workspace) => workspace.name).join(', ')
+                        : 'No owned workspaces'}
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+                    <p className="font-semibold">{deletionImpact.sharedWorkspaceCount} shared workspaces will lose this membership</p>
+                    <p className="mt-1 text-xs">{deletionImpact.groupMembershipCount} group memberships and {deletionImpact.oauthTokenCount} OAuth tokens will be removed</p>
+                  </div>
+                  <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+                    <p className="font-semibold">Detached shared references</p>
+                    <p className="mt-1 text-xs">
+                      {deletionImpact.authoredFileCount} files, {deletionImpact.authoredKnowledgeCount} knowledge items
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+                    <p className="font-semibold">Detached conversation history</p>
+                    <p className="mt-1 text-xs">
+                      {deletionImpact.authoredConversationCount} conversations, {deletionImpact.authoredMessageCount} messages
+                    </p>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => {
+                  setPendingDeleteUser(null);
+                  setDeletionImpact(null);
+                }}
+                className="rounded-2xl border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmDeleteUser}
+                disabled={deletionImpactLoading || deletingUserId === pendingDeleteUser.id}
+                className={cx(
+                  'inline-flex items-center gap-2 rounded-2xl px-4 py-2.5 text-sm font-semibold text-white transition',
+                  deletionImpactLoading || deletingUserId === pendingDeleteUser.id
+                    ? 'cursor-not-allowed bg-rose-300'
+                    : 'bg-rose-600 hover:bg-rose-700',
+                )}
+              >
+                {deletingUserId === pendingDeleteUser.id ? <Loader2 size={16} className="animate-spin" /> : <Trash2 size={16} />}
+                Delete user
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </SettingsShell>
   );
 };

--- a/frontend/src/services/settingsApi.ts
+++ b/frontend/src/services/settingsApi.ts
@@ -15,6 +15,23 @@ export type ManagedGroup = {
   name: string;
 };
 
+export type UserDeletionImpact = {
+  user: Pick<ManagedUser, 'id' | 'displayName' | 'email' | 'externalId' | 'isAdmin'>;
+  ownedWorkspaces: Array<{ id: string; name: string }>;
+  sharedWorkspaceCount: number;
+  groupMembershipCount: number;
+  oauthTokenCount: number;
+  authoredFileCount: number;
+  authoredKnowledgeCount: number;
+  authoredConversationCount: number;
+  authoredMessageCount: number;
+};
+
+export type GroupPromptAccess = {
+  skillIds: string[];
+  mcpServerIds: string[];
+};
+
 export type SkillBuilderAction =
   | {
       type: 'create_skill';
@@ -432,6 +449,25 @@ export const setUserAdmin = async (userId: string, isAdmin: boolean): Promise<Ma
   return data.user;
 };
 
+export const fetchUserDeletionImpact = async (userId: string): Promise<UserDeletionImpact> => {
+  const response = await apiFetch(`${API_URL}/users/${userId}/deletion-impact`);
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || 'Failed to load deletion impact');
+  }
+  return response.json();
+};
+
+export const deleteUser = async (userId: string): Promise<void> => {
+  const response = await apiFetch(`${API_URL}/users/${userId}`, {
+    method: 'DELETE',
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || 'Failed to delete user');
+  }
+};
+
 export const fetchGroups = async (): Promise<ManagedGroup[]> => {
   const response = await apiFetch(`${API_URL}/users/groups/list`);
   if (!response.ok) {
@@ -500,4 +536,28 @@ export const removeGroupMember = async (groupId: string, userId: string): Promis
     const data = await response.json().catch(() => ({}));
     throw new Error(data.error || 'Failed to remove member');
   }
+};
+
+export const fetchGroupPromptAccess = async (groupId: string): Promise<GroupPromptAccess> => {
+  const response = await apiFetch(`${API_URL}/users/groups/${groupId}/access`);
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || 'Failed to load group access');
+  }
+  return response.json();
+};
+
+export const saveGroupPromptAccess = async (groupId: string, payload: GroupPromptAccess): Promise<GroupPromptAccess> => {
+  const response = await apiFetch(`${API_URL}/users/groups/${groupId}/access`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || 'Failed to update group access');
+  }
+  return response.json();
 };


### PR DESCRIPTION
## Summary
This PR adds two admin portal capabilities and wires them through the backend/runtime path:

- destructive user deletion with impact preview and cleanup of owned resources
- group-based prompt RBAC for skills and MCP servers

## What Changed
- Added a `Delete user` action in the admin UI with confirmation and impact counts.
- Deleting a user now removes memberships, tokens, grants, and owned workspaces/resources through the existing cleanup path.
- Added group prompt-access editing so admins can assign allowed skills and MCP servers to groups such as Sales or HR.
- Effective access is computed from the user’s group memberships, with admins seeing the full catalog.
- The agent token now carries the resolved allowlists so the Python agent can enforce skill access at runtime.
- Updated the RBAC plan doc to match the simpler implementation we are shipping.

## Behavior
- Group grants are additive: a user gets the union of all skill and MCP access from their groups.
- Admin users bypass these restrictions.
- Skill access is enforced both in slash metadata and inside the agent runtime.
- MCP access is resolved on the backend and passed through to the agent policy layer.

## Verification
- Backend TypeScript compile passed with `tsc --noEmit`.
- Frontend production build passed with `npm run build`.
- Targeted lint on `frontend/src/pages/UsersPage.tsx` passed.

## Notes
- Repo-wide frontend lint still has pre-existing failures outside this change set.
- Backend dependency install required `npm ci --legacy-peer-deps` because of an existing `connect-redis` / `redis` peer dependency mismatch in the repo.
