### PR TITLE
CP3: extract polished summary and dashboard renderers

### DIFF
--- a/agent/helpudoc_agent/data_agent_tools.py
+++ b/agent/helpudoc_agent/data_agent_tools.py
@@ -4,6 +4,7 @@ import hashlib
 import html
 import json
 import logging
+import os
 import re
 import shutil
 from dataclasses import dataclass
@@ -64,6 +65,30 @@ MAX_QUERY_COUNT = 10
 MAX_CHART_COUNT = 5
 DEFAULT_CACHE_TTL_HOURS = 24
 MAX_MATERIALIZED_ROWS = 100000
+MAX_QUERY_RESULT_ROWS = MAX_SESSION_ROWS + 1
+WORKSPACE_SCAN_EXCLUDED_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+    "dist",
+    "build",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".idea",
+    ".vscode",
+}
+DATA_FILE_EXTENSIONS = {".csv", ".parquet"}
+DATA_DISCOVERY_DIR_CANDIDATES = (
+    "data",
+    "datasets",
+    "exports",
+    "data_exports",
+)
 
 
 @dataclass
@@ -71,6 +96,7 @@ class _QueryRecord:
     sql: str
     row_count: int
     preview: "pd.DataFrame"
+    truncated: bool = False
 
 
 @dataclass
@@ -169,11 +195,66 @@ def _safe_slug(value: str, default: str) -> str:
     return slug or default
 
 
+def _should_skip_directory(name: str) -> bool:
+    if name in WORKSPACE_SCAN_EXCLUDED_DIRS:
+        return True
+    return name.startswith(".")
+
+
+def _iter_workspace_files(
+    root: Path,
+    *,
+    allowed_extensions: Optional[Set[str]] = None,
+    preferred_dirs: Tuple[str, ...] = (),
+) -> List[Path]:
+    seen: Set[Path] = set()
+    files: List[Path] = []
+
+    def _append_file(path: Path) -> None:
+        if allowed_extensions and path.suffix.lower() not in allowed_extensions:
+            return
+        resolved = path.resolve()
+        if resolved in seen:
+            return
+        seen.add(resolved)
+        files.append(path)
+
+    for child in root.iterdir():
+        if child.is_file():
+            _append_file(child)
+
+    preferred_roots: List[Path] = []
+    for dirname in preferred_dirs:
+        candidate = root / dirname
+        if candidate.exists() and candidate.is_dir():
+            preferred_roots.append(candidate)
+
+    def _scan_recursive(base: Path) -> None:
+        for current_root, dirnames, filenames in os.walk(base):
+            current_path = Path(current_root)
+            if current_path != base and _should_skip_directory(current_path.name):
+                dirnames[:] = []
+                continue
+            dirnames[:] = [
+                dirname for dirname in dirnames if not _should_skip_directory(dirname)
+            ]
+            for filename in filenames:
+                _append_file(current_path / filename)
+
+    for base in preferred_roots:
+        _scan_recursive(base)
+    if not preferred_roots or len(files) == 0:
+        _scan_recursive(root)
+    return files
+
+
 def _snapshot_workspace(root: Path) -> Dict[str, Tuple[int, int]]:
     snapshot: Dict[str, Tuple[int, int]] = {}
-    for path in root.rglob("*"):
-        if not path.is_file():
-            continue
+    for path in _iter_workspace_files(
+        root,
+        allowed_extensions=set(ALLOWED_ARTIFACT_EXTENSIONS.keys()),
+        preferred_dirs=("charts", "reports", "dashboards", "exports", "data_exports"),
+    ):
         rel = path.relative_to(root).as_posix()
         try:
             stat = path.stat()
@@ -205,14 +286,24 @@ def _detect_new_files(
     return artifacts
 
 
-def _format_dataframe_markdown(df: pd.DataFrame) -> str:
+def _format_dataframe_markdown(df: pd.DataFrame, *, truncated: bool = False) -> str:
     if df.empty:
         return "Query executed successfully but returned no data."
 
     display_df = df.head(MAX_RESULT_ROWS)
-    message_lines = [
-        f"The query returned {len(df)} rows.",
-    ]
+    message_lines = [f"Result shape: {len(df)} rows x {len(df.columns)} columns."]
+    if truncated:
+        message_lines.append(
+            f"Execution was safety-capped at {MAX_SESSION_ROWS} rows. Refine the query for the full result."
+        )
+    if len(df.columns):
+        columns = ", ".join(f"`{column}`" for column in df.columns[:10])
+        if len(df.columns) > 10:
+            columns += ", ..."
+        message_lines.append(f"Columns: {columns}")
+    numeric_summary = _format_numeric_summary(df)
+    if numeric_summary:
+        message_lines.append(f"Numeric summary: {numeric_summary}")
     if len(df) > MAX_RESULT_ROWS:
         message_lines.append(f"Showing the first {MAX_RESULT_ROWS} rows below.")
     message_lines.append(display_df.to_markdown())
@@ -220,6 +311,48 @@ def _format_dataframe_markdown(df: pd.DataFrame) -> str:
     if len(rendered) > 4000:
         return rendered[:4000] + "\n... (Output truncated due to length)"
     return rendered
+
+
+def _format_sample_value(value: Any) -> str:
+    if pd.isna(value):
+        return "null"
+    if isinstance(value, str):
+        compact = value if len(value) <= 32 else value[:29] + "..."
+        return repr(compact)
+    if isinstance(value, (datetime, pd.Timestamp)):
+        return value.isoformat()
+    return str(value)
+
+
+def _format_numeric_summary(df: pd.DataFrame) -> str:
+    numeric_df = df.select_dtypes(include=["number"])
+    if numeric_df.empty:
+        return ""
+
+    summaries: List[str] = []
+    for column in numeric_df.columns[:3]:
+        series = numeric_df[column].dropna()
+        if series.empty:
+            continue
+        summaries.append(
+            f"`{column}` min={series.min():.3g}, median={series.median():.3g}, max={series.max():.3g}"
+        )
+    return "; ".join(summaries)
+
+
+def _query_looks_aggregated(query: str) -> bool:
+    aggregate_markers = [
+        r"\bgroup\s+by\b",
+        r"\bdistinct\b",
+        r"\bhaving\b",
+        r"\bcount\s*\(",
+        r"\bsum\s*\(",
+        r"\bavg\s*\(",
+        r"\bmean\s*\(",
+        r"\bmin\s*\(",
+        r"\bmax\s*\(",
+    ]
+    return any(re.search(pattern, query, re.IGNORECASE) for pattern in aggregate_markers)
 
 
 def _markdown_to_html(markdown_text: str) -> str:
@@ -595,10 +728,18 @@ class DuckDBManager:
         """Scans workspace for CSV and Parquet files and registers them as tables."""
         self._registered_tables.clear()
         root = self.workspace_state.root_path
-        parquet_files = list(root.rglob("*.parquet"))
-        csv_files = list(root.rglob("*.csv"))
+        preferred_dirs = tuple(
+            dirname
+            for dirname in DATA_DISCOVERY_DIR_CANDIDATES
+            if (root / dirname).exists()
+        )
+        data_files = _iter_workspace_files(
+            root,
+            allowed_extensions=DATA_FILE_EXTENSIONS,
+            preferred_dirs=preferred_dirs,
+        )
         used_names: Set[str] = set()
-        for file_path in parquet_files + csv_files:
+        for file_path in sorted(data_files):
             relative_stem = file_path.relative_to(root).with_suffix("").as_posix()
             base_name = re.sub(r"[^a-zA-Z0-9_]", "_", file_path.stem)
             path_name = re.sub(r"[^a-zA-Z0-9_]", "_", relative_stem)
@@ -631,21 +772,40 @@ class DuckDBManager:
         if not tables:
             return "No tables found in the workspace."
 
-        schema_str = ""
+        schema_lines: List[str] = []
         for table in tables:
             table_name = table[0]
             if table_names and table_name not in table_names:
                 continue
 
-            schema_str += f"Table: {table_name}\n"
+            schema_lines.append(f"Table: {table_name}")
             columns = self.con.execute(f"DESCRIBE {table_name}").fetchall()
+            sample_rows = self.con.execute(f"SELECT * FROM {table_name} LIMIT 3").df()
             for col in columns:
-                schema_str += f"  - {col[0]} ({col[1]})\n"
-            schema_str += "\n"
+                sample_values: List[str] = []
+                if not sample_rows.empty and col[0] in sample_rows.columns:
+                    non_null = sample_rows[col[0]].dropna().tolist()
+                    for value in non_null:
+                        formatted = _format_sample_value(value)
+                        if formatted not in sample_values:
+                            sample_values.append(formatted)
+                        if len(sample_values) == 2:
+                            break
+                sample_suffix = (
+                    f" [examples: {', '.join(sample_values)}]" if sample_values else ""
+                )
+                schema_lines.append(f"  - {col[0]} ({col[1]}){sample_suffix}")
+            schema_lines.append("")
 
-        return schema_str
+        return "\n".join(schema_lines).strip()
 
-    def run_query(self, query: str) -> pd.DataFrame:
+    def run_query(
+        self,
+        query: str,
+        *,
+        record_sql: Optional[str] = None,
+        truncated: bool = False,
+    ) -> pd.DataFrame:
         if self.session.query_count >= MAX_QUERY_COUNT:
             raise ValueError(
                 f"Query budget exhausted: at most {MAX_QUERY_COUNT} queries are allowed per run."
@@ -653,12 +813,14 @@ class DuckDBManager:
         df = self.con.execute(query).df()
         self.session.query_count += 1
         self.session.last_query_result = df
-        self.session.last_query_sql = query
+        stored_sql = record_sql or query
+        self.session.last_query_sql = stored_sql
         self.session.query_history.append(
             _QueryRecord(
-                sql=query,
+                sql=stored_sql,
                 row_count=len(df),
                 preview=df.head(MAX_RESULT_ROWS).copy(),
+                truncated=truncated,
             )
         )
         return df
@@ -803,7 +965,7 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
 
     @tool
     def run_sql_query(
-        sql_query: str = Field(description="The SQL query to run. Always limit rows to 1000."),
+        sql_query: str = Field(description="The SQL query to run."),
     ) -> str:
         """Run a SQL query against the database and return the results."""
         try:
@@ -818,11 +980,25 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
             cleaned_query = _rewrite_virtual_paths(
                 cleaned_query, db_manager.workspace_state.root_path
             )
-            if not re.search(r"\blimit\s+\d+\b", cleaned_query, re.IGNORECASE):
-                cleaned_query = f"{cleaned_query} LIMIT 1000"
+            truncated = False
+            executed_query = cleaned_query
+            safety_capped = not _query_looks_aggregated(cleaned_query)
+            if safety_capped:
+                executed_query = (
+                    f"SELECT * FROM ({cleaned_query}) AS helpudoc_query_preview "
+                    f"LIMIT {MAX_QUERY_RESULT_ROWS}"
+                )
 
-            df = db_manager.run_query(cleaned_query)
-            return _format_dataframe_markdown(df)
+            df = db_manager.run_query(executed_query, record_sql=cleaned_query)
+            if safety_capped and len(df) > MAX_SESSION_ROWS:
+                truncated = True
+                df = df.head(MAX_SESSION_ROWS).copy()
+                db_manager.session.last_query_result = df
+                if db_manager.session.query_history:
+                    db_manager.session.query_history[-1].row_count = len(df)
+                    db_manager.session.query_history[-1].preview = df.head(MAX_RESULT_ROWS).copy()
+                    db_manager.session.query_history[-1].truncated = True
+            return _format_dataframe_markdown(df, truncated=truncated)
         except Exception as exc:  # pragma: no cover - defensive
             return f"Error executing query: {str(exc)}"
 
@@ -1281,8 +1457,13 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
                 ]
             )
             for idx, query_record in enumerate(db_manager.session.query_history, start=1):
+                row_label = (
+                    f"{query_record.row_count}+ rows previewed"
+                    if query_record.truncated
+                    else f"{query_record.row_count} rows"
+                )
                 report_lines.append(
-                    f"      <h3>Query {idx} <span class=\"meta\">({query_record.row_count} rows)</span></h3>"
+                    f"      <h3>Query {idx} <span class=\"meta\">({row_label})</span></h3>"
                 )
                 report_lines.append(f"      <pre><code>{html.escape(query_record.sql)}</code></pre>")
                 if not query_record.preview.empty:
@@ -1588,9 +1769,14 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
 
         query_items = []
         for idx, query_record in enumerate(db_manager.session.query_history, start=1):
+            row_label = (
+                f"{query_record.row_count}+ rows previewed"
+                if query_record.truncated
+                else f"{query_record.row_count} rows"
+            )
             query_items.append(
                 "<div class=\"query-item\">"
-                f"<div class=\"query-meta\">Query {idx} • {query_record.row_count} rows</div>"
+                f"<div class=\"query-meta\">Query {idx} • {row_label}</div>"
                 f"<pre class=\"query-block\">{html.escape(query_record.sql)}</pre>"
                 "</div>"
             )

--- a/agent/helpudoc_agent/data_agent_tools.py
+++ b/agent/helpudoc_agent/data_agent_tools.py
@@ -314,7 +314,18 @@ def _format_dataframe_markdown(df: pd.DataFrame, *, truncated: bool = False) -> 
 
 
 def _format_sample_value(value: Any) -> str:
-    if pd.isna(value):
+    if isinstance(value, np.ndarray):
+        value = value.tolist()
+    if isinstance(value, pd.Series):
+        value = value.tolist()
+    if isinstance(value, (list, tuple, set, dict)):
+        structured = json.dumps(value, default=str)
+        return structured if len(structured) <= 32 else structured[:29] + "..."
+    try:
+        is_null = pd.isna(value)
+    except (TypeError, ValueError):
+        is_null = False
+    if is_null:
         return "null"
     if isinstance(value, str):
         compact = value if len(value) <= 32 else value[:29] + "..."
@@ -341,10 +352,14 @@ def _format_numeric_summary(df: pd.DataFrame) -> str:
 
 
 def _query_looks_aggregated(query: str) -> bool:
+    if re.search(r"\bover\s*\(", query, re.IGNORECASE):
+        return False
+    if re.search(r"\bgroup\s+by\b", query, re.IGNORECASE):
+        return True
+    if re.search(r"\bhaving\b", query, re.IGNORECASE):
+        return True
+
     aggregate_markers = [
-        r"\bgroup\s+by\b",
-        r"\bdistinct\b",
-        r"\bhaving\b",
         r"\bcount\s*\(",
         r"\bsum\s*\(",
         r"\bavg\s*\(",

--- a/agent/helpudoc_agent/data_agent_tools.py
+++ b/agent/helpudoc_agent/data_agent_tools.py
@@ -207,6 +207,7 @@ def _iter_workspace_files(
     *,
     allowed_extensions: Optional[Set[str]] = None,
     preferred_dirs: Tuple[str, ...] = (),
+    include_root_recursive: bool = False,
 ) -> List[Path]:
     seen: Set[Path] = set()
     files: List[Path] = []
@@ -244,7 +245,7 @@ def _iter_workspace_files(
 
     for base in preferred_roots:
         _scan_recursive(base)
-    if not preferred_roots or len(files) == 0:
+    if include_root_recursive or not preferred_roots:
         _scan_recursive(root)
     return files
 
@@ -255,6 +256,7 @@ def _snapshot_workspace(root: Path) -> Dict[str, Tuple[int, int]]:
         root,
         allowed_extensions=set(ALLOWED_ARTIFACT_EXTENSIONS.keys()),
         preferred_dirs=("charts", "reports", "dashboards", "exports", "data_exports"),
+        include_root_recursive=True,
     ):
         rel = path.relative_to(root).as_posix()
         try:
@@ -355,20 +357,10 @@ def _format_numeric_summary(df: pd.DataFrame) -> str:
 def _query_looks_aggregated(query: str) -> bool:
     if re.search(r"\bover\s*\(", query, re.IGNORECASE):
         return False
-    if re.search(r"\bgroup\s+by\b", query, re.IGNORECASE):
-        return True
-    if re.search(r"\bhaving\b", query, re.IGNORECASE):
-        return True
-
-    aggregate_markers = [
-        r"\bcount\s*\(",
-        r"\bsum\s*\(",
-        r"\bavg\s*\(",
-        r"\bmean\s*\(",
-        r"\bmin\s*\(",
-        r"\bmax\s*\(",
-    ]
-    return any(re.search(pattern, query, re.IGNORECASE) for pattern in aggregate_markers)
+    return bool(
+        re.search(r"\bgroup\s+by\b", query, re.IGNORECASE)
+        or re.search(r"\bhaving\b", query, re.IGNORECASE)
+    )
 
 
 def _markdown_to_html(markdown_text: str) -> str:

--- a/agent/helpudoc_agent/data_agent_tools.py
+++ b/agent/helpudoc_agent/data_agent_tools.py
@@ -27,6 +27,7 @@ from .bigquery_export_tools import (
     validate_read_only_sql,
     write_export_dataframe,
 )
+from .data_report_renderers import render_dashboard_html, render_summary_html
 from .state import WorkspaceState
 
 logger = logging.getLogger(__name__)
@@ -1404,87 +1405,40 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
         except ValueError as exc:
             return str(exc)
         db_manager.mark_summary_generated()
-
-        report_lines = [
-            "<!doctype html>",
-            "<html lang=\"en\">",
-            "<head>",
-            "  <meta charset=\"utf-8\" />",
-            "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />",
-            "  <title>Data Analysis Report</title>",
-            "  <style>",
-            "    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background:#f7f7f8; color:#1f2933; margin:0; padding:0; }",
-            "    .container { max-width: 960px; margin: 0 auto; padding: 32px 20px 48px; }",
-            "    h1 { margin: 0 0 8px; }",
-            "    h2 { margin-top: 28px; margin-bottom: 12px; }",
-            "    h3 { margin-top: 20px; margin-bottom: 10px; }",
-            "    .card { background:#fff; border:1px solid #e5e7eb; border-radius:14px; padding:18px 20px; box-shadow:0 1px 2px rgba(0,0,0,0.04); margin-top:12px; }",
-            "    .meta { color:#6b7280; font-size: 0.95rem; margin-bottom: 6px; }",
-            "    table { border-collapse: collapse; width: 100%; }",
-            "    table thead { background:#f3f4f6; }",
-            "    table th, table td { border:1px solid #e5e7eb; padding:8px 10px; text-align:left; font-size: 0.95rem; }",
-            "    ul { padding-left: 20px; }",
-            "    pre { background:#0f172a; color:#e2e8f0; padding:12px; border-radius:12px; overflow-x:auto; white-space:pre-wrap; }",
-            "    img { max-width: 100%; height: auto; display: block; margin: 12px 0; border-radius:12px; border:1px solid #e5e7eb; }",
-            "    .plotly-embed { margin: 16px 0; }",
-            "    .agent-markdown { line-height: 1.7; font-size: 0.98rem; }",
-            "  </style>",
-            "  <script src=\"https://cdn.plot.ly/plotly-3.3.0.min.js\"></script>",
-            "</head>",
-            "<body>",
-            "  <div class=\"container\">",
-            "    <h1>Data Analysis Report</h1>",
-            f"    <div class=\"meta\">Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}</div>",
-            "    <div class=\"card\">",
-            "      <h2>Summary</h2>",
-            f"      <div class=\"agent-markdown\">{_markdown_to_html(summary) or '<p>No summary provided.</p>'}</div>",
-            "      <h2>Key Insights</h2>",
-            f"      <div class=\"agent-markdown\">{_markdown_to_html(insights) or '<p>No insights provided.</p>'}</div>",
-            "    </div>",
-        ]
+        generated_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        materialization_items: List[str] = []
+        query_items: List[str] = []
+        visualization_items: List[str] = []
 
         if db_manager.session.materialization_history:
-            report_lines.extend(
-                [
-                    "    <div class=\"card\">",
-                    "      <h2>Warehouse Materializations</h2>",
-                ]
-            )
             for item in db_manager.session.materialization_history:
-                report_lines.extend(
-                    [
-                        f"      <p><strong>Connector:</strong> {html.escape(item.connector)}<br />"
-                        f"<strong>Rows:</strong> {item.row_count}<br />"
-                        f"<strong>Cached:</strong> {'yes' if item.cached else 'no'}<br />"
-                        f"<strong>Parquet:</strong> <code>{html.escape(item.parquet_path)}</code><br />"
-                        f"<strong>Metadata:</strong> <code>{html.escape(item.metadata_path)}</code><br />"
-                        f"<strong>Expires:</strong> {html.escape(item.expires_at or 'n/a')}</p>",
-                        f"      <pre><code>{html.escape(item.sql)}</code></pre>",
-                    ]
+                materialization_items.append(
+                    "<article class=\"stack-item\">"
+                    f"<div class=\"stack-meta\">Connector {html.escape(item.connector)} • Rows {item.row_count} • Cached {'yes' if item.cached else 'no'}</div>"
+                    f"<p><strong>Parquet:</strong> <code>{html.escape(item.parquet_path)}</code><br />"
+                    f"<strong>Metadata:</strong> <code>{html.escape(item.metadata_path)}</code><br />"
+                    f"<strong>Expires:</strong> {html.escape(item.expires_at or 'n/a')}</p>"
+                    f"<pre><code>{html.escape(item.sql)}</code></pre>"
+                    "</article>"
                 )
-            report_lines.append("    </div>")
 
         if db_manager.session.query_history:
-            report_lines.extend(
-                [
-                    "    <div class=\"card\">",
-                    "      <h2>SQL Queries</h2>",
-                ]
-            )
             for idx, query_record in enumerate(db_manager.session.query_history, start=1):
                 row_label = (
                     f"{query_record.row_count}+ rows previewed"
                     if query_record.truncated
                     else f"{query_record.row_count} rows"
                 )
-                report_lines.append(
-                    f"      <h3>Query {idx} <span class=\"meta\">({row_label})</span></h3>"
-                )
-                report_lines.append(f"      <pre><code>{html.escape(query_record.sql)}</code></pre>")
+                query_block = [
+                    "<article class=\"stack-item\">",
+                    f"<div class=\"stack-meta\">Query {idx} • {row_label}</div>",
+                    f"<pre><code>{html.escape(query_record.sql)}</code></pre>",
+                ]
                 if not query_record.preview.empty:
-                    report_lines.append("      <h4>Sample Data</h4>")
-                    report_lines.append(query_record.preview.to_html(index=False, border=0))
-            report_lines.append("    </div>")
+                    query_block.append("<h4>Sample Data</h4>")
+                    query_block.append(query_record.preview.to_html(index=False, border=0))
+                query_block.append("</article>")
+                query_items.append("".join(query_block))
 
         run_chart_paths: List[str] = []
         for chart_record in db_manager.session.chart_history:
@@ -1503,22 +1457,21 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
             if p.exists()
         )
         if plotly_json_files or plotly_html_files or png_files:
-            report_lines.append("    <div class=\"card\">")
-            report_lines.append("      <h2>Visualizations</h2>")
-
             for idx, json_path in enumerate(plotly_json_files, start=1):
                 try:
                     fig_json = json.loads(json_path.read_text(encoding="utf-8"))
                     script_payload = json.dumps(fig_json)
                     div_id = f"plotly-json-{idx}"
-                    report_lines.append(f"      <h3>{_chart_title_from_path(json_path)}</h3>")
-                    report_lines.append(f"      <div id=\"{div_id}\" class=\"plotly-embed\" style=\"height:420px;\"></div>")
-                    report_lines.append(
-                        "      <script>"
+                    visualization_items.append(
+                        "<article class=\"stack-item\">"
+                        f"<h3>{_chart_title_from_path(json_path)}</h3>"
+                        f"<div id=\"{div_id}\" class=\"plotly-embed\"></div>"
+                        "<script>"
                         f"const spec{idx} = {script_payload};"
                         f"const data{idx} = spec{idx}.data || []; const layout{idx} = spec{idx}.layout || {{}}; const config{idx} = spec{idx}.config || {{}}; const frames{idx} = spec{idx}.frames || undefined;"
                         f"Plotly.newPlot('{div_id}', data{idx}, layout{idx}, config{idx}).then(() => {{ if (frames{idx} && frames{idx}.length) {{ Plotly.addFrames('{div_id}', frames{idx}); }} }});"
                         "</script>"
+                        "</article>"
                     )
                 except Exception:
                     logger.warning("Failed to embed Plotly JSON %s", json_path, exc_info=True)
@@ -1526,23 +1479,63 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
             for html_path in plotly_html_files:
                 try:
                     html_fragment = html_path.read_text(encoding="utf-8")
-                    report_lines.append(f"      <h3>{_chart_title_from_path(html_path)}</h3>")
-                    report_lines.append(f"      <div class=\"plotly-embed\">{html_fragment}</div>")
+                    visualization_items.append(
+                        "<article class=\"stack-item\">"
+                        f"<h3>{_chart_title_from_path(html_path)}</h3>"
+                        f"<div class=\"plotly-embed\">{html_fragment}</div>"
+                        "</article>"
+                    )
                 except Exception:
                     logger.warning("Failed to embed Plotly HTML %s", html_path, exc_info=True)
 
             for png_path in png_files:
                 try:
                     encoded = base64.b64encode(png_path.read_bytes()).decode("utf-8")
-                    report_lines.append(
-                        f"      <h3>{_chart_title_from_path(png_path)}</h3><img src=\"data:image/png;base64,{encoded}\" alt=\"{png_path.stem}\" />"
+                    visualization_items.append(
+                        "<article class=\"stack-item\">"
+                        f"<h3>{_chart_title_from_path(png_path)}</h3>"
+                        f"<img src=\"data:image/png;base64,{encoded}\" alt=\"{png_path.stem}\" />"
+                        "</article>"
                     )
                 except Exception:
                     logger.warning("Failed to embed PNG %s", png_path, exc_info=True)
+        summary_metric_cards = [
+            {
+                "label": "Queries Run",
+                "value": str(len(db_manager.session.query_history)),
+                "meta": "SQL steps captured in this report",
+            },
+            {
+                "label": "Charts Embedded",
+                "value": str(len(visualization_items)),
+                "meta": "Visual artifacts included below",
+            },
+            {
+                "label": "Warehouse Pulls",
+                "value": str(len(db_manager.session.materialization_history)),
+                "meta": "Materializations cached or refreshed",
+            },
+        ]
+        if db_manager.session.query_history:
+            latest_query = db_manager.session.query_history[-1]
+            summary_metric_cards.append(
+                {
+                    "label": "Latest Result",
+                    "value": str(latest_query.row_count),
+                    "meta": "Rows in the final SQL step",
+                }
+            )
 
-            report_lines.append("    </div>")
-
-        report_lines.extend(["  </div>", "</body>", "</html>"])
+        report_html = render_summary_html(
+            title="Data Analysis Report",
+            generated_at=generated_at,
+            summary_html=_markdown_to_html(summary),
+            insights_html=_markdown_to_html(insights),
+            metric_cards=summary_metric_cards,
+            materialization_items=materialization_items,
+            query_items=query_items,
+            visualization_items=visualization_items,
+        )
 
         try:
             reports_dir = workspace_state.root_path / "reports"
@@ -1558,7 +1551,7 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
                 report_path = reports_dir / f"analysis_report_{timestamp}.html"
             report_path.parent.mkdir(parents=True, exist_ok=True)
-            report_path.write_text("\n".join(report_lines), encoding="utf-8")
+            report_path.write_text(report_html, encoding="utf-8")
 
             artifact = {
                 "path": _workspace_rel(report_path, workspace_state.root_path),
@@ -1795,473 +1788,67 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
                 f"<pre class=\"query-block\">{html.escape(query_record.sql)}</pre>"
                 "</div>"
             )
-
-        html_lines = [
-            "<!doctype html>",
-            "<html lang=\"en\">",
-            "<head>",
-            "  <meta charset=\"utf-8\" />",
-            "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />",
-            f"  <title>{html.escape(title)}</title>",
-            "  <style>",
-            "    :root{--bg:#f4f1ea;--panel:#fffdf8;--ink:#1f2937;--muted:#6b7280;--line:#e7dfd2;--accent:#1f4d3a;--shadow:0 16px 40px rgba(68,50,28,0.08);}",
-            "    *{box-sizing:border-box}",
-            "    body{margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:linear-gradient(180deg,#f7f4ee 0%,#f4f1ea 100%);color:var(--ink);}",
-            "    .shell{max-width:1320px;margin:0 auto;padding:28px 22px 56px}",
-            "    .hero,.section{background:rgba(255,253,248,0.96);border:1px solid rgba(231,223,210,0.95);box-shadow:var(--shadow);border-radius:28px;padding:28px 30px;}",
-            "    .hero h1{margin:0 0 10px;font-size:clamp(2rem,4vw,3.2rem);line-height:1.02;letter-spacing:-0.04em;}",
-            "    .hero p{margin:0;color:#4b5563;line-height:1.65;max-width:760px}",
-            "    .hero-meta{margin-top:16px;color:var(--muted);font-size:0.9rem}",
-            "    .section{margin-top:22px}",
-            "    .chart-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:18px}",
-            "    .chart-card{background:linear-gradient(180deg,#fffefb 0%,#fbf8f2 100%);border:1px solid var(--line);border-radius:20px;padding:18px}",
-            "    .chart-card h3{margin:0 0 8px;font-size:1.05rem}",
-            "    .chart-meta{margin:0 0 12px;color:var(--muted);font-size:0.88rem}",
-            "    .chart-note{margin:10px 0 0;color:#4b5563;font-size:0.9rem;line-height:1.4}",
-            "    .plotly-embed{width:100%;height:340px}",
-            "    img.chart-img{width:100%;border-radius:12px;border:1px solid var(--line)}",
-            "    .filter-bar{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px;margin-top:22px}",
-            "    .filter-card{background:rgba(255,253,248,0.96);border:1px solid rgba(231,223,210,0.95);box-shadow:var(--shadow);border-radius:20px;padding:18px}",
-            "    .filter-card h2{margin:0 0 6px;font-size:1rem}",
-            "    .filter-card p{margin:0 0 12px;color:var(--muted);font-size:0.9rem;line-height:1.5}",
-            "    .filter-controls{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}",
-            "    .filter-control{display:flex;flex-direction:column;gap:6px}",
-            "    .filter-control label{font-size:0.88rem;font-weight:600;color:#374151}",
-            "    .filter-control select,.filter-control input,.filter-actions button{border:1px solid var(--line);border-radius:12px;padding:10px 12px;background:#fff;color:var(--ink)}",
-            "    .filter-actions{display:flex;gap:10px;align-items:end}",
-            "    .filter-actions button{cursor:pointer;background:var(--accent);color:#fff;font-weight:600}",
-            "    .filter-actions button.secondary{background:#fff;color:var(--ink)}",
-            "    .dataset-meta{margin-top:14px;color:var(--muted);font-size:0.85rem}",
-            "    details.appendix{margin-top:18px}",
-            "    .query-item{background:#faf7f1;border:1px solid var(--line);border-radius:16px;padding:16px;margin-top:12px}",
-            "    .query-meta{font-size:0.82rem;color:#9a3412;font-weight:700;letter-spacing:0.03em;text-transform:uppercase;margin-bottom:8px}",
-            "    .query-block{margin:0;background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px 16px;overflow-x:auto;white-space:pre-wrap;color:#374151}",
-            "    @media (max-width: 768px){.shell{padding:16px 14px 42px}.hero,.section,.filter-card{padding:22px 18px}.chart-grid{grid-template-columns:1fr}.plotly-embed{height:300px}}",
-            "  </style>",
-            "  <script src=\"https://cdn.plot.ly/plotly-3.3.0.min.js\"></script>",
-            "</head>",
-            "<body>",
-            "  <div class=\"shell\">",
-            "    <section class=\"hero\">",
-            "      <div>Interactive dashboard</div>",
-            f"      <h1>{html.escape(title)}</h1>",
-            f"      <p>{html.escape(description)}</p>",
-            f"      <div class=\"hero-meta\">Generated {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} • Charts embedded: {len(bound_cards) + len(static_cards)} • Queries embedded: {len(db_manager.session.query_history)}</div>",
-            "    </section>",
-        ]
-
-        if data_filtering_enabled:
-            html_lines.extend(
-                [
-                    "    <section class=\"filter-bar\">",
-                    "      <div class=\"filter-card\">",
-                    "        <h2>Shared data filters</h2>",
-                    "        <p>These controls update all compatible charts from the embedded dashboard dataset.</p>",
-                    "        <div id=\"dashboard-filter-controls\" class=\"filter-controls\"></div>",
-                    "        <div class=\"filter-actions\">",
-                    "          <button type=\"button\" id=\"dashboard-apply-filters\" class=\"secondary\">Apply filters</button>",
-                    "          <button type=\"button\" id=\"dashboard-reset-filters\">Reset filters</button>",
-                    "        </div>",
-                    f"        <div class=\"dataset-meta\">Dataset: {html.escape(dashboard_dataset_path)} • Rows embedded: {len(dataset_records)} • Format: {html.escape(dataset_format)}</div>",
-                    "      </div>",
-                    "    </section>",
-                ]
-            )
-
-        html_lines.extend(
-            [
-            "    <section class=\"section\">",
-            "      <h2>Highlights</h2>" if bound_cards else "      <h2>Charts</h2>",
-            "      <div class=\"chart-grid\">",
-            *(bound_cards or static_cards),
-            "      </div>",
-        ]
+        generated_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        hero_meta = (
+            f"Charts embedded: {len(bound_cards) + len(static_cards)} • "
+            f"Queries embedded: {len(db_manager.session.query_history)}"
         )
-
-        if bound_cards and static_cards:
-            html_lines.extend(
-                [
-                    "      <details class=\"appendix\">",
-                    "        <summary>Static appendix charts</summary>",
-                    "        <div class=\"chart-grid\">",
-                    *static_cards,
-                    "        </div>",
-                    "      </details>",
-                ]
-            )
-
-        html_lines.extend(
-            [
-            "      <details class=\"appendix\">",
-            "        <summary>Technical appendix</summary>",
-            *query_items,
-            "      </details>",
-            "    </section>",
-            "  </div>",
-            "  <script>",
-            f"    const DASHBOARD_DATASET = {_json_dump(dataset_records)};",
-            f"    const DASHBOARD_FILTER_SCHEMA = {_json_dump(filter_config)};",
-            f"    const DASHBOARD_CHART_DEFS = {_json_dump(chart_runtime_defs)};",
-            f"    const DASHBOARD_DATASET_SCHEMA = {_json_dump(dataset_schema)};",
-            """
-    (function() {
-      if (!DASHBOARD_DATASET.length || !DASHBOARD_FILTER_SCHEMA.length || !DASHBOARD_CHART_DEFS.length) {
-        return;
-      }
-
-      const controlHost = document.getElementById('dashboard-filter-controls');
-      const applyButton = document.getElementById('dashboard-apply-filters');
-      const resetButton = document.getElementById('dashboard-reset-filters');
-      const fieldTypes = Object.fromEntries((DASHBOARD_DATASET_SCHEMA || []).map((item) => [item.name, String(item.type || '').toLowerCase()]));
-
-      function inferFieldType(filterDef) {
-        if (filterDef.type === 'numeric' || filterDef.type === 'date' || filterDef.type === 'datetime') {
-          return filterDef.type;
-        }
-        const raw = fieldTypes[filterDef.field] || '';
-        if (raw.includes('date') || raw.includes('time')) return 'date';
-        if (raw.includes('int') || raw.includes('float') || raw.includes('double') || raw.includes('decimal')) return 'numeric';
-        return 'categorical';
-      }
-
-      function parseDateValue(value) {
-        if (value === null || value === undefined || value === '') return null;
-        const parsed = new Date(value);
-        return Number.isNaN(parsed.getTime()) ? null : parsed;
-      }
-
-      function parseNumericValue(value) {
-        if (value === null || value === undefined || value === '') return null;
-        const parsed = Number(value);
-        return Number.isFinite(parsed) ? parsed : null;
-      }
-
-      function normalizeComparable(value, type) {
-        if (type === 'date' || type === 'datetime') {
-          const parsed = parseDateValue(value);
-          return parsed ? parsed.getTime() : null;
-        }
-        if (type === 'numeric') {
-          return parseNumericValue(value);
-        }
-        return value;
-      }
-
-      function distinctValues(field) {
-        const values = [];
-        const seen = new Set();
-        DASHBOARD_DATASET.forEach((row) => {
-          const value = row[field];
-          const key = value === null || value === undefined ? '__null__' : String(value);
-          if (!seen.has(key) && value !== null && value !== undefined && value !== '') {
-            seen.add(key);
-            values.push(value);
-          }
-        });
-        return values.sort((a, b) => String(a).localeCompare(String(b)));
-      }
-
-      function fieldExtent(field, type) {
-        let min = null;
-        let max = null;
-        DASHBOARD_DATASET.forEach((row) => {
-          const value = normalizeComparable(row[field], type);
-          if (value === null) return;
-          if (min === null || value < min) min = value;
-          if (max === null || value > max) max = value;
-        });
-        return { min, max };
-      }
-
-      function createControl(filterDef) {
-        const wrapper = document.createElement('div');
-        wrapper.className = 'filter-control';
-        const label = document.createElement('label');
-        label.textContent = filterDef.label;
-        wrapper.appendChild(label);
-        const fieldType = inferFieldType(filterDef);
-        filterDef.resolvedType = fieldType;
-
-        if (fieldType === 'categorical') {
-          const select = document.createElement('select');
-          select.id = filterDef.id;
-          if (filterDef.multi) select.multiple = true;
-          const values = (filterDef.options && filterDef.options.length ? filterDef.options : distinctValues(filterDef.field));
-          values.forEach((value) => {
-            const option = document.createElement('option');
-            option.value = String(value);
-            option.textContent = String(value);
-            select.appendChild(option);
-          });
-          wrapper.appendChild(select);
-          return wrapper;
-        }
-
-        if (fieldType === 'date' || fieldType === 'datetime') {
-          const extent = fieldExtent(filterDef.field, 'date');
-          const preset = document.createElement('select');
-          preset.id = filterDef.id + '__preset';
-          ['', 'last_30_days', 'last_90_days', 'last_180_days'].forEach((value) => {
-            const option = document.createElement('option');
-            option.value = value;
-            option.textContent = value ? value.replaceAll('_', ' ') : 'Custom range';
-            preset.appendChild(option);
-          });
-          wrapper.appendChild(preset);
-          const startInput = document.createElement('input');
-          startInput.type = 'date';
-          startInput.id = filterDef.id + '__start';
-          const endInput = document.createElement('input');
-          endInput.type = 'date';
-          endInput.id = filterDef.id + '__end';
-          if (extent.min !== null) startInput.value = new Date(extent.min).toISOString().slice(0, 10);
-          if (extent.max !== null) endInput.value = new Date(extent.max).toISOString().slice(0, 10);
-          preset.addEventListener('change', () => {
-            if (!preset.value || extent.max === null) return;
-            const end = new Date(extent.max);
-            const start = new Date(end);
-            const days = preset.value === 'last_30_days' ? 30 : preset.value === 'last_90_days' ? 90 : 180;
-            start.setDate(start.getDate() - days);
-            startInput.value = start.toISOString().slice(0, 10);
-            endInput.value = end.toISOString().slice(0, 10);
-          });
-          wrapper.appendChild(startInput);
-          wrapper.appendChild(endInput);
-          return wrapper;
-        }
-
-        const extent = fieldExtent(filterDef.field, 'numeric');
-        const minInput = document.createElement('input');
-        minInput.type = 'number';
-        minInput.id = filterDef.id + '__min';
-        minInput.placeholder = extent.min === null ? 'Min' : String(extent.min);
-        const maxInput = document.createElement('input');
-        maxInput.type = 'number';
-        maxInput.id = filterDef.id + '__max';
-        maxInput.placeholder = extent.max === null ? 'Max' : String(extent.max);
-        wrapper.appendChild(minInput);
-        wrapper.appendChild(maxInput);
-        return wrapper;
-      }
-
-      function readFilterValue(filterDef) {
-        const type = filterDef.resolvedType || inferFieldType(filterDef);
-        if (type === 'categorical') {
-          const select = document.getElementById(filterDef.id);
-          return Array.from(select ? select.selectedOptions : []).map((option) => option.value);
-        }
-        if (type === 'date' || type === 'datetime') {
-          return {
-            start: document.getElementById(filterDef.id + '__start')?.value || '',
-            end: document.getElementById(filterDef.id + '__end')?.value || '',
-          };
-        }
-        return {
-          min: document.getElementById(filterDef.id + '__min')?.value || '',
-          max: document.getElementById(filterDef.id + '__max')?.value || '',
-        };
-      }
-
-      function rowMatchesFilter(row, filterDef, value) {
-        const type = filterDef.resolvedType || inferFieldType(filterDef);
-        const rowValue = row[filterDef.field];
-        if (type === 'categorical') {
-          if (!value || !value.length) return true;
-          return value.includes(String(rowValue));
-        }
-        if (type === 'date' || type === 'datetime') {
-          const rowTime = normalizeComparable(rowValue, 'date');
-          if (rowTime === null) return false;
-          const start = value.start ? parseDateValue(value.start) : null;
-          const end = value.end ? parseDateValue(value.end) : null;
-          if (start && rowTime < start.getTime()) return false;
-          if (end) {
-            const inclusiveEnd = new Date(end);
-            inclusiveEnd.setHours(23, 59, 59, 999);
-            if (rowTime > inclusiveEnd.getTime()) return false;
-          }
-          return true;
-        }
-        const numericValue = normalizeComparable(rowValue, 'numeric');
-        if (numericValue === null) return false;
-        const minValue = parseNumericValue(value.min);
-        const maxValue = parseNumericValue(value.max);
-        if (minValue !== null && numericValue < minValue) return false;
-        if (maxValue !== null && numericValue > maxValue) return false;
-        return true;
-      }
-
-      function aggregateRows(rows, chartDef) {
-        const map = new Map();
-        rows.forEach((row) => {
-          const xValue = row[chartDef.xField];
-          const seriesValue = chartDef.seriesField ? row[chartDef.seriesField] : '__single__';
-          const key = JSON.stringify([xValue, seriesValue]);
-          if (!map.has(key)) {
-            map.set(key, { x: xValue, series: seriesValue, count: 0, sum: 0, min: null, max: null, values: [] });
-          }
-          const bucket = map.get(key);
-          bucket.count += 1;
-          const yRaw = chartDef.yField ? parseNumericValue(row[chartDef.yField]) : null;
-          if (yRaw !== null) {
-            bucket.sum += yRaw;
-            bucket.min = bucket.min === null ? yRaw : Math.min(bucket.min, yRaw);
-            bucket.max = bucket.max === null ? yRaw : Math.max(bucket.max, yRaw);
-            bucket.values.push(yRaw);
-          }
-        });
-
-        const points = Array.from(map.values()).map((bucket) => {
-          let yValue = bucket.count;
-          switch (chartDef.aggregation) {
-            case 'sum':
-              yValue = bucket.sum;
-              break;
-            case 'avg':
-            case 'mean':
-              yValue = bucket.values.length ? bucket.sum / bucket.values.length : 0;
-              break;
-            case 'min':
-              yValue = bucket.min === null ? 0 : bucket.min;
-              break;
-            case 'max':
-              yValue = bucket.max === null ? 0 : bucket.max;
-              break;
-            case 'nunique':
-            case 'count_distinct':
-              yValue = new Set(bucket.values).size;
-              break;
-            case 'count':
-            default:
-              yValue = bucket.count;
-              break;
-          }
-          return { x: bucket.x, y: yValue, series: bucket.series };
-        });
-
-        points.sort((left, right) => {
-          const direction = chartDef.sortDirection === 'asc' ? 1 : -1;
-          const leftValue = chartDef.sortBy === 'x' ? String(left.x ?? '') : Number(left.y ?? 0);
-          const rightValue = chartDef.sortBy === 'x' ? String(right.x ?? '') : Number(right.y ?? 0);
-          if (leftValue < rightValue) return -1 * direction;
-          if (leftValue > rightValue) return 1 * direction;
-          return 0;
-        });
-
-        return chartDef.limit > 0 ? points.slice(0, chartDef.limit) : points;
-      }
-
-      function buildPlotlyPayload(rows, chartDef) {
-        const grouped = aggregateRows(rows, chartDef);
-        const seriesValues = chartDef.seriesField
-          ? [...new Set(grouped.map((item) => item.series))]
-          : ['__single__'];
-        const traces = seriesValues.map((seriesKey) => {
-          const points = grouped.filter((item) => item.series === seriesKey);
-          const trace = {
-            type: chartDef.chartType === 'area' ? 'scatter' : chartDef.chartType,
-            name: seriesKey === '__single__' ? chartDef.title : String(seriesKey),
-            x: points.map((item) => item.x),
-            y: points.map((item) => item.y),
-          };
-          if (chartDef.chartType === 'line' || chartDef.chartType === 'area') {
-            trace.type = 'scatter';
-            trace.mode = chartDef.mode || 'lines+markers';
-            if (chartDef.chartType === 'area') trace.fill = 'tozeroy';
-          }
-          if (chartDef.chartType === 'scatter') {
-            trace.mode = chartDef.mode || 'markers';
-          }
-          if (chartDef.chartType === 'bar' && chartDef.orientation === 'h') {
-            trace.orientation = 'h';
-            trace.x = points.map((item) => item.y);
-            trace.y = points.map((item) => item.x);
-          }
-          if (chartDef.chartType === 'pie') {
-            trace.type = 'pie';
-            trace.labels = points.map((item) => item.x);
-            trace.values = points.map((item) => item.y);
-            delete trace.x;
-            delete trace.y;
-          }
-          return trace;
-        });
-        return {
-          data: traces,
-          layout: {
-            title: chartDef.title,
-            paper_bgcolor: 'rgba(0,0,0,0)',
-            plot_bgcolor: 'rgba(0,0,0,0)',
-            margin: { t: 56, r: 24, b: 56, l: 56 },
-            xaxis: chartDef.chartType === 'pie' ? undefined : { title: chartDef.xTitle || chartDef.xField },
-            yaxis: chartDef.chartType === 'pie' ? undefined : { title: chartDef.yTitle || chartDef.yField || chartDef.aggregation },
-            legend: { orientation: 'h' },
-          },
-          config: { responsive: true, displayModeBar: false },
-        };
-      }
-
-      function renderCharts() {
-        const filterState = Object.fromEntries(DASHBOARD_FILTER_SCHEMA.map((filterDef) => [filterDef.id, readFilterValue(filterDef)]));
-        const filteredRows = DASHBOARD_DATASET.filter((row) =>
-          DASHBOARD_FILTER_SCHEMA.every((filterDef) => rowMatchesFilter(row, filterDef, filterState[filterDef.id]))
-        );
-
-        DASHBOARD_CHART_DEFS.forEach((chartDef) => {
-          const statusNode = document.getElementById(chartDef.divId + '-status');
-          const plotNode = document.getElementById(chartDef.divId);
-          if (!plotNode) return;
-          const payload = buildPlotlyPayload(filteredRows, chartDef);
-          if (!payload.data.length || !payload.data.some((trace) => (trace.x && trace.x.length) || (trace.labels && trace.labels.length))) {
-            Plotly.purge(plotNode);
-            if (statusNode) statusNode.textContent = 'No data matches the current filters for this chart.';
-            return;
-          }
-          Plotly.newPlot(plotNode, payload.data, payload.layout, payload.config);
-          if (statusNode) statusNode.textContent = filteredRows.length + ' rows match the current filters.';
-        });
-      }
-
-      DASHBOARD_FILTER_SCHEMA.forEach((filterDef) => {
-        controlHost.appendChild(createControl(filterDef));
-      });
-      if (applyButton) applyButton.addEventListener('click', renderCharts);
-      if (resetButton) {
-        resetButton.addEventListener('click', () => {
-          DASHBOARD_FILTER_SCHEMA.forEach((filterDef) => {
-            const type = filterDef.resolvedType || inferFieldType(filterDef);
-            if (type === 'categorical') {
-              const select = document.getElementById(filterDef.id);
-              if (select) Array.from(select.options).forEach((option) => { option.selected = false; });
-            } else if (type === 'date' || type === 'datetime') {
-              const preset = document.getElementById(filterDef.id + '__preset');
-              const start = document.getElementById(filterDef.id + '__start');
-              const end = document.getElementById(filterDef.id + '__end');
-              if (preset) preset.value = '';
-              if (start) start.value = '';
-              if (end) end.value = '';
-            } else {
-              const minInput = document.getElementById(filterDef.id + '__min');
-              const maxInput = document.getElementById(filterDef.id + '__max');
-              if (minInput) minInput.value = '';
-              if (maxInput) maxInput.value = '';
-            }
-          });
-          renderCharts();
-        });
-      }
-      renderCharts();
-    })();
-            """,
-            "  </script>",
-            "</body>",
-            "</html>",
+        dashboard_metric_cards = [
+            {
+                "label": "Charts Embedded",
+                "value": str(len(bound_cards) + len(static_cards)),
+                "meta": "Across live and appendix sections",
+            },
+            {
+                "label": "Filter-Aware",
+                "value": str(len(bound_cards)),
+                "meta": "Charts bound to the canonical dataset",
+            },
+            {
+                "label": "Static Appendix",
+                "value": str(len(static_cards)),
+                "meta": "Snapshot-only visual artifacts",
+            },
+            {
+                "label": "Dataset Rows",
+                "value": str(len(dataset_records)) if dataset_records else "n/a",
+                "meta": "Browser-side filter dataset payload",
+            },
         ]
+        filter_panel_html = ""
+        if data_filtering_enabled:
+            filter_panel_html = (
+                "<section class=\"filter-card\">"
+                "<h2>Shared data filters</h2>"
+                "<p>These controls update all compatible charts from the embedded dashboard dataset.</p>"
+                "<div id=\"dashboard-filter-controls\" class=\"filter-controls\"></div>"
+                "<div class=\"filter-actions\">"
+                "<button type=\"button\" id=\"dashboard-apply-filters\" class=\"secondary\">Apply filters</button>"
+                "<button type=\"button\" id=\"dashboard-reset-filters\">Reset filters</button>"
+                "</div>"
+                f"<div class=\"dataset-meta\">Dataset: {html.escape(dashboard_dataset_path)} • Rows embedded: {len(dataset_records)} • Format: {html.escape(dataset_format)}</div>"
+                "</section>"
+            )
+        html_output = render_dashboard_html(
+            title=title,
+            description=description,
+            generated_at=generated_at,
+            hero_meta=hero_meta,
+            metric_cards=dashboard_metric_cards,
+            filter_panel_html=filter_panel_html,
+            primary_cards=bound_cards or static_cards,
+            appendix_cards=static_cards if bound_cards and static_cards else [],
+            query_items=query_items,
+            dataset_records=dataset_records,
+            filter_config=filter_config,
+            chart_runtime_defs=chart_runtime_defs,
+            dataset_schema=dataset_schema,
+            highlights_heading="Highlights" if bound_cards else "Charts",
         )
 
         try:
             dashboard_path.parent.mkdir(parents=True, exist_ok=True)
-            dashboard_path.write_text("\n".join(html_lines), encoding="utf-8")
+            dashboard_path.write_text(html_output, encoding="utf-8")
             artifact = {
                 "path": _workspace_rel(dashboard_path, workspace_state.root_path),
                 "mimeType": ALLOWED_ARTIFACT_EXTENSIONS[".html"],

--- a/agent/helpudoc_agent/data_report_renderers.py
+++ b/agent/helpudoc_agent/data_report_renderers.py
@@ -1,0 +1,956 @@
+from __future__ import annotations
+
+import html
+import json
+from typing import Any, Dict, List, Optional
+
+
+PLOTLY_CDN = "https://cdn.plot.ly/plotly-3.3.0.min.js"
+
+SUMMARY_CSS = """
+    :root {
+      --bg: #f3ede2;
+      --panel: rgba(255, 251, 245, 0.94);
+      --panel-strong: #fffdf8;
+      --ink: #24313f;
+      --muted: #667085;
+      --line: rgba(143, 119, 91, 0.18);
+      --accent: #0f5c4d;
+      --accent-soft: rgba(15, 92, 77, 0.12);
+      --warm: #c9792b;
+      --shadow: 0 22px 60px rgba(71, 51, 25, 0.12);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      color: var(--ink);
+      background:
+        radial-gradient(circle at top left, rgba(201, 121, 43, 0.16), transparent 28%),
+        radial-gradient(circle at top right, rgba(15, 92, 77, 0.14), transparent 26%),
+        linear-gradient(180deg, #f9f5ef 0%, var(--bg) 100%);
+      font-family: "Avenir Next", "Segoe UI", sans-serif;
+    }
+    .shell { max-width: 1140px; margin: 0 auto; padding: 28px 20px 56px; }
+    .hero, .panel {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 28px;
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(8px);
+    }
+    .hero {
+      padding: 32px;
+      position: relative;
+      overflow: hidden;
+    }
+    .hero::after {
+      content: "";
+      position: absolute;
+      inset: auto -40px -60px auto;
+      width: 220px;
+      height: 220px;
+      border-radius: 999px;
+      background: radial-gradient(circle, rgba(201, 121, 43, 0.22), transparent 70%);
+      pointer-events: none;
+    }
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 12px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.72);
+      color: var(--accent);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .hero h1 {
+      margin: 16px 0 10px;
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-size: clamp(2.2rem, 5vw, 4rem);
+      line-height: 0.98;
+      letter-spacing: -0.04em;
+    }
+    .hero p {
+      max-width: 760px;
+      margin: 0;
+      color: #455467;
+      font-size: 1rem;
+      line-height: 1.7;
+    }
+    .hero-meta {
+      margin-top: 18px;
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+    .metric-section { margin-top: 22px; }
+    .metric-heading {
+      margin: 0 0 12px;
+      font-size: 0.86rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+    .metric-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 14px;
+    }
+    .metric-card {
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(255, 250, 244, 0.95));
+      border: 1px solid rgba(143, 119, 91, 0.14);
+      border-radius: 20px;
+      padding: 18px;
+      min-height: 132px;
+    }
+    .metric-label {
+      color: var(--muted);
+      font-size: 0.8rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    .metric-value {
+      margin-top: 10px;
+      font-size: clamp(1.8rem, 3vw, 2.5rem);
+      font-weight: 700;
+      line-height: 1;
+    }
+    .metric-meta {
+      margin-top: 10px;
+      color: #516172;
+      font-size: 0.92rem;
+      line-height: 1.5;
+    }
+    .panel { margin-top: 22px; padding: 28px 30px; }
+    .panel h2 {
+      margin: 0 0 14px;
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-size: 1.7rem;
+      letter-spacing: -0.03em;
+    }
+    .panel h3 { margin: 0 0 10px; font-size: 1.08rem; }
+    .panel h4 { margin: 18px 0 8px; font-size: 0.96rem; color: var(--muted); }
+    .panel p, .agent-markdown { line-height: 1.7; }
+    .agent-markdown code, .panel code {
+      background: rgba(15, 92, 77, 0.08);
+      border-radius: 8px;
+      padding: 0.16rem 0.42rem;
+      font-size: 0.92em;
+    }
+    .stack { display: grid; gap: 16px; }
+    .stack-item {
+      background: var(--panel-strong);
+      border: 1px solid var(--line);
+      border-radius: 20px;
+      padding: 18px;
+    }
+    .stack-meta {
+      margin-bottom: 10px;
+      color: var(--muted);
+      font-size: 0.88rem;
+    }
+    table {
+      width: 100%;
+      border-collapse: separate;
+      border-spacing: 0;
+      overflow: hidden;
+      border-radius: 16px;
+      border: 1px solid var(--line);
+      background: #fff;
+    }
+    table thead { background: rgba(15, 92, 77, 0.08); }
+    table th, table td {
+      padding: 10px 12px;
+      border-bottom: 1px solid rgba(143, 119, 91, 0.12);
+      text-align: left;
+      font-size: 0.95rem;
+    }
+    table tr:last-child td { border-bottom: 0; }
+    pre {
+      margin: 0;
+      background: #17212b;
+      color: #e9eff5;
+      padding: 14px 16px;
+      border-radius: 16px;
+      overflow-x: auto;
+      white-space: pre-wrap;
+    }
+    img {
+      max-width: 100%;
+      display: block;
+      border-radius: 18px;
+      border: 1px solid var(--line);
+    }
+    .plotly-embed { width: 100%; min-height: 420px; }
+    .split-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 18px;
+    }
+    @media (max-width: 768px) {
+      .shell { padding: 16px 14px 40px; }
+      .hero, .panel { padding: 22px 18px; border-radius: 22px; }
+      .plotly-embed { min-height: 320px; }
+    }
+"""
+
+SUMMARY_SUBTITLE = (
+    "A polished, self-contained analysis artifact that combines narrative findings, "
+    "SQL evidence, and the visual outputs created during this run."
+)
+
+DASHBOARD_CSS = """
+    :root {
+      --bg: #f3ede2;
+      --panel: rgba(255, 251, 245, 0.94);
+      --panel-strong: #fffdf8;
+      --ink: #24313f;
+      --muted: #667085;
+      --line: rgba(143, 119, 91, 0.18);
+      --accent: #0f5c4d;
+      --accent-soft: rgba(15, 92, 77, 0.1);
+      --warm: #c9792b;
+      --shadow: 0 22px 60px rgba(71, 51, 25, 0.12);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      color: var(--ink);
+      background:
+        radial-gradient(circle at top left, rgba(201, 121, 43, 0.16), transparent 28%),
+        radial-gradient(circle at top right, rgba(15, 92, 77, 0.14), transparent 26%),
+        linear-gradient(180deg, #f9f5ef 0%, var(--bg) 100%);
+      font-family: "Avenir Next", "Segoe UI", sans-serif;
+    }
+    .shell { max-width: 1340px; margin: 0 auto; padding: 28px 20px 56px; }
+    .hero, .section, .filter-card {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 28px;
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(8px);
+    }
+    .hero { padding: 32px; position: relative; overflow: hidden; }
+    .hero::after {
+      content: "";
+      position: absolute;
+      inset: auto -40px -60px auto;
+      width: 240px;
+      height: 240px;
+      border-radius: 999px;
+      background: radial-gradient(circle, rgba(15, 92, 77, 0.18), transparent 70%);
+      pointer-events: none;
+    }
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 12px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.72);
+      color: var(--accent);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .hero h1 {
+      margin: 16px 0 10px;
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-size: clamp(2.4rem, 5vw, 4.3rem);
+      line-height: 0.96;
+      letter-spacing: -0.05em;
+    }
+    .hero p {
+      max-width: 760px;
+      margin: 0;
+      color: #455467;
+      font-size: 1rem;
+      line-height: 1.72;
+    }
+    .hero-meta { margin-top: 18px; color: var(--muted); font-size: 0.92rem; }
+    .metric-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 14px;
+      margin-top: 22px;
+    }
+    .metric-card {
+      background: linear-gradient(180deg, rgba(255,255,255,0.86), rgba(255, 250, 244, 0.96));
+      border: 1px solid rgba(143, 119, 91, 0.14);
+      border-radius: 20px;
+      padding: 18px;
+      min-height: 132px;
+    }
+    .metric-label {
+      color: var(--muted);
+      font-size: 0.8rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    .metric-value {
+      margin-top: 10px;
+      font-size: clamp(1.8rem, 3vw, 2.5rem);
+      font-weight: 700;
+      line-height: 1;
+    }
+    .metric-meta {
+      margin-top: 10px;
+      color: #516172;
+      font-size: 0.92rem;
+      line-height: 1.5;
+    }
+    .section, .filter-card { margin-top: 22px; padding: 28px 30px; }
+    .section h2, .filter-card h2 {
+      margin: 0 0 12px;
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-size: 1.75rem;
+      letter-spacing: -0.03em;
+    }
+    .chart-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 18px;
+    }
+    .chart-card {
+      background: linear-gradient(180deg, #fffefb 0%, #fbf8f2 100%);
+      border: 1px solid var(--line);
+      border-radius: 22px;
+      padding: 18px;
+      min-height: 100%;
+    }
+    .chart-card.filter-aware { grid-column: span 1; }
+    .chart-card h3 { margin: 0 0 8px; font-size: 1.08rem; }
+    .chart-meta {
+      margin: 0 0 12px;
+      color: var(--muted);
+      font-size: 0.88rem;
+    }
+    .chart-note {
+      margin: 10px 0 0;
+      color: #516172;
+      font-size: 0.92rem;
+      line-height: 1.5;
+    }
+    .plotly-embed { width: 100%; height: 340px; }
+    img.chart-img {
+      width: 100%;
+      border-radius: 16px;
+      border: 1px solid var(--line);
+    }
+    .filter-controls {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 12px;
+    }
+    .filter-control { display: flex; flex-direction: column; gap: 6px; }
+    .filter-control label {
+      font-size: 0.88rem;
+      font-weight: 700;
+      color: #374151;
+    }
+    .filter-control select,
+    .filter-control input,
+    .filter-actions button {
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      padding: 10px 12px;
+      background: #fff;
+      color: var(--ink);
+      font: inherit;
+    }
+    .filter-actions {
+      display: flex;
+      gap: 10px;
+      align-items: end;
+      margin-top: 14px;
+    }
+    .filter-actions button {
+      cursor: pointer;
+      background: var(--accent);
+      color: #fff;
+      font-weight: 700;
+    }
+    .filter-actions button.secondary {
+      background: #fff;
+      color: var(--ink);
+    }
+    .dataset-meta { margin-top: 14px; color: var(--muted); font-size: 0.86rem; }
+    details.appendix { margin-top: 18px; }
+    summary {
+      cursor: pointer;
+      color: var(--accent);
+      font-weight: 700;
+      list-style: none;
+    }
+    summary::-webkit-details-marker { display: none; }
+    .query-item {
+      background: #faf7f1;
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      padding: 16px;
+      margin-top: 12px;
+    }
+    .query-meta {
+      font-size: 0.82rem;
+      color: var(--warm);
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+      margin-bottom: 8px;
+    }
+    .query-block {
+      margin: 0;
+      background: #fff;
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      padding: 14px 16px;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      color: #374151;
+    }
+    @media (max-width: 768px) {
+      .shell { padding: 16px 14px 40px; }
+      .hero, .section, .filter-card { padding: 22px 18px; border-radius: 22px; }
+      .chart-grid { grid-template-columns: 1fr; }
+      .plotly-embed { height: 300px; }
+    }
+"""
+
+DASHBOARD_FILTER_SCRIPT = """
+    (function() {
+      if (!DASHBOARD_DATASET.length || !DASHBOARD_FILTER_SCHEMA.length || !DASHBOARD_CHART_DEFS.length) {
+        return;
+      }
+
+      const controlHost = document.getElementById('dashboard-filter-controls');
+      const applyButton = document.getElementById('dashboard-apply-filters');
+      const resetButton = document.getElementById('dashboard-reset-filters');
+      const fieldTypes = Object.fromEntries((DASHBOARD_DATASET_SCHEMA || []).map((item) => [item.name, String(item.type || '').toLowerCase()]));
+
+      function inferFieldType(filterDef) {
+        if (filterDef.type === 'numeric' || filterDef.type === 'date' || filterDef.type === 'datetime') {
+          return filterDef.type;
+        }
+        const raw = fieldTypes[filterDef.field] || '';
+        if (raw.includes('date') || raw.includes('time')) return 'date';
+        if (raw.includes('int') || raw.includes('float') || raw.includes('double') || raw.includes('decimal')) return 'numeric';
+        return 'categorical';
+      }
+
+      function parseDateValue(value) {
+        if (value === null || value === undefined || value === '') return null;
+        const parsed = new Date(value);
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
+      }
+
+      function parseNumericValue(value) {
+        if (value === null || value === undefined || value === '') return null;
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : null;
+      }
+
+      function normalizeComparable(value, type) {
+        if (type === 'date' || type === 'datetime') {
+          const parsed = parseDateValue(value);
+          return parsed ? parsed.getTime() : null;
+        }
+        if (type === 'numeric') {
+          return parseNumericValue(value);
+        }
+        return value;
+      }
+
+      function distinctValues(field) {
+        const values = [];
+        const seen = new Set();
+        DASHBOARD_DATASET.forEach((row) => {
+          const value = row[field];
+          const key = value === null || value === undefined ? '__null__' : String(value);
+          if (!seen.has(key) && value !== null && value !== undefined && value !== '') {
+            seen.add(key);
+            values.push(value);
+          }
+        });
+        return values.sort((a, b) => String(a).localeCompare(String(b)));
+      }
+
+      function fieldExtent(field, type) {
+        let min = null;
+        let max = null;
+        DASHBOARD_DATASET.forEach((row) => {
+          const value = normalizeComparable(row[field], type);
+          if (value === null) return;
+          if (min === null || value < min) min = value;
+          if (max === null || value > max) max = value;
+        });
+        return { min, max };
+      }
+
+      function createControl(filterDef) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'filter-control';
+        const label = document.createElement('label');
+        label.textContent = filterDef.label;
+        wrapper.appendChild(label);
+        const fieldType = inferFieldType(filterDef);
+        filterDef.resolvedType = fieldType;
+
+        if (fieldType === 'categorical') {
+          const select = document.createElement('select');
+          select.id = filterDef.id;
+          if (filterDef.multi) select.multiple = true;
+          const values = (filterDef.options && filterDef.options.length ? filterDef.options : distinctValues(filterDef.field));
+          values.forEach((value) => {
+            const option = document.createElement('option');
+            option.value = String(value);
+            option.textContent = String(value);
+            select.appendChild(option);
+          });
+          wrapper.appendChild(select);
+          return wrapper;
+        }
+
+        if (fieldType === 'date' || fieldType === 'datetime') {
+          const extent = fieldExtent(filterDef.field, 'date');
+          const preset = document.createElement('select');
+          preset.id = filterDef.id + '__preset';
+          ['', 'last_30_days', 'last_90_days', 'last_180_days'].forEach((value) => {
+            const option = document.createElement('option');
+            option.value = value;
+            option.textContent = value ? value.replaceAll('_', ' ') : 'Custom range';
+            preset.appendChild(option);
+          });
+          wrapper.appendChild(preset);
+          const startInput = document.createElement('input');
+          startInput.type = 'date';
+          startInput.id = filterDef.id + '__start';
+          const endInput = document.createElement('input');
+          endInput.type = 'date';
+          endInput.id = filterDef.id + '__end';
+          if (extent.min !== null) startInput.value = new Date(extent.min).toISOString().slice(0, 10);
+          if (extent.max !== null) endInput.value = new Date(extent.max).toISOString().slice(0, 10);
+          preset.addEventListener('change', () => {
+            if (!preset.value || extent.max === null) return;
+            const end = new Date(extent.max);
+            const start = new Date(end);
+            const days = preset.value === 'last_30_days' ? 30 : preset.value === 'last_90_days' ? 90 : 180;
+            start.setDate(start.getDate() - days);
+            startInput.value = start.toISOString().slice(0, 10);
+            endInput.value = end.toISOString().slice(0, 10);
+          });
+          wrapper.appendChild(startInput);
+          wrapper.appendChild(endInput);
+          return wrapper;
+        }
+
+        const extent = fieldExtent(filterDef.field, 'numeric');
+        const minInput = document.createElement('input');
+        minInput.type = 'number';
+        minInput.id = filterDef.id + '__min';
+        minInput.placeholder = extent.min === null ? 'Min' : String(extent.min);
+        const maxInput = document.createElement('input');
+        maxInput.type = 'number';
+        maxInput.id = filterDef.id + '__max';
+        maxInput.placeholder = extent.max === null ? 'Max' : String(extent.max);
+        wrapper.appendChild(minInput);
+        wrapper.appendChild(maxInput);
+        return wrapper;
+      }
+
+      function readFilterValue(filterDef) {
+        const type = filterDef.resolvedType || inferFieldType(filterDef);
+        if (type === 'categorical') {
+          const select = document.getElementById(filterDef.id);
+          return Array.from(select ? select.selectedOptions : []).map((option) => option.value);
+        }
+        if (type === 'date' || type === 'datetime') {
+          return {
+            start: document.getElementById(filterDef.id + '__start')?.value || '',
+            end: document.getElementById(filterDef.id + '__end')?.value || '',
+          };
+        }
+        return {
+          min: document.getElementById(filterDef.id + '__min')?.value || '',
+          max: document.getElementById(filterDef.id + '__max')?.value || '',
+        };
+      }
+
+      function rowMatchesFilter(row, filterDef, value) {
+        const type = filterDef.resolvedType || inferFieldType(filterDef);
+        const rowValue = row[filterDef.field];
+        if (type === 'categorical') {
+          if (!value || !value.length) return true;
+          return value.includes(String(rowValue));
+        }
+        if (type === 'date' || type === 'datetime') {
+          const rowTime = normalizeComparable(rowValue, 'date');
+          if (rowTime === null) return false;
+          const start = value.start ? parseDateValue(value.start) : null;
+          const end = value.end ? parseDateValue(value.end) : null;
+          if (start && rowTime < start.getTime()) return false;
+          if (end) {
+            const inclusiveEnd = new Date(end);
+            inclusiveEnd.setHours(23, 59, 59, 999);
+            if (rowTime > inclusiveEnd.getTime()) return false;
+          }
+          return true;
+        }
+        const numericValue = normalizeComparable(rowValue, 'numeric');
+        if (numericValue === null) return false;
+        const minValue = parseNumericValue(value.min);
+        const maxValue = parseNumericValue(value.max);
+        if (minValue !== null && numericValue < minValue) return false;
+        if (maxValue !== null && numericValue > maxValue) return false;
+        return true;
+      }
+
+      function aggregateRows(rows, chartDef) {
+        const map = new Map();
+        rows.forEach((row) => {
+          const xValue = row[chartDef.xField];
+          const seriesValue = chartDef.seriesField ? row[chartDef.seriesField] : '__single__';
+          const key = JSON.stringify([xValue, seriesValue]);
+          if (!map.has(key)) {
+            map.set(key, { x: xValue, series: seriesValue, count: 0, sum: 0, min: null, max: null, values: [] });
+          }
+          const bucket = map.get(key);
+          bucket.count += 1;
+          const yRaw = chartDef.yField ? parseNumericValue(row[chartDef.yField]) : null;
+          if (yRaw !== null) {
+            bucket.sum += yRaw;
+            bucket.min = bucket.min === null ? yRaw : Math.min(bucket.min, yRaw);
+            bucket.max = bucket.max === null ? yRaw : Math.max(bucket.max, yRaw);
+            bucket.values.push(yRaw);
+          }
+        });
+
+        const points = Array.from(map.values()).map((bucket) => {
+          let yValue = bucket.count;
+          switch (chartDef.aggregation) {
+            case 'sum':
+              yValue = bucket.sum;
+              break;
+            case 'avg':
+            case 'mean':
+              yValue = bucket.values.length ? bucket.sum / bucket.values.length : 0;
+              break;
+            case 'min':
+              yValue = bucket.min === null ? 0 : bucket.min;
+              break;
+            case 'max':
+              yValue = bucket.max === null ? 0 : bucket.max;
+              break;
+            case 'nunique':
+            case 'count_distinct':
+              yValue = new Set(bucket.values).size;
+              break;
+            case 'count':
+            default:
+              yValue = bucket.count;
+              break;
+          }
+          return { x: bucket.x, y: yValue, series: bucket.series };
+        });
+
+        points.sort((left, right) => {
+          const direction = chartDef.sortDirection === 'asc' ? 1 : -1;
+          const leftValue = chartDef.sortBy === 'x' ? String(left.x ?? '') : Number(left.y ?? 0);
+          const rightValue = chartDef.sortBy === 'x' ? String(right.x ?? '') : Number(right.y ?? 0);
+          if (leftValue < rightValue) return -1 * direction;
+          if (leftValue > rightValue) return 1 * direction;
+          return 0;
+        });
+
+        return chartDef.limit > 0 ? points.slice(0, chartDef.limit) : points;
+      }
+
+      function buildPlotlyPayload(rows, chartDef) {
+        const grouped = aggregateRows(rows, chartDef);
+        const seriesValues = chartDef.seriesField
+          ? [...new Set(grouped.map((item) => item.series))]
+          : ['__single__'];
+        const traces = seriesValues.map((seriesKey) => {
+          const points = grouped.filter((item) => item.series === seriesKey);
+          const trace = {
+            type: chartDef.chartType === 'area' ? 'scatter' : chartDef.chartType,
+            name: seriesKey === '__single__' ? chartDef.title : String(seriesKey),
+            x: points.map((item) => item.x),
+            y: points.map((item) => item.y),
+          };
+          if (chartDef.chartType === 'line' || chartDef.chartType === 'area') {
+            trace.type = 'scatter';
+            trace.mode = chartDef.mode || 'lines+markers';
+            if (chartDef.chartType === 'area') trace.fill = 'tozeroy';
+          }
+          if (chartDef.chartType === 'scatter') {
+            trace.mode = chartDef.mode || 'markers';
+          }
+          if (chartDef.chartType === 'bar' && chartDef.orientation === 'h') {
+            trace.orientation = 'h';
+            trace.x = points.map((item) => item.y);
+            trace.y = points.map((item) => item.x);
+          }
+          if (chartDef.chartType === 'pie') {
+            trace.type = 'pie';
+            trace.labels = points.map((item) => item.x);
+            trace.values = points.map((item) => item.y);
+            delete trace.x;
+            delete trace.y;
+          }
+          return trace;
+        });
+        return {
+          data: traces,
+          layout: {
+            title: chartDef.title,
+            template: 'plotly_white',
+            colorway: ['#0f5c4d', '#c9792b', '#2f6db0', '#7b5ea7', '#d35f5f'],
+            font: { family: '"Avenir Next", "Segoe UI", sans-serif', color: '#24313f' },
+            paper_bgcolor: 'rgba(0,0,0,0)',
+            plot_bgcolor: 'rgba(0,0,0,0)',
+            margin: { t: 56, r: 24, b: 56, l: 56 },
+            xaxis: chartDef.chartType === 'pie' ? undefined : { title: chartDef.xTitle || chartDef.xField },
+            yaxis: chartDef.chartType === 'pie' ? undefined : { title: chartDef.yTitle || chartDef.yField || chartDef.aggregation },
+            legend: { orientation: 'h' },
+          },
+          config: { responsive: true, displayModeBar: false },
+        };
+      }
+
+      function renderCharts() {
+        const filterState = Object.fromEntries(DASHBOARD_FILTER_SCHEMA.map((filterDef) => [filterDef.id, readFilterValue(filterDef)]));
+        const filteredRows = DASHBOARD_DATASET.filter((row) =>
+          DASHBOARD_FILTER_SCHEMA.every((filterDef) => rowMatchesFilter(row, filterDef, filterState[filterDef.id]))
+        );
+
+        DASHBOARD_CHART_DEFS.forEach((chartDef) => {
+          const statusNode = document.getElementById(chartDef.divId + '-status');
+          const plotNode = document.getElementById(chartDef.divId);
+          if (!plotNode) return;
+          const payload = buildPlotlyPayload(filteredRows, chartDef);
+          if (!payload.data.length || !payload.data.some((trace) => (trace.x && trace.x.length) || (trace.labels && trace.labels.length))) {
+            Plotly.purge(plotNode);
+            if (statusNode) statusNode.textContent = 'No data matches the current filters for this chart.';
+            return;
+          }
+          Plotly.newPlot(plotNode, payload.data, payload.layout, payload.config);
+          if (statusNode) statusNode.textContent = filteredRows.length + ' rows match the current filters.';
+        });
+      }
+
+      DASHBOARD_FILTER_SCHEMA.forEach((filterDef) => {
+        controlHost.appendChild(createControl(filterDef));
+      });
+      if (applyButton) applyButton.addEventListener('click', renderCharts);
+      if (resetButton) {
+        resetButton.addEventListener('click', () => {
+          DASHBOARD_FILTER_SCHEMA.forEach((filterDef) => {
+            const type = filterDef.resolvedType || inferFieldType(filterDef);
+            if (type === 'categorical') {
+              const select = document.getElementById(filterDef.id);
+              if (select) Array.from(select.options).forEach((option) => { option.selected = false; });
+            } else if (type === 'date' || type === 'datetime') {
+              const preset = document.getElementById(filterDef.id + '__preset');
+              const start = document.getElementById(filterDef.id + '__start');
+              const end = document.getElementById(filterDef.id + '__end');
+              if (preset) preset.value = '';
+              if (start) start.value = '';
+              if (end) end.value = '';
+            } else {
+              const minInput = document.getElementById(filterDef.id + '__min');
+              const maxInput = document.getElementById(filterDef.id + '__max');
+              if (minInput) minInput.value = '';
+              if (maxInput) maxInput.value = '';
+            }
+          });
+          renderCharts();
+        });
+      }
+      renderCharts();
+    })();
+"""
+
+
+def _render_metric_cards(cards: List[Dict[str, str]], heading: str) -> str:
+    if not cards:
+        return ""
+    card_html = []
+    for card in cards:
+        card_html.append(
+            "<article class=\"metric-card\">"
+            f"<div class=\"metric-label\">{html.escape(card.get('label', 'Metric'))}</div>"
+            f"<div class=\"metric-value\">{html.escape(card.get('value', '0'))}</div>"
+            f"<div class=\"metric-meta\">{html.escape(card.get('meta', ''))}</div>"
+            "</article>"
+        )
+    return (
+        "<section class=\"metric-section\">"
+        f"<div class=\"metric-heading\">{html.escape(heading)}</div>"
+        "<div class=\"metric-grid\">"
+        + "".join(card_html)
+        + "</div></section>"
+    )
+
+
+def render_summary_html(
+    *,
+    title: str,
+    generated_at: str,
+    summary_html: str,
+    insights_html: str,
+    metric_cards: List[Dict[str, str]],
+    materialization_items: List[str],
+    query_items: List[str],
+    visualization_items: List[str],
+) -> str:
+    sections: List[str] = [
+        "<section class=\"panel\">"
+        "<div class=\"split-grid\">"
+        "<div>"
+        "<h2>Summary</h2>"
+        f"<div class=\"agent-markdown\">{summary_html or '<p>No summary provided.</p>'}</div>"
+        "</div>"
+        "<div>"
+        "<h2>Key Insights</h2>"
+        f"<div class=\"agent-markdown\">{insights_html or '<p>No insights provided.</p>'}</div>"
+        "</div>"
+        "</div>"
+        "</section>"
+    ]
+    if materialization_items:
+        sections.append(
+            "<section class=\"panel\">"
+            "<h2>Warehouse Materializations</h2>"
+            "<div class=\"stack\">"
+            + "".join(materialization_items)
+            + "</div></section>"
+        )
+    if query_items:
+        sections.append(
+            "<section class=\"panel\">"
+            "<h2>SQL Queries</h2>"
+            "<div class=\"stack\">"
+            + "".join(query_items)
+            + "</div></section>"
+        )
+    if visualization_items:
+        sections.append(
+            "<section class=\"panel\">"
+            "<h2>Visualizations</h2>"
+            "<div class=\"stack\">"
+            + "".join(visualization_items)
+            + "</div></section>"
+        )
+
+    return "\n".join(
+        [
+            "<!doctype html>",
+            "<html lang=\"en\">",
+            "<head>",
+            "  <meta charset=\"utf-8\" />",
+            "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />",
+            f"  <title>{html.escape(title)}</title>",
+            "  <style>",
+            SUMMARY_CSS,
+            "  </style>",
+            f"  <script src=\"{PLOTLY_CDN}\"></script>",
+            "</head>",
+            "<body>",
+            "  <div class=\"shell\">",
+            "    <section class=\"hero\">",
+            "      <div class=\"eyebrow\">Narrative Report</div>",
+            f"      <h1>{html.escape(title)}</h1>",
+            f"      <p>{html.escape(SUMMARY_SUBTITLE)}</p>",
+            f"      <div class=\"hero-meta\">Generated {html.escape(generated_at)}</div>",
+            _render_metric_cards(metric_cards, "Executive Snapshot"),
+            "    </section>",
+            *sections,
+            "  </div>",
+            "</body>",
+            "</html>",
+        ]
+    )
+
+
+def render_dashboard_html(
+    *,
+    title: str,
+    description: str,
+    generated_at: str,
+    hero_meta: str,
+    metric_cards: List[Dict[str, str]],
+    filter_panel_html: str,
+    primary_cards: List[str],
+    appendix_cards: List[str],
+    query_items: List[str],
+    dataset_records: List[Dict[str, Any]],
+    filter_config: List[Dict[str, Any]],
+    chart_runtime_defs: List[Dict[str, Any]],
+    dataset_schema: List[Dict[str, Any]],
+    highlights_heading: str,
+) -> str:
+    primary_cards_html = "".join(primary_cards)
+    appendix_html = (
+        "<details class=\"appendix\">"
+        "<summary>Static appendix charts</summary>"
+        "<div class=\"chart-grid\">"
+        + "".join(appendix_cards)
+        + "</div></details>"
+        if appendix_cards
+        else ""
+    )
+    query_html = (
+        "<details class=\"appendix\">"
+        "<summary>Technical appendix</summary>"
+        + "".join(query_items)
+        + "</details>"
+    )
+    return "\n".join(
+        [
+            "<!doctype html>",
+            "<html lang=\"en\">",
+            "<head>",
+            "  <meta charset=\"utf-8\" />",
+            "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />",
+            f"  <title>{html.escape(title)}</title>",
+            "  <style>",
+            DASHBOARD_CSS,
+            "  </style>",
+            f"  <script src=\"{PLOTLY_CDN}\"></script>",
+            "</head>",
+            "<body>",
+            "  <div class=\"shell\">",
+            "    <section class=\"hero\">",
+            "      <div class=\"eyebrow\">Interactive Dashboard</div>",
+            f"      <h1>{html.escape(title)}</h1>",
+            f"      <p>{html.escape(description)}</p>",
+            f"      <div class=\"hero-meta\">Generated {html.escape(generated_at)} • {html.escape(hero_meta)}</div>",
+            _render_metric_cards(metric_cards, "Quick Pulse"),
+            "    </section>",
+            filter_panel_html,
+            "    <section class=\"section\">",
+            f"      <h2>{html.escape(highlights_heading)}</h2>",
+            "      <div class=\"chart-grid\">",
+            primary_cards_html,
+            "      </div>",
+            appendix_html,
+            query_html,
+            "    </section>",
+            "  </div>",
+            "  <script>",
+            f"    const DASHBOARD_DATASET = {json.dumps(dataset_records, ensure_ascii=False)};",
+            f"    const DASHBOARD_FILTER_SCHEMA = {json.dumps(filter_config, ensure_ascii=False)};",
+            f"    const DASHBOARD_CHART_DEFS = {json.dumps(chart_runtime_defs, ensure_ascii=False)};",
+            f"    const DASHBOARD_DATASET_SCHEMA = {json.dumps(dataset_schema, ensure_ascii=False)};",
+            DASHBOARD_FILTER_SCRIPT,
+            "  </script>",
+            "</body>",
+            "</html>",
+        ]
+    )

--- a/agent/tests/test_data_agent_tools.py
+++ b/agent/tests/test_data_agent_tools.py
@@ -36,6 +36,19 @@ class DataAgentToolsTest(unittest.TestCase):
             self.assertIn("charts/plot.png", snapshot)
             self.assertNotIn("node_modules/pkg/ignored.png", snapshot)
 
+    def test_snapshot_workspace_falls_back_to_full_scan_for_off_path_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "reports").mkdir()
+            (root / "reports" / "summary.html").write_text("<h1>ok</h1>", encoding="utf-8")
+            (root / "README.md").write_text("readme", encoding="utf-8")
+            (root / "custom_artifacts").mkdir()
+            (root / "custom_artifacts" / "chart.png").write_bytes(b"png")
+
+            snapshot = _snapshot_workspace(root)
+
+            self.assertIn("custom_artifacts/chart.png", snapshot)
+
     def test_register_files_prefers_data_directories(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -148,6 +161,35 @@ class DataAgentToolsTest(unittest.TestCase):
                 {
                     "sql_query": (
                         "SELECT order_id, MAX(revenue) OVER () AS max_revenue "
+                        "FROM orders"
+                    )
+                }
+            )
+
+            self.assertIn("Execution was safety-capped at 1000 rows.", raw)
+            manager = workspace.context["data_agent_manager"]
+            self.assertEqual(len(manager.session.last_query_result), 1000)
+            self.assertTrue(manager.session.query_history[-1].truncated)
+
+    def test_run_sql_query_caps_scalar_subquery_aggregate_results(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "datasets").mkdir()
+            rows = ["order_id,revenue"]
+            rows.extend(f"{i},{i * 10}" for i in range(1105))
+            (root / "datasets" / "orders.csv").write_text(
+                "\n".join(rows) + "\n",
+                encoding="utf-8",
+            )
+            workspace = self._workspace(root)
+            tools = self._tool_map(workspace)
+
+            tools["get_table_schema"].invoke({"table_names": ["orders"]})
+            raw = tools["run_sql_query"].invoke(
+                {
+                    "sql_query": (
+                        "SELECT order_id, "
+                        "(SELECT COUNT(*) FROM orders) AS total_orders "
                         "FROM orders"
                     )
                 }

--- a/agent/tests/test_data_agent_tools.py
+++ b/agent/tests/test_data_agent_tools.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from helpudoc_agent.data_agent_tools import (
     DuckDBManager,
+    _format_sample_value,
     _snapshot_workspace,
     build_data_agent_tools,
 )
@@ -72,6 +73,11 @@ class DataAgentToolsTest(unittest.TestCase):
             self.assertIn("[examples: 'active', 'pending']", raw)
             self.assertIn("revenue (BIGINT)", raw)
 
+    def test_format_sample_value_handles_non_scalar_values(self) -> None:
+        rendered = _format_sample_value({"segments": ["vip", "trial"]})
+        self.assertIn("segments", rendered)
+        self.assertIn("vip", rendered)
+
     def test_run_sql_query_keeps_aggregate_results_intact(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -120,6 +126,34 @@ class DataAgentToolsTest(unittest.TestCase):
             self.assertIn("Result shape: 1000 rows x 2 columns.", raw)
             self.assertIn("Execution was safety-capped at 1000 rows.", raw)
             self.assertIn("Numeric summary:", raw)
+            manager = workspace.context["data_agent_manager"]
+            self.assertEqual(len(manager.session.last_query_result), 1000)
+            self.assertTrue(manager.session.query_history[-1].truncated)
+
+    def test_run_sql_query_caps_window_function_results(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "datasets").mkdir()
+            rows = ["order_id,revenue"]
+            rows.extend(f"{i},{i * 10}" for i in range(1105))
+            (root / "datasets" / "orders.csv").write_text(
+                "\n".join(rows) + "\n",
+                encoding="utf-8",
+            )
+            workspace = self._workspace(root)
+            tools = self._tool_map(workspace)
+
+            tools["get_table_schema"].invoke({"table_names": ["orders"]})
+            raw = tools["run_sql_query"].invoke(
+                {
+                    "sql_query": (
+                        "SELECT order_id, MAX(revenue) OVER () AS max_revenue "
+                        "FROM orders"
+                    )
+                }
+            )
+
+            self.assertIn("Execution was safety-capped at 1000 rows.", raw)
             manager = workspace.context["data_agent_manager"]
             self.assertEqual(len(manager.session.last_query_result), 1000)
             self.assertTrue(manager.session.query_history[-1].truncated)

--- a/agent/tests/test_data_agent_tools.py
+++ b/agent/tests/test_data_agent_tools.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from helpudoc_agent.data_agent_tools import (
+    DuckDBManager,
+    _snapshot_workspace,
+    build_data_agent_tools,
+)
+from helpudoc_agent.state import WorkspaceState
+
+
+class DataAgentToolsTest(unittest.TestCase):
+    def _workspace(self, root: Path) -> WorkspaceState:
+        return WorkspaceState(workspace_id="ws-data-tools", root_path=root)
+
+    def _tool_map(self, workspace: WorkspaceState):
+        return {tool.name: tool for tool in build_data_agent_tools(workspace)}
+
+    def test_snapshot_workspace_skips_ignored_dirs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "reports").mkdir()
+            (root / "charts").mkdir()
+            (root / "node_modules" / "pkg").mkdir(parents=True)
+            (root / "reports" / "summary.html").write_text("<h1>ok</h1>", encoding="utf-8")
+            (root / "charts" / "plot.png").write_bytes(b"png")
+            (root / "node_modules" / "pkg" / "ignored.png").write_bytes(b"ignored")
+
+            snapshot = _snapshot_workspace(root)
+
+            self.assertIn("reports/summary.html", snapshot)
+            self.assertIn("charts/plot.png", snapshot)
+            self.assertNotIn("node_modules/pkg/ignored.png", snapshot)
+
+    def test_register_files_prefers_data_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "datasets").mkdir()
+            (root / "node_modules").mkdir()
+            (root / "datasets" / "orders.csv").write_text(
+                "status,revenue\nactive,10\npending,20\n",
+                encoding="utf-8",
+            )
+            (root / "node_modules" / "ignored.csv").write_text(
+                "status,revenue\nbad,0\n",
+                encoding="utf-8",
+            )
+
+            manager = DuckDBManager(self._workspace(root))
+            tables = {row[0] for row in manager.con.execute("SHOW TABLES").fetchall()}
+
+            self.assertIn("orders", tables)
+            self.assertNotIn("ignored", tables)
+
+    def test_get_table_schema_includes_example_values(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "datasets").mkdir()
+            (root / "datasets" / "orders.csv").write_text(
+                "status,revenue\nactive,10\npending,20\nactive,30\n",
+                encoding="utf-8",
+            )
+            tools = self._tool_map(self._workspace(root))
+
+            raw = tools["get_table_schema"].invoke({"table_names": ["orders"]})
+
+            self.assertIn("Table: orders", raw)
+            self.assertIn("status (VARCHAR)", raw)
+            self.assertIn("[examples: 'active', 'pending']", raw)
+            self.assertIn("revenue (BIGINT)", raw)
+
+    def test_run_sql_query_keeps_aggregate_results_intact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "datasets").mkdir()
+            rows = ["category,value"]
+            rows.extend(f"c{i},1" for i in range(1005))
+            (root / "datasets" / "orders.csv").write_text(
+                "\n".join(rows) + "\n",
+                encoding="utf-8",
+            )
+            workspace = self._workspace(root)
+            tools = self._tool_map(workspace)
+
+            tools["get_table_schema"].invoke({"table_names": ["orders"]})
+            raw = tools["run_sql_query"].invoke(
+                {
+                    "sql_query": (
+                        "SELECT category, SUM(value) AS total "
+                        "FROM orders GROUP BY category ORDER BY category"
+                    )
+                }
+            )
+
+            self.assertIn("Result shape: 1005 rows x 2 columns.", raw)
+            self.assertNotIn("Execution was safety-capped", raw)
+            manager = workspace.context["data_agent_manager"]
+            self.assertEqual(len(manager.session.last_query_result), 1005)
+            self.assertFalse(manager.session.query_history[-1].truncated)
+
+    def test_run_sql_query_caps_non_aggregated_previews(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "datasets").mkdir()
+            rows = ["order_id,revenue"]
+            rows.extend(f"{i},{i * 10}" for i in range(1105))
+            (root / "datasets" / "orders.csv").write_text(
+                "\n".join(rows) + "\n",
+                encoding="utf-8",
+            )
+            workspace = self._workspace(root)
+            tools = self._tool_map(workspace)
+
+            tools["get_table_schema"].invoke({"table_names": ["orders"]})
+            raw = tools["run_sql_query"].invoke({"sql_query": "SELECT * FROM orders"})
+
+            self.assertIn("Result shape: 1000 rows x 2 columns.", raw)
+            self.assertIn("Execution was safety-capped at 1000 rows.", raw)
+            self.assertIn("Numeric summary:", raw)
+            manager = workspace.context["data_agent_manager"]
+            self.assertEqual(len(manager.session.last_query_result), 1000)
+            self.assertTrue(manager.session.query_history[-1].truncated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data_skill_family.py
+++ b/tests/test_data_skill_family.py
@@ -564,6 +564,8 @@ class TestRunScopedHistory:
         # Both queries must appear in the report
         assert "first_query" in content
         assert "second_query" in content
+        assert "Executive Snapshot" in content
+        assert "Queries Run" in content
 
     def test_stale_charts_not_included_in_new_run(self, tmp_path: Path) -> None:
         """Charts from a prior run do not appear in a fresh run's report."""
@@ -643,6 +645,8 @@ class TestDashboardTool:
         assert "<!doctype html>" in content.lower()
         # Should include query block  
         assert "42" in content  # the SELECT 42 result
+        assert "Quick Pulse" in content
+        assert "Charts Embedded" in content
 
     def test_dashboard_accepts_section_titles(self, tmp_path: Path) -> None:
         tools = self._run_analysis_and_chart(tmp_path)


### PR DESCRIPTION
## Summary
- extract summary and dashboard HTML/CSS/JS into a dedicated renderer module so data_agent_tools.py no longer carries large inline page templates
- introduce a shared visual system with KPI-style metric cards for reports and dashboards while preserving self-contained output
- keep existing summary/dashboard behavior intact and extend regression coverage to assert the new rendered sections

## Testing
- python3 -m pytest /Users/licheng.phan/.codex/worktrees/360c/HelpUDoc/tests/test_data_skill_family.py -k "summary_includes_full_query_history or dashboard_tool_creates_html_file or dashboard_html_is_self_contained or dashboard_accepts_section_titles or generate_summary_with_output_path_overwrites_stable_file or generate_dashboard_with_output_path_overwrites_stable_file or dashboard_supports_data_backed_filters_and_static_appendix"
- python3 -m pytest /Users/licheng.phan/.codex/worktrees/360c/HelpUDoc/agent/tests/test_data_agent_tools.py /Users/licheng.phan/.codex/worktrees/360c/HelpUDoc/tests/test_data_skill_family.py -k "summary or dashboard"