### PR TITLE
Add hierarchical workspace file tree and move flow

### DIFF
--- a/backend/src/api/files.ts
+++ b/backend/src/api/files.ts
@@ -21,8 +21,11 @@ export default function(fileService: FileService) {
   });
 
   const renameFileSchema = z.object({
-    name: z.string().min(1),
+    name: z.string().min(1).optional(),
+    path: z.string().optional(),
     version: z.number().int().positive().optional(),
+  }).refine((value) => value.name !== undefined || value.path !== undefined, {
+    message: 'Missing destination name',
   });
 
   const ragStatusSchema = z.object({
@@ -169,8 +172,16 @@ export default function(fileService: FileService) {
     try {
       const { fileId } = req.params;
       const user = requireUserContext(req);
-      const { name, version } = renameFileSchema.parse(req.body);
-      const updatedFile = await fileService.renameFile(parseInt(fileId, 10), name, user.userId, version);
+      const { name, path: destinationPath, version } = renameFileSchema.parse(req.body);
+      const updatedFile = await fileService.renameFile(
+        parseInt(fileId, 10),
+        {
+          name,
+          path: destinationPath,
+        },
+        user.userId,
+        version,
+      );
       res.json(updatedFile);
     } catch (error) {
       handleError(res, error, 'Failed to rename file');

--- a/backend/src/services/fileService.ts
+++ b/backend/src/services/fileService.ts
@@ -106,6 +106,10 @@ export class FileService {
       .replace(/^(\.\.\/)+/, '')
       .replace(/^\/+/, '')
       .replace(/\/+$/, '');
+    const parts = normalized.split('/').filter(Boolean);
+    if (parts.includes('..')) {
+      throw new ConflictError('Invalid folder path');
+    }
     if (!normalized || normalized === '.') {
       return '';
     }

--- a/backend/src/services/fileService.ts
+++ b/backend/src/services/fileService.ts
@@ -100,6 +100,18 @@ export class FileService {
     return normalized;
   }
 
+  private normalizeRelativeFolderPath(folderPath: string): string {
+    const normalized = path.posix
+      .normalize((folderPath || '').replace(/\\/g, '/'))
+      .replace(/^(\.\.\/)+/, '')
+      .replace(/^\/+/, '')
+      .replace(/\/+$/, '');
+    if (!normalized || normalized === '.') {
+      return '';
+    }
+    return normalized;
+  }
+
   private getLocalPath(workspaceId: string, fileName: string): string {
     const relative = this.normalizeRelativePath(fileName);
     return path.join(WORKSPACE_DIR, workspaceId, relative);
@@ -407,30 +419,58 @@ export class FileService {
     }
   }
 
-  async renameFile(fileId: number, newName: string, userId: string, expectedVersion?: number) {
+  async renameFile(
+    fileId: number,
+    target: { name?: string; path?: string },
+    userId: string,
+    expectedVersion?: number,
+  ) {
     const file = await this.db('files').where({ id: fileId }).first();
     if (!file) {
       throw new NotFoundError('File not found');
     }
 
-    const normalizedNewName = this.normalizeRelativePath(newName);
     await this.workspaceService.ensureMembership(file.workspaceId, userId, { requireEdit: true });
     const currentVersion = this.assertVersion(file.version, expectedVersion);
     const nextVersion = currentVersion + 1;
+    const currentRelativePath = this.normalizeRelativePath(file.name);
+    const wasRagIndexable = this.isRagIndexable(currentRelativePath);
+    const destinationRelativePath = target.path !== undefined
+      ? (() => {
+          const destinationFolder = this.normalizeRelativeFolderPath(target.path || '');
+          const baseName = path.posix.basename(currentRelativePath);
+          return destinationFolder ? path.posix.join(destinationFolder, baseName) : baseName;
+        })()
+      : (() => {
+          if (!target.name) {
+            throw new ConflictError('Missing destination name');
+          }
+          const normalizedNewName = this.normalizeRelativePath(target.name);
+          const currentDir = path.posix.dirname(currentRelativePath);
+          return currentDir === '.'
+            ? normalizedNewName
+            : path.posix.join(currentDir, normalizedNewName);
+        })();
+    const isDestinationRagIndexable = this.isRagIndexable(destinationRelativePath);
+
+    if (destinationRelativePath === currentRelativePath) {
+      return file;
+    }
 
     if (file.storageType === 'local') {
-      const targetDir = path.dirname(file.path);
-      const newPath = path.join(targetDir, normalizedNewName);
+      const currentLocalPath = this.getLocalPath(file.workspaceId, currentRelativePath);
+      const newPath = this.getLocalPath(file.workspaceId, destinationRelativePath);
 
       try {
-        await fs.rename(file.path, newPath);
+        await fs.mkdir(path.dirname(newPath), { recursive: true });
+        await fs.rename(currentLocalPath, newPath);
       } catch (error) {
         console.error('Failed to rename file on disk:', error);
         throw error;
       }
 
       await this.db('files').where({ id: fileId }).update({
-        name: normalizedNewName,
+        name: destinationRelativePath,
         path: newPath,
         updatedBy: userId,
         updatedAt: this.db.fn.now(),
@@ -438,12 +478,9 @@ export class FileService {
       });
     } else {
       const currentKey = file.path.replace(/\\/g, '/');
-      const currentLocalPath = this.getLocalPath(file.workspaceId, file.name);
-      const newLocalPath = this.getLocalPath(file.workspaceId, normalizedNewName);
-      const currentDir = path.posix.dirname(currentKey);
-      const newKey = currentDir === '.'
-        ? normalizedNewName
-        : `${currentDir}/${normalizedNewName}`;
+      const currentLocalPath = this.getLocalPath(file.workspaceId, currentRelativePath);
+      const newLocalPath = this.getLocalPath(file.workspaceId, destinationRelativePath);
+      const newKey = normalizeS3Key(file.workspaceId, destinationRelativePath);
       await this.s3Service.copyFile(currentKey, newKey);
       await this.s3Service.deleteFile(currentKey);
       const publicUrl = this.s3Service.getPublicUrl(newKey);
@@ -455,7 +492,7 @@ export class FileService {
       }
 
       await this.db('files').where({ id: fileId }).update({
-        name: normalizedNewName,
+        name: destinationRelativePath,
         path: newKey,
         publicUrl,
         updatedBy: userId,
@@ -465,6 +502,32 @@ export class FileService {
     }
 
     await this.workspaceService.touchWorkspace(file.workspaceId, userId);
+
+    if (wasRagIndexable) {
+      try {
+        await this.ragQueueService?.enqueueFileDelete({
+          workspaceId: file.workspaceId,
+          relativePath: currentRelativePath,
+        });
+      } catch (error) {
+        console.error('Failed to enqueue RAG delete job after file move/rename', error);
+      }
+    }
+
+    if (isDestinationRagIndexable) {
+      try {
+        await this.ragQueueService?.enqueueFileUpsert({
+          workspaceId: file.workspaceId,
+          fileId: file.id,
+          relativePath: destinationRelativePath,
+          mimeType: file.mimeType ?? null,
+          storageType: file.storageType,
+          publicUrl: file.storageType === 's3' ? this.s3Service.getPublicUrl(normalizeS3Key(file.workspaceId, destinationRelativePath)) : null,
+        });
+      } catch (error) {
+        console.error('Failed to enqueue RAG upsert job after file move/rename', error);
+      }
+    }
 
     return this.db('files').where({ id: fileId }).first();
   }

--- a/frontend/e2e/workspace-file-tree.spec.ts
+++ b/frontend/e2e/workspace-file-tree.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+
+test.setTimeout(120_000);
+
+const E2E_USER = {
+  id: 'local-e2e',
+  name: 'E2E User',
+  email: 'e2e@example.com',
+  provider: 'local',
+};
+
+const uploadNestedFile = async (
+  request: APIRequestContext,
+  workspaceId: string,
+  name: string,
+  content: string,
+  mimeType = 'text/markdown',
+) => {
+  const response = await request.post(`/api/workspaces/${workspaceId}/files`, {
+    multipart: {
+      file: {
+        name,
+        mimeType,
+        buffer: Buffer.from(content, 'utf-8'),
+      },
+    },
+  });
+  expect(response.status(), await response.text()).toBe(201);
+};
+
+test('workspace file tree shows hierarchy and moves files between folders', async ({ page, baseURL }) => {
+  const resolvedBaseUrl = baseURL || 'https://lc-demo.com';
+  const workspaceName = `tree-${Date.now()}`;
+
+  await page.addInitScript((payload) => {
+    window.localStorage.setItem('helpudoc-auth-user', JSON.stringify(payload));
+  }, E2E_USER);
+
+  const createWs = await page.request.post('/api/workspaces', { data: { name: workspaceName } });
+  expect(createWs.status(), await createWs.text()).toBe(201);
+  const workspace = await createWs.json();
+  const workspaceId: string | undefined = workspace?.id;
+  expect(workspaceId).toBeTruthy();
+
+  try {
+    await uploadNestedFile(page.request, workspaceId!, 'docs/alpha.md', '# Alpha\n');
+    await uploadNestedFile(page.request, workspaceId!, 'docs/reports/beta.md', '# Beta\n');
+    await uploadNestedFile(page.request, workspaceId!, 'root-note.md', '# Root\n');
+
+    await page.goto(resolvedBaseUrl, { waitUntil: 'domcontentloaded' });
+
+    await page.getByRole('button').first().click();
+    await page.getByPlaceholder('Search workspaces').fill(workspaceName);
+    await page.getByRole('button', { name: new RegExp(workspaceName) }).click();
+
+    await expect(page.getByText('docs', { exact: true })).toBeVisible();
+    await expect(page.getByText('reports', { exact: true })).toBeVisible();
+    await expect(page.getByText('alpha.md', { exact: true })).toBeVisible();
+    await expect(page.getByText('beta.md', { exact: true })).toBeVisible();
+
+    const alphaRow = page.getByTitle('docs/alpha.md');
+    await alphaRow.getByText('alpha.md', { exact: true }).click();
+    await expect(page.getByRole('heading', { name: 'docs/alpha.md' })).toBeVisible();
+
+    await alphaRow.hover();
+    await page.once('dialog', async (dialog) => {
+      expect(dialog.type()).toBe('prompt');
+      await dialog.accept('archive');
+    });
+    await alphaRow.getByRole('button', { name: 'Move' }).click();
+
+    await expect(page.getByText('archive', { exact: true })).toBeVisible();
+    await expect(page.getByTitle('archive/alpha.md')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'archive/alpha.md' })).toBeVisible();
+  } finally {
+    try {
+      await page.request.delete(`/api/workspaces/${workspaceId}`, { timeout: 5_000 });
+    } catch (error) {
+      console.warn('Failed to delete e2e workspace (continuing):', error);
+    }
+  }
+});

--- a/frontend/src/components/WorkspaceFileTree.tsx
+++ b/frontend/src/components/WorkspaceFileTree.tsx
@@ -1,0 +1,487 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  ChevronDown,
+  ChevronRight,
+  Folder,
+  FolderOpen,
+  Link as LinkIcon,
+  MoveRight,
+  Trash,
+  Edit,
+} from 'lucide-react';
+
+import type { File as WorkspaceFile } from '../types';
+import { getFileDisplayName, getFileTypeIcon } from '../utils/files';
+import {
+  buildWorkspaceFileTree,
+  collectWorkspaceFolderPaths,
+  getWorkspaceAncestorFolderPaths,
+  type WorkspaceFileTreeFolderNode,
+  type WorkspaceFileTreeLeafNode,
+  type WorkspaceFileTreeNode,
+} from '../utils/workspaceFileTree';
+
+interface WorkspaceFileTreeProps {
+  files: WorkspaceFile[];
+  selectedFileId: string | null;
+  selectedFiles: Set<string>;
+  ragStatuses: Record<string, { status?: string; updatedAt?: string; error?: string }>;
+  isDraftWorkspaceFile: (file?: WorkspaceFile | null) => boolean;
+  onSelectFile: (file: WorkspaceFile) => void;
+  onToggleFileSelection: (fileId: string) => void;
+  onCopyPublicUrl: (file: WorkspaceFile) => void;
+  onRenameFile: (file: WorkspaceFile) => void;
+  onDeleteFile: (file: WorkspaceFile) => void;
+  onMoveFile: (file: WorkspaceFile, destinationFolderPath?: string) => void;
+}
+
+const getFolderLabel = (node: WorkspaceFileTreeFolderNode) => {
+  if (!node.path) {
+    return node.name;
+  }
+  return node.name;
+};
+
+const getRagStatus = (
+  ragStatuses: Record<string, { status?: string; updatedAt?: string; error?: string }>,
+  file: WorkspaceFile,
+) => {
+  return typeof file.name === 'string' ? ragStatuses[file.name] : undefined;
+};
+
+const TreeFileRow: React.FC<{
+  node: WorkspaceFileTreeLeafNode;
+  selected: boolean;
+  selectedFiles: Set<string>;
+  ragStatuses: Record<string, { status?: string; updatedAt?: string; error?: string }>;
+  isDraftWorkspaceFile: (file?: WorkspaceFile | null) => boolean;
+  onSelectFile: (file: WorkspaceFile) => void;
+  onToggleFileSelection: (fileId: string) => void;
+  onCopyPublicUrl: (file: WorkspaceFile) => void;
+  onRenameFile: (file: WorkspaceFile) => void;
+  onDeleteFile: (file: WorkspaceFile) => void;
+  onMoveFile: (file: WorkspaceFile, destinationFolderPath?: string) => void;
+  draggedFileId: string | null;
+  setDraggedFileId: (fileId: string | null) => void;
+  setDropTargetPath: (path: string | null) => void;
+}> = ({
+  node,
+  selected,
+  selectedFiles,
+  ragStatuses,
+  isDraftWorkspaceFile,
+  onSelectFile,
+  onToggleFileSelection,
+  onCopyPublicUrl,
+  onRenameFile,
+  onDeleteFile,
+  onMoveFile,
+  draggedFileId,
+  setDraggedFileId,
+  setDropTargetPath,
+}) => {
+  const { file } = node;
+  const isPendingJob = file.mimeType === 'application/vnd.helpudoc.paper2slides-job';
+  const ragStatus = getRagStatus(ragStatuses, file);
+  const ragState = ragStatus?.status ? String(ragStatus.status).toLowerCase() : '';
+  const isIndexing = !isPendingJob && ['pending', 'processing', 'preprocessed'].includes(ragState);
+  const displayName = getFileDisplayName(file.name || '');
+  const fileIcon = getFileTypeIcon(file.name || '');
+  const isDraft = isDraftWorkspaceFile(file);
+  const isDraggable = !isPendingJob && !isDraft;
+  const isBeingDragged = draggedFileId === file.id;
+
+  return (
+    <div
+      className={`group flex items-start gap-2 rounded-lg px-2 py-2 transition-colors ${
+        selected ? 'bg-blue-50 ring-1 ring-blue-100' : 'hover:bg-slate-100/80'
+      } ${isBeingDragged ? 'opacity-40' : ''}`}
+      title={file.name}
+      draggable={isDraggable}
+      onDragStart={(event) => {
+        if (!isDraggable) {
+          return;
+        }
+        setDraggedFileId(file.id);
+        event.dataTransfer.effectAllowed = 'move';
+        event.dataTransfer.setData('text/plain', file.id);
+      }}
+      onDragEnd={() => {
+        setDraggedFileId(null);
+        setDropTargetPath(null);
+      }}
+    >
+      <input
+        type="checkbox"
+        checked={selectedFiles.has(file.id)}
+        disabled={isPendingJob}
+        onChange={() => onToggleFileSelection(file.id)}
+        onClick={(event) => event.stopPropagation()}
+        className="mt-1 shrink-0"
+      />
+      <button
+        type="button"
+        onClick={() => {
+          if (isPendingJob) {
+            return;
+          }
+          onSelectFile(file);
+        }}
+        className="flex min-w-0 flex-1 items-start gap-2 text-left"
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          {(isPendingJob || isIndexing) && (
+            <span className="inline-flex h-4 w-4 items-center justify-center text-blue-500">
+              <span className="h-2 w-2 animate-pulse rounded-full bg-current" />
+            </span>
+          )}
+          <span className="shrink-0" aria-hidden="true">
+            {fileIcon}
+          </span>
+          <span className="min-w-0 break-words text-sm leading-snug text-slate-800">{displayName}</span>
+        </div>
+      </button>
+      {!isPendingJob && (
+        <div className="ml-1 flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+          {file.publicUrl && !isDraft && (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                onCopyPublicUrl(file);
+              }}
+              className="rounded p-1.5 text-slate-500 hover:bg-slate-200 hover:text-slate-700"
+              title={file.publicUrl}
+            >
+              <LinkIcon size={14} />
+            </button>
+          )}
+          {!isDraft && (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                onMoveFile(file);
+              }}
+              className="rounded p-1.5 text-slate-500 hover:bg-slate-200 hover:text-slate-700"
+              title="Move"
+            >
+              <MoveRight size={14} />
+            </button>
+          )}
+          {!isDraft && (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                onRenameFile(file);
+              }}
+              className="rounded p-1.5 text-slate-500 hover:bg-slate-200 hover:text-slate-700"
+              title="Rename"
+            >
+              <Edit size={14} />
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onDeleteFile(file);
+            }}
+            className="rounded p-1.5 text-slate-500 hover:bg-slate-200 hover:text-slate-700"
+            title="Delete"
+          >
+            <Trash size={14} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const TreeFolderRow: React.FC<{
+  node: WorkspaceFileTreeFolderNode;
+  expanded: boolean;
+  onToggle: (folderPath: string) => void;
+  onDropFileToFolder: (fileId: string, folderPath: string) => void;
+  draggedFileId: string | null;
+  setDropTargetPath: (path: string | null) => void;
+  dropTargetPath: string | null;
+  children: React.ReactNode;
+}> = ({
+  node,
+  expanded,
+  onToggle,
+  onDropFileToFolder,
+  draggedFileId,
+  setDropTargetPath,
+  dropTargetPath,
+  children,
+}) => {
+  const isDropTarget = dropTargetPath === node.path;
+  const canAcceptDrop = Boolean(draggedFileId);
+
+  return (
+    <div className="select-none">
+      <div
+        className={`group flex items-center gap-2 rounded-lg px-2 py-2 transition-colors ${
+          isDropTarget ? 'bg-blue-50 ring-1 ring-blue-100' : 'hover:bg-slate-100/80'
+        }`}
+        onDragOver={(event) => {
+          if (!canAcceptDrop) {
+            return;
+          }
+          event.preventDefault();
+          event.dataTransfer.dropEffect = 'move';
+          setDropTargetPath(node.path);
+        }}
+        onDragLeave={(event) => {
+          if (event.currentTarget.contains(event.relatedTarget as Node)) {
+            return;
+          }
+          if (dropTargetPath === node.path) {
+            setDropTargetPath(null);
+          }
+        }}
+        onDrop={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          const fileId = event.dataTransfer.getData('text/plain') || draggedFileId;
+          if (!fileId) {
+            return;
+          }
+          onDropFileToFolder(fileId, node.path);
+          setDropTargetPath(null);
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => onToggle(node.path)}
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md text-slate-500 hover:bg-slate-200 hover:text-slate-800"
+          aria-label={`${expanded ? 'Collapse' : 'Expand'} ${node.name}`}
+        >
+          {expanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+        </button>
+        {expanded ? <FolderOpen size={16} className="shrink-0 text-amber-500" /> : <Folder size={16} className="shrink-0 text-amber-500" />}
+        <button
+          type="button"
+          onClick={() => onToggle(node.path)}
+          className="min-w-0 flex-1 text-left"
+          title={node.path || node.name}
+        >
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-medium text-slate-800">{getFolderLabel(node)}</span>
+            <span className="rounded-full bg-slate-200 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-600">
+              {node.fileCount}
+            </span>
+          </div>
+        </button>
+      </div>
+      {expanded && <div className="mt-1 space-y-1 pl-5">{children}</div>}
+    </div>
+  );
+};
+
+const renderTreeNodes = (
+  nodes: WorkspaceFileTreeNode[],
+  options: {
+    expandedFolders: Set<string>;
+    selectedFileId: string | null;
+    selectedFiles: Set<string>;
+    ragStatuses: Record<string, { status?: string; updatedAt?: string; error?: string }>;
+    isDraftWorkspaceFile: (file?: WorkspaceFile | null) => boolean;
+    onSelectFile: (file: WorkspaceFile) => void;
+    onToggleFileSelection: (fileId: string) => void;
+    onCopyPublicUrl: (file: WorkspaceFile) => void;
+    onRenameFile: (file: WorkspaceFile) => void;
+    onDeleteFile: (file: WorkspaceFile) => void;
+    onMoveFile: (file: WorkspaceFile, destinationFolderPath?: string) => void;
+    onToggleFolder: (folderPath: string) => void;
+    onDropFileToFolder: (fileId: string, folderPath: string) => void;
+    draggedFileId: string | null;
+    setDraggedFileId: (fileId: string | null) => void;
+    setDropTargetPath: (path: string | null) => void;
+    dropTargetPath: string | null;
+  },
+): React.ReactNode => {
+  return nodes.map((node) => {
+    if (node.kind === 'folder') {
+      const expanded = options.expandedFolders.has(node.path);
+      return (
+        <TreeFolderRow
+          key={node.id}
+          node={node}
+          expanded={expanded}
+          onToggle={options.onToggleFolder}
+          onDropFileToFolder={options.onDropFileToFolder}
+          draggedFileId={options.draggedFileId}
+          setDropTargetPath={options.setDropTargetPath}
+          dropTargetPath={options.dropTargetPath}
+        >
+          {renderTreeNodes(node.children, options)}
+        </TreeFolderRow>
+      );
+    }
+
+    return (
+      <TreeFileRow
+        key={node.id}
+        node={node}
+        selected={options.selectedFileId === node.file.id}
+        selectedFiles={options.selectedFiles}
+        ragStatuses={options.ragStatuses}
+        isDraftWorkspaceFile={options.isDraftWorkspaceFile}
+        onSelectFile={options.onSelectFile}
+        onToggleFileSelection={options.onToggleFileSelection}
+        onCopyPublicUrl={options.onCopyPublicUrl}
+        onRenameFile={options.onRenameFile}
+        onDeleteFile={options.onDeleteFile}
+        onMoveFile={options.onMoveFile}
+        draggedFileId={options.draggedFileId}
+        setDraggedFileId={options.setDraggedFileId}
+        setDropTargetPath={options.setDropTargetPath}
+      />
+    );
+  });
+};
+
+export default function WorkspaceFileTree({
+  files,
+  selectedFileId,
+  selectedFiles,
+  ragStatuses,
+  isDraftWorkspaceFile,
+  onSelectFile,
+  onToggleFileSelection,
+  onCopyPublicUrl,
+  onRenameFile,
+  onDeleteFile,
+  onMoveFile,
+}: WorkspaceFileTreeProps) {
+  const tree = useMemo(() => buildWorkspaceFileTree(files), [files]);
+  const folderPaths = useMemo(() => collectWorkspaceFolderPaths(tree), [tree]);
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
+  const [draggedFileId, setDraggedFileId] = useState<string | null>(null);
+  const [dropTargetPath, setDropTargetPath] = useState<string | null>(null);
+  const [hasInitializedExpandedFolders, setHasInitializedExpandedFolders] = useState(false);
+
+  const fileById = useMemo(() => new Map(files.map((file) => [file.id, file])), [files]);
+
+  useEffect(() => {
+    if (!hasInitializedExpandedFolders && folderPaths.length > 0) {
+      setExpandedFolders(new Set(folderPaths));
+      setHasInitializedExpandedFolders(true);
+    }
+  }, [folderPaths, hasInitializedExpandedFolders]);
+
+  useEffect(() => {
+    if (!selectedFileId) {
+      return;
+    }
+    const selectedFile = fileById.get(selectedFileId);
+    if (!selectedFile) {
+      return;
+    }
+    const nextPaths = getWorkspaceAncestorFolderPaths(selectedFile.name || '');
+    if (!nextPaths.length) {
+      return;
+    }
+    setExpandedFolders((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const path of nextPaths) {
+        if (!next.has(path)) {
+          next.add(path);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [fileById, selectedFileId]);
+
+  const handleToggleFolder = (folderPath: string) => {
+    setExpandedFolders((prev) => {
+      const next = new Set(prev);
+      if (next.has(folderPath)) {
+        next.delete(folderPath);
+      } else {
+        next.add(folderPath);
+      }
+      return next;
+    });
+  };
+
+  const handleDropFileToFolder = (fileId: string, folderPath: string) => {
+    const file = fileById.get(fileId);
+    if (!file) {
+      return;
+    }
+    onMoveFile(file, folderPath);
+    setDraggedFileId(null);
+    setDropTargetPath(null);
+  };
+
+  const handleRootDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const fileId = event.dataTransfer.getData('text/plain') || draggedFileId;
+    if (!fileId) {
+      return;
+    }
+    handleDropFileToFolder(fileId, '');
+  };
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-slate-200/80 bg-white/90 shadow-sm"
+      onDragOver={(event) => {
+        if (!draggedFileId) {
+          return;
+        }
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'move';
+      }}
+      onDrop={handleRootDrop}
+    >
+      <div
+        className={`border-b border-dashed px-4 py-2 text-xs transition-colors ${
+          draggedFileId ? 'border-blue-200 bg-blue-50/60 text-blue-700' : 'border-transparent text-slate-400'
+        }`}
+      >
+        {draggedFileId ? 'Drop here to move a file to the workspace root.' : 'Drag a file onto a folder to move it. Drop here to move to the workspace root.'}
+      </div>
+      <div className="flex-1 overflow-y-auto px-3 py-3">
+        {tree.children.length ? (
+          <div className="space-y-1">
+            {renderTreeNodes(tree.children, {
+              expandedFolders,
+              selectedFileId,
+              selectedFiles,
+              ragStatuses,
+              isDraftWorkspaceFile,
+              onSelectFile,
+              onToggleFileSelection,
+              onCopyPublicUrl,
+              onRenameFile,
+              onDeleteFile,
+              onMoveFile,
+              onToggleFolder: handleToggleFolder,
+              onDropFileToFolder: handleDropFileToFolder,
+              draggedFileId,
+              setDraggedFileId,
+              setDropTargetPath,
+              dropTargetPath,
+            })}
+          </div>
+        ) : (
+          <div className="flex h-full items-center justify-center rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-6 py-12 text-center">
+            <div>
+              <Folder className="mx-auto mb-3 text-slate-300" size={24} />
+              <p className="text-sm font-medium text-slate-700">No files yet</p>
+              <p className="mt-1 text-xs text-slate-500">Upload files to start building a workspace hierarchy.</p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -60,6 +60,7 @@ import CollapsibleDrawer from '../components/CollapsibleDrawer';
 import FileEditor from '../components/FileEditor';
 import UIBlockRenderer, { type UIBlock } from '../components/UIBlockRenderer';
 import ExpandableSidebar from '../components/ExpandableSidebar';
+import WorkspaceFileTree from '../components/WorkspaceFileTree';
 import AgentChatPane from '../components/chat/AgentChatPane';
 import { buildApprovalDraftContent, buildApprovalReview } from '../components/chat/approvalReview';
 import type { RenderableInterruptAction } from '../components/chat/interruptActions';
@@ -72,7 +73,12 @@ import {
   PAPER2SLIDES_STYLE_PRESETS,
   SLASH_COMMANDS,
 } from '../constants/workspace';
-import { getFileDisplayName, getFileTypeIcon, isSystemFile, normalizeFilePath } from '../utils/files';
+import { isSystemFile, normalizeFilePath } from '../utils/files';
+import {
+  buildWorkspaceDestinationPath,
+  getWorkspaceParentFolderPath,
+  normalizeWorkspaceFolderPath,
+} from '../utils/workspaceFileTree';
 import { buildMessageMetadata, mapMessagesToAgentHistory, mergeMessageMetadata, sanitizeRunPolicy } from '../utils/messages';
 import { createMarkdownComponents } from '../components/markdown/MarkdownShared';
 
@@ -327,7 +333,6 @@ export default function WorkspacePage() {
   const [chatMessage, setChatMessage] = useState('');
   const [chatAttachments, setChatAttachments] = useState<File[]>([]);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [hoveredFileId, setHoveredFileId] = useState<string | null>(null);
   const personas = DEFAULT_PERSONAS;
   const [selectedPersona, setSelectedPersona] = useState(DEFAULT_PERSONA_NAME);
   const [isEditMode, setIsEditMode] = useState(false);
@@ -397,7 +402,6 @@ export default function WorkspacePage() {
     return workspaces.filter((workspace) => workspace.name.toLowerCase().includes(query));
   }, [workspaceSearchQuery, workspaces]);
   const [copiedImageUrl, setCopiedImageUrl] = useState(false);
-  const [copiedFileUrlId, setCopiedFileUrlId] = useState<string | null>(null);
   const [ragStatuses, setRagStatuses] = useState<Record<string, { status?: string; updatedAt?: string; error?: string }>>({});
   const [copiedWorkspaceContent, setCopiedWorkspaceContent] = useState(false);
   const [copiedMessageId, setCopiedMessageId] = useState<ConversationMessage['id'] | null>(null);
@@ -1112,10 +1116,33 @@ export default function WorkspacePage() {
     }
     try {
       await navigator.clipboard.writeText(file.publicUrl);
-      setCopiedFileUrlId(file.id);
-      window.setTimeout(() => setCopiedFileUrlId((current) => (current === file.id ? null : current)), 1500);
     } catch (error) {
       console.error('Failed to copy file public URL', error);
+    }
+  }, []);
+
+  const applyWorkspaceFileUpdate = useCallback((previousName: string, updated: WorkspaceFile) => {
+    const mergeFile = (current: WorkspaceFile) => ({
+      ...current,
+      ...updated,
+      content: updated.content ?? current.content,
+    });
+
+    setFiles((prev) => prev.map((item) => (item.id === updated.id ? mergeFile(item) : item)));
+    setSelectedFile((prev) => (prev?.id === updated.id ? mergeFile(prev) : prev));
+    setSelectedFileDetails((prev) => (prev?.id === updated.id ? mergeFile(prev) : prev));
+
+    if (previousName !== updated.name) {
+      setRagStatuses((prev) => {
+        const existing = prev[previousName];
+        if (!existing) {
+          return prev;
+        }
+        const next = { ...prev };
+        next[updated.name] = existing;
+        delete next[previousName];
+        return next;
+      });
     }
   }, []);
 
@@ -1127,25 +1154,59 @@ export default function WorkspacePage() {
     }
 
     try {
-      const updated = await renameFile(selectedWorkspace.id, file.id, proposedName);
-      setFiles((prev) =>
-        prev.map((item) => (item.id === file.id ? { ...item, name: updated.name } : item))
-      );
-      if (selectedFile?.id === file.id) {
-        setSelectedFile((prev) => (prev ? { ...prev, name: updated.name } : prev));
-      }
+      const updated = await renameFile(selectedWorkspace.id, file.id, { name: proposedName });
+      applyWorkspaceFileUpdate(file.name, updated);
     } catch (error) {
       console.error('Failed to rename file:', error);
     }
   };
 
+  const handleMoveFile = async (file: WorkspaceFile, destinationFolderPath?: string) => {
+    if (!selectedWorkspace || isDraftWorkspaceFile(file)) {
+      return;
+    }
+
+    const currentFolder = getWorkspaceParentFolderPath(file.name);
+    const nextFolderPath = destinationFolderPath !== undefined
+      ? destinationFolderPath
+      : window.prompt(
+          'Move file to folder',
+          currentFolder,
+        )?.trim();
+
+    if (nextFolderPath === undefined || nextFolderPath === null) {
+      return;
+    }
+
+    const normalizedFolder = normalizeWorkspaceFolderPath(nextFolderPath);
+    const destinationPath = buildWorkspaceDestinationPath(file.name, normalizedFolder);
+    if (destinationPath === file.name) {
+      return;
+    }
+
+    try {
+      const updated = await renameFile(selectedWorkspace.id, file.id, { path: normalizedFolder });
+      applyWorkspaceFileUpdate(file.name, updated);
+    } catch (error) {
+      console.error('Failed to move file:', error);
+    }
+  };
+
   const handleDeleteSingleFile = async (file: WorkspaceFile) => {
     if (!selectedWorkspace) return;
-    if (isDraftWorkspaceFile(file)) {
+    const removeFromState = () => {
       setFiles((prev) => prev.filter((item) => item.id !== file.id));
       setSelectedFiles((prev) => {
         const next = new Set(prev);
         next.delete(file.id);
+        return next;
+      });
+      setRagStatuses((prev) => {
+        if (!prev[file.name]) {
+          return prev;
+        }
+        const next = { ...prev };
+        delete next[file.name];
         return next;
       });
       if (selectedFile?.id === file.id) {
@@ -1153,6 +1214,10 @@ export default function WorkspacePage() {
         setSelectedFileDetails(null);
         setFileContent('');
       }
+    };
+
+    if (isDraftWorkspaceFile(file)) {
+      removeFromState();
       return;
     }
     const confirmed = window.confirm(`Delete ${file.name}?`);
@@ -1160,17 +1225,7 @@ export default function WorkspacePage() {
 
     try {
       await deleteFile(selectedWorkspace.id, file.id);
-      setFiles((prev) => prev.filter((item) => item.id !== file.id));
-      setSelectedFiles((prev) => {
-        const next = new Set(prev);
-        next.delete(file.id);
-        return next;
-      });
-      if (selectedFile?.id === file.id) {
-        setSelectedFile(null);
-        setSelectedFileDetails(null);
-        setFileContent('');
-      }
+      removeFromState();
     } catch (error) {
       console.error('Failed to delete file:', error);
     }
@@ -4785,6 +4840,15 @@ export default function WorkspacePage() {
       setFiles((prevFiles) =>
         prevFiles.filter((file) => !selectedFiles.has(file.id))
       );
+      setRagStatuses((prev) => {
+        const next = { ...prev };
+        for (const file of files) {
+          if (selectedFiles.has(file.id)) {
+            delete next[file.name];
+          }
+        }
+        return next;
+      });
       setSelectedFiles(new Set());
       setSelectedFile(null);
       setSelectedFileDetails(null);
@@ -5073,105 +5137,30 @@ export default function WorkspacePage() {
                     </div>
                   )}
                   <div
-                    className={`flex-1 px-4 py-3 overflow-y-auto min-h-0 transition-opacity duration-200 ${isFilePaneVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+                    className={`flex-1 overflow-hidden min-h-0 transition-opacity duration-200 ${isFilePaneVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'
                       }`}
                     aria-hidden={!isFilePaneVisible}
                   >
-                    {visibleFiles.map((file) => {
-                      const isPendingJob = file.mimeType === 'application/vnd.helpudoc.paper2slides-job';
-                      const ragStatus = typeof file.name === 'string' ? ragStatuses[file.name] : undefined;
-                      const ragState = ragStatus?.status ? String(ragStatus.status).toLowerCase() : '';
-                      const isIndexing =
-                        !isPendingJob &&
-                        ['pending', 'processing', 'preprocessed'].includes(ragState);
-                      const displayName = getFileDisplayName(file.name || '');
-                      const fileIcon = getFileTypeIcon(file.name || '');
-                      return (
-                        <div
-                          key={file.id}
-                          className={`group flex items-center p-2 rounded-lg cursor-pointer transition-colors ${selectedFile?.id === file.id ? 'bg-blue-50' : 'hover:bg-gray-100'
-                            }`}
-                          onMouseEnter={() => setHoveredFileId(file.id)}
-                          onMouseLeave={() => setHoveredFileId((current) => (current === file.id ? null : current))}
-                        >
-                          <input
-                            type="checkbox"
-                            checked={selectedFiles.has(file.id)}
-                            disabled={isPendingJob}
-                            onChange={() => handleFileSelect(file.id)}
-                            className="mr-3"
-                          />
-                          <div
-                            onClick={() => {
-                            if (isPendingJob) {
-                              return;
-                            }
-                            setSelectedFile(file);
-                            setSelectedFileDetails(null);
-                            setFileContent('');
-                            setIsEditMode(shouldForceEditMode(file.name));
-                          }}
-                            className="flex-1 flex items-start justify-between gap-2 min-w-0"
-                          >
-                            <div className="flex items-center gap-2 min-w-0">
-                              {(isPendingJob || isIndexing) && (
-                                <Loader2 size={14} className="text-blue-500 animate-spin shrink-0" />
-                              )}
-                              <span className="shrink-0" aria-hidden="true">
-                                {fileIcon}
-                              </span>
-                              <span
-                                className="text-sm text-gray-800 break-words leading-snug"
-                                title={file.name}
-                              >
-                                {displayName}
-                              </span>
-                            </div>
-                            {!isPendingJob && (
-                              <div className={`shrink-0 items-center gap-1 ml-1 ${hoveredFileId === file.id ? 'flex' : 'hidden group-hover:flex'}`}>
-                                {file.publicUrl && !isDraftWorkspaceFile(file) && (
-                                  <button
-                                    type="button"
-                                    onClick={(event) => {
-                                      event.stopPropagation();
-                                      handleCopyFilePublicUrl(file);
-                                    }}
-                                    className="p-1 rounded hover:bg-gray-200"
-                                    title={copiedFileUrlId === file.id ? 'Copied!' : file.publicUrl}
-                                  >
-                                    <LinkIcon size={14} className="text-gray-600" />
-                                  </button>
-                                )}
-                                {!isDraftWorkspaceFile(file) ? (
-                                  <button
-                                    type="button"
-                                    onClick={(event) => {
-                                      event.stopPropagation();
-                                      handleRenameFile(file);
-                                    }}
-                                    className="p-1 rounded hover:bg-gray-200"
-                                    title="Rename"
-                                  >
-                                    <Edit size={14} className="text-gray-600" />
-                                  </button>
-                                ) : null}
-                                <button
-                                  type="button"
-                                  onClick={(event) => {
-                                    event.stopPropagation();
-                                    handleDeleteSingleFile(file);
-                                  }}
-                                  className="p-1 rounded hover:bg-gray-200"
-                                  title="Delete"
-                                >
-                                  <Trash size={14} className="text-gray-600" />
-                                </button>
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                      );
-                    })}
+                    <div className="h-full min-h-0 px-4 py-3">
+                      <WorkspaceFileTree
+                        files={visibleFiles}
+                        selectedFileId={selectedFile?.id || null}
+                        selectedFiles={selectedFiles}
+                        ragStatuses={ragStatuses}
+                        isDraftWorkspaceFile={isDraftWorkspaceFile}
+                        onSelectFile={(file) => {
+                          setSelectedFile(file);
+                          setSelectedFileDetails(null);
+                          setFileContent('');
+                          setIsEditMode(shouldForceEditMode(file.name));
+                        }}
+                        onToggleFileSelection={handleFileSelect}
+                        onCopyPublicUrl={handleCopyFilePublicUrl}
+                        onRenameFile={handleRenameFile}
+                        onDeleteFile={handleDeleteSingleFile}
+                        onMoveFile={handleMoveFile}
+                      />
+                    </div>
                   </div>
                 </div>
 

--- a/frontend/src/services/fileApi.ts
+++ b/frontend/src/services/fileApi.ts
@@ -90,7 +90,11 @@ export const deleteFile = async (workspaceId: string, fileId: string) => {
   }
 };
 
-export const renameFile = async (workspaceId: string, fileId: string, name: string) => {
+export const renameFile = async (
+  workspaceId: string,
+  fileId: string,
+  payload: { name?: string; path?: string; version?: number },
+) => {
   const response = await apiFetch(
     `${API_URL}/workspaces/${workspaceId}/files/${fileId}`,
     {
@@ -98,7 +102,7 @@ export const renameFile = async (workspaceId: string, fileId: string, name: stri
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ name }),
+      body: JSON.stringify(payload),
     },
   );
   if (!response.ok) {

--- a/frontend/src/utils/workspaceFileTree.ts
+++ b/frontend/src/utils/workspaceFileTree.ts
@@ -1,0 +1,169 @@
+import type { File as WorkspaceFile } from '../types';
+import { normalizeFilePath } from './files';
+
+export type WorkspaceFileTreeNode = WorkspaceFileTreeFolderNode | WorkspaceFileTreeLeafNode;
+
+export interface WorkspaceFileTreeFolderNode {
+  kind: 'folder';
+  id: string;
+  name: string;
+  path: string;
+  depth: number;
+  fileCount: number;
+  children: WorkspaceFileTreeNode[];
+}
+
+export interface WorkspaceFileTreeLeafNode {
+  kind: 'file';
+  id: string;
+  name: string;
+  path: string;
+  depth: number;
+  file: WorkspaceFile;
+}
+
+export const splitWorkspacePath = (value: string): string[] => {
+  const normalized = normalizeFilePath(value || '')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '');
+  if (!normalized || normalized === '.') {
+    return [];
+  }
+  return normalized.split('/').filter(Boolean);
+};
+
+export const normalizeWorkspaceFolderPath = (value: string): string => splitWorkspacePath(value).join('/');
+
+export const getWorkspaceParentFolderPath = (value: string): string => {
+  const parts = splitWorkspacePath(value);
+  if (parts.length <= 1) {
+    return '';
+  }
+  return parts.slice(0, -1).join('/');
+};
+
+export const getWorkspaceAncestorFolderPaths = (value: string): string[] => {
+  const parts = splitWorkspacePath(value);
+  const paths: string[] = [];
+  for (let index = 1; index < parts.length; index += 1) {
+    paths.push(parts.slice(0, index).join('/'));
+  }
+  return paths;
+};
+
+export const buildWorkspaceDestinationPath = (fileName: string, destinationFolderPath: string): string => {
+  const fileParts = splitWorkspacePath(fileName);
+  if (!fileParts.length) {
+    return normalizeWorkspaceFolderPath(destinationFolderPath);
+  }
+  const baseName = fileParts[fileParts.length - 1];
+  const folderParts = splitWorkspacePath(destinationFolderPath);
+  return [...folderParts, baseName].join('/');
+};
+
+const compareTreeNodes = (left: WorkspaceFileTreeNode, right: WorkspaceFileTreeNode): number => {
+  if (left.kind !== right.kind) {
+    return left.kind === 'folder' ? -1 : 1;
+  }
+  return left.name.localeCompare(right.name, undefined, { numeric: true, sensitivity: 'base' });
+};
+
+const sortChildren = (node: WorkspaceFileTreeFolderNode): void => {
+  node.children.sort(compareTreeNodes);
+  node.children.forEach((child) => {
+    if (child.kind === 'folder') {
+      sortChildren(child);
+    }
+  });
+};
+
+const countFiles = (node: WorkspaceFileTreeFolderNode): number => {
+  let total = 0;
+  for (const child of node.children) {
+    if (child.kind === 'file') {
+      total += 1;
+    } else {
+      total += countFiles(child);
+    }
+  }
+  node.fileCount = total;
+  return total;
+};
+
+export const buildWorkspaceFileTree = (files: WorkspaceFile[]): WorkspaceFileTreeFolderNode => {
+  const root: WorkspaceFileTreeFolderNode = {
+    kind: 'folder',
+    id: 'workspace-root',
+    name: 'Workspace root',
+    path: '',
+    depth: 0,
+    fileCount: 0,
+    children: [],
+  };
+
+  const folderIndex = new Map<string, WorkspaceFileTreeFolderNode>();
+  folderIndex.set('', root);
+
+  const sortedFiles = [...files].sort((left, right) =>
+    normalizeFilePath(left.name || '').localeCompare(
+      normalizeFilePath(right.name || ''),
+      undefined,
+      { numeric: true, sensitivity: 'base' },
+    ),
+  );
+
+  for (const file of sortedFiles) {
+    const parts = splitWorkspacePath(file.name || '');
+    if (!parts.length) {
+      continue;
+    }
+
+    let currentFolder = root;
+    let currentPath = '';
+
+    for (let index = 0; index < parts.length - 1; index += 1) {
+      const segment = parts[index];
+      currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+      let folderNode = folderIndex.get(currentPath);
+      if (!folderNode) {
+        folderNode = {
+          kind: 'folder',
+          id: `folder:${currentPath}`,
+          name: segment,
+          path: currentPath,
+          depth: index + 1,
+          fileCount: 0,
+          children: [],
+        };
+        folderIndex.set(currentPath, folderNode);
+        currentFolder.children.push(folderNode);
+      }
+      currentFolder = folderNode;
+    }
+
+    const leafName = parts[parts.length - 1];
+    currentFolder.children.push({
+      kind: 'file',
+      id: file.id,
+      name: leafName,
+      path: normalizeFilePath(file.name || ''),
+      depth: parts.length - 1,
+      file,
+    });
+  }
+
+  sortChildren(root);
+  countFiles(root);
+  return root;
+};
+
+export const collectWorkspaceFolderPaths = (node: WorkspaceFileTreeFolderNode): string[] => {
+  const paths: string[] = [];
+  for (const child of node.children) {
+    if (child.kind === 'folder') {
+      paths.push(child.path);
+      paths.push(...collectWorkspaceFolderPaths(child));
+    }
+  }
+  return paths;
+};


### PR DESCRIPTION
## Summary
- replace the workspace file pane with a hierarchical tree that shows nested folders and supports moving files
- extend the rename API so the frontend can move files by destination folder while keeping backend storage paths in sync
- keep RAG indexing correct across renames and preserve a fully collapsed tree state
- add a Playwright smoke test for nested file rendering and move behavior

## Verification
- npm run build (frontend)
- npx tsc -p tsconfig.json --noEmit (backend)