### PR TITLE
Unify admin portal theming and dark-mode behavior

### DIFF
--- a/frontend/src/components/settings/AgentSettingsTabs.tsx
+++ b/frontend/src/components/settings/AgentSettingsTabs.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Wrench, Library, Loader2 } from 'lucide-react';
 import { fetchAgentConfig, saveAgentConfig } from '../../services/settingsApi';
-import ToolsTab from './ToolsTab';
+import ToolsTab, { type AgentConfig } from './ToolsTab';
 import SkillsRegistryTab from './SkillsRegistryTab';
 import { SettingsEmptyState, SettingsLoadingState, SettingsTabPanel, SettingsTabs } from './SettingsScaffold';
 import YAML from 'yaml';
@@ -9,7 +9,7 @@ import { getAuthUser } from '../../auth/authStore';
 
 const AgentSettingsTabs = () => {
     const [activeTab, setActiveTab] = useState<'tools' | 'skills'>('skills');
-    const [config, setConfig] = useState<any>(null);
+    const [config, setConfig] = useState<AgentConfig | null>(null);
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -40,7 +40,7 @@ const AgentSettingsTabs = () => {
         void loadConfig();
     }, [loadConfig]);
 
-    const handleSave = async (newConfig: any) => {
+    const handleSave = async (newConfig: AgentConfig) => {
         try {
             setSaving(true);
             const yamlString = YAML.stringify(newConfig);
@@ -80,7 +80,7 @@ const AgentSettingsTabs = () => {
                         <button
                             type="button"
                             onClick={loadConfig}
-                            className="rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800"
+                            className="settings-portal-button-secondary rounded-xl px-4 py-2 text-sm font-medium transition"
                         >
                             Retry
                         </button>

--- a/frontend/src/components/settings/SettingsScaffold.tsx
+++ b/frontend/src/components/settings/SettingsScaffold.tsx
@@ -11,7 +11,7 @@ type SurfaceProps = {
 export const SettingsSurface = ({ children, className }: SurfaceProps) => (
   <section
     className={cx(
-      'rounded-[28px] border border-slate-200/80 bg-white/95 p-6 shadow-[0_18px_45px_rgba(15,23,42,0.08)] backdrop-blur',
+      'settings-portal-surface rounded-[28px] p-6',
       className,
     )}
   >
@@ -32,7 +32,7 @@ export const SettingsSectionHeader = ({ title, description, eyebrow, actions }: 
       {eyebrow ? (
         <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">{eyebrow}</p>
       ) : null}
-      <h3 className="text-lg font-semibold text-slate-950">{title}</h3>
+      <h3 className="text-lg font-semibold tracking-tight text-slate-950">{title}</h3>
       {description ? <p className="max-w-2xl text-sm leading-6 text-slate-600">{description}</p> : null}
     </div>
     {actions ? <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div> : null}
@@ -46,13 +46,13 @@ type NoticeProps = {
 };
 
 const noticeStyles: Record<NonNullable<NoticeProps['variant']>, string> = {
-  info: 'border-slate-200 bg-slate-50 text-slate-700',
+  info: 'border-blue-200 bg-blue-50/80 text-slate-700',
   warning: 'border-amber-200 bg-amber-50 text-amber-800',
   error: 'border-rose-200 bg-rose-50 text-rose-700',
 };
 
 export const SettingsNotice = ({ children, variant = 'info', className }: NoticeProps) => (
-  <div className={cx('rounded-2xl border px-4 py-3 text-sm shadow-sm', noticeStyles[variant], className)}>{children}</div>
+  <div className={cx('settings-portal-surface-muted rounded-2xl border px-4 py-3 text-sm', noticeStyles[variant], className)}>{children}</div>
 );
 
 type EmptyStateProps = {
@@ -72,13 +72,13 @@ export const SettingsEmptyState = ({
 }: EmptyStateProps) => (
   <div
     className={cx(
-      'rounded-[24px] border border-dashed border-slate-200 bg-slate-50/90 p-8',
+      'settings-portal-surface-muted rounded-[24px] border border-dashed border-slate-200 p-8',
       align === 'center' ? 'text-center' : 'text-left',
     )}
   >
     <div className={cx('flex gap-4', align === 'center' ? 'flex-col items-center' : 'items-start')}>
       {Icon ? (
-        <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white text-slate-700 shadow-sm ring-1 ring-slate-200">
+        <span className="settings-portal-icon-muted flex h-12 w-12 items-center justify-center rounded-2xl ring-1 ring-slate-200">
           <Icon size={20} />
         </span>
       ) : null}
@@ -97,7 +97,7 @@ type LoadingStateProps = {
 };
 
 export const SettingsLoadingState = ({ label, className }: LoadingStateProps) => (
-  <div className={cx('flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600', className)}>
+  <div className={cx('settings-portal-surface-muted flex items-center gap-3 rounded-2xl border border-slate-200 p-4 text-sm text-slate-600', className)}>
     <Loader2 className="h-4 w-4 animate-spin" />
     {label}
   </div>
@@ -120,7 +120,7 @@ type MetricCardProps = {
 };
 
 export const SettingsMetricCard = ({ label, value, hint, icon: Icon }: MetricCardProps) => (
-  <div className="rounded-[24px] border border-slate-200/80 bg-gradient-to-br from-white via-slate-50 to-slate-100/80 p-5 shadow-[0_10px_30px_rgba(15,23,42,0.06)]">
+  <div className="settings-portal-card rounded-[24px] p-5">
     <div className="flex items-start justify-between gap-4">
       <div>
         <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">{label}</p>
@@ -128,7 +128,7 @@ export const SettingsMetricCard = ({ label, value, hint, icon: Icon }: MetricCar
         {hint ? <p className="mt-1 text-sm text-slate-500">{hint}</p> : null}
       </div>
       {Icon ? (
-        <span className="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-900 text-white shadow-sm">
+        <span className="settings-portal-icon inline-flex h-11 w-11 items-center justify-center rounded-2xl">
           <Icon size={18} />
         </span>
       ) : null}
@@ -147,7 +147,7 @@ type TabsProps<T extends string> = {
 };
 
 export const SettingsTabs = <T extends string>({ tabs, value, onChange }: TabsProps<T>) => (
-  <div className="inline-flex flex-wrap items-center gap-1 rounded-2xl border border-slate-200 bg-slate-100/90 p-1 shadow-inner">
+  <div className="settings-portal-surface-muted inline-flex flex-wrap items-center gap-1 rounded-2xl border border-slate-200 p-1">
     {tabs.map(({ id, label, icon: Icon }) => {
       const isActive = id === value;
       return (
@@ -156,10 +156,10 @@ export const SettingsTabs = <T extends string>({ tabs, value, onChange }: TabsPr
           type="button"
           onClick={() => onChange(id)}
           className={cx(
-            'inline-flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-medium transition',
+            'settings-portal-nav-item inline-flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-medium transition',
             isActive
-              ? 'bg-white text-slate-950 shadow-sm ring-1 ring-slate-200'
-              : 'text-slate-600 hover:bg-white/80 hover:text-slate-900',
+              ? 'settings-portal-nav-item-active'
+              : '',
           )}
         >
           {Icon ? <Icon size={16} /> : null}
@@ -176,5 +176,5 @@ type TabPanelProps = {
 };
 
 export const SettingsTabPanel = ({ children, className }: TabPanelProps) => (
-  <SettingsSurface className={cx('min-h-[500px]', className)}>{children}</SettingsSurface>
+  <SettingsSurface className={cx('min-h-[520px]', className)}>{children}</SettingsSurface>
 );

--- a/frontend/src/components/settings/SettingsShell.tsx
+++ b/frontend/src/components/settings/SettingsShell.tsx
@@ -39,7 +39,7 @@ const SettingsShell = ({ title, description, eyebrow = 'Workspace settings', act
   const backToWorkspaceAction = (
     <Link
       to="/"
-      className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition-colors hover:border-slate-300 hover:text-slate-900"
+      className="settings-portal-button-secondary inline-flex items-center gap-2 rounded-xl px-3.5 py-2.5 text-sm font-medium transition-colors"
     >
       <ArrowLeftCircle size={16} />
       Back to Workspace
@@ -47,17 +47,25 @@ const SettingsShell = ({ title, description, eyebrow = 'Workspace settings', act
   );
 
   return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(148,163,184,0.14),_transparent_35%),linear-gradient(180deg,_#f8fafc_0%,_#eef2f7_100%)] lg:flex">
-      <aside className="border-b border-slate-200/80 bg-white/90 backdrop-blur lg:flex lg:min-h-screen lg:w-72 lg:flex-col lg:border-b-0 lg:border-r">
-        <div className="border-b border-slate-100 px-6 py-5">
-          <p className="text-[11px] uppercase tracking-[0.18em] text-slate-500">Workspace settings</p>
-          <div className="mt-2 flex items-center gap-3">
-            <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-slate-900 text-white shadow-sm">
+    <div className="settings-portal min-h-screen lg:flex">
+      <aside className="settings-portal-sidebar border-b lg:flex lg:min-h-screen lg:w-72 lg:flex-col lg:border-b-0 lg:border-r">
+        <div className="border-b border-slate-100 px-6 py-6">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Workspace settings</p>
+          <div className="mt-3 flex items-start gap-3">
+            <span className="settings-portal-icon inline-flex h-11 w-11 items-center justify-center rounded-2xl">
               <PanelLeft size={18} />
             </span>
-            <div>
+            <div className="min-w-0">
               <h1 className="text-xl font-semibold text-slate-900">Admin Portal</h1>
-              <p className="text-sm text-slate-500">Unified settings, people, and knowledge controls.</p>
+              <p className="mt-1 text-sm leading-6 text-slate-500">Unified settings, people, and knowledge controls.</p>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <span className="settings-portal-chip inline-flex rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em]">
+                  Shared system
+                </span>
+                <span className="inline-flex rounded-full border border-slate-200 bg-slate-50/80 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.18em] text-slate-500">
+                  Operational view
+                </span>
+              </div>
             </div>
           </div>
         </div>
@@ -73,9 +81,9 @@ const SettingsShell = ({ title, description, eyebrow = 'Workspace settings', act
                   key={label}
                   to={path}
                   aria-current={isActive ? 'page' : undefined}
-                  className={`flex min-w-fit items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-colors ${isActive
-                    ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900/5'
-                    : 'text-slate-600 hover:text-slate-900 hover:bg-slate-100'
+                  className={`settings-portal-nav-item flex min-w-fit items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors ${isActive
+                    ? 'settings-portal-nav-item-active'
+                    : ''
                     }`}
                 >
                   <Icon size={16} />
@@ -88,16 +96,23 @@ const SettingsShell = ({ title, description, eyebrow = 'Workspace settings', act
       </aside>
 
       <main className="min-w-0 flex-1 overflow-y-auto">
-        <div className="w-full px-4 py-6 sm:px-6 lg:px-8 lg:py-8 xl:px-10 2xl:px-12">
-          <div className="space-y-6">
-            <div className="rounded-[32px] border border-slate-200/80 bg-white/92 p-6 shadow-[0_22px_55px_rgba(15,23,42,0.08)] backdrop-blur sm:p-8">
-              <p className="text-xs uppercase tracking-wide text-slate-500">{eyebrow}</p>
-              <div className="mt-3 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="w-full px-4 py-4 sm:px-6 sm:py-5 lg:px-8 lg:py-6 xl:px-10 2xl:px-12">
+          <div className="space-y-5">
+            <div className="settings-portal-header rounded-[28px] p-5 sm:p-6">
+              <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
                 <div>
-                  <h2 className="text-2xl font-semibold text-slate-900 sm:text-[2rem]">{title}</h2>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="settings-portal-chip inline-flex rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em]">
+                      {eyebrow}
+                    </span>
+                    <span className="inline-flex rounded-full border border-slate-200 bg-slate-50/80 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                      Unified admin surface
+                    </span>
+                  </div>
+                  <h2 className="mt-4 text-2xl font-semibold tracking-tight text-slate-900 sm:text-[2rem]">{title}</h2>
                   {description && <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600 sm:text-base">{description}</p>}
                 </div>
-                <div className="flex flex-wrap items-center gap-3">
+                <div className="flex flex-wrap items-center gap-3 xl:justify-end">
                   {backToWorkspaceAction}
                   {actions}
                 </div>

--- a/frontend/src/components/settings/SkillsRegistryTab.tsx
+++ b/frontend/src/components/settings/SkillsRegistryTab.tsx
@@ -61,6 +61,10 @@ const makeId = () =>
     ? crypto.randomUUID()
     : `id-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 
+const primaryButtonClass = 'settings-button-primary inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition disabled:opacity-60';
+const secondaryButtonClass = 'settings-portal-button-secondary inline-flex items-center gap-2 rounded-lg px-2 py-1 text-xs transition disabled:opacity-60';
+const workbenchColumnClass = 'settings-workbench-column flex flex-col overflow-hidden rounded-xl';
+
 const SkillsRegistryTab: React.FC = () => {
   const [skills, setSkills] = useState<SkillDefinition[]>([]);
   const [loading, setLoading] = useState(true);
@@ -583,7 +587,7 @@ const SkillsRegistryTab: React.FC = () => {
         <p className="text-rose-600 mb-4">{error}</p>
         <button
           onClick={loadSkills}
-          className="px-4 py-2 bg-slate-900 text-white rounded-lg hover:bg-slate-800 transition-colors"
+          className="settings-button-primary rounded-lg px-4 py-2 transition-colors"
         >
           Retry
         </button>
@@ -592,8 +596,8 @@ const SkillsRegistryTab: React.FC = () => {
   }
 
   return (
-    <div style={{ height: 'calc(100vh - 260px)', minHeight: '620px' }} className="flex gap-4">
-      <div className={`${builderCollapsed ? 'w-12' : 'w-[390px]'} flex-shrink-0 border border-slate-200 rounded-xl bg-white flex flex-col overflow-hidden`}>
+    <div style={{ height: 'calc(100vh - 260px)', minHeight: '620px' }} className="settings-workbench flex gap-4">
+      <div className={`${builderCollapsed ? 'w-12' : 'w-[390px]'} ${workbenchColumnClass} flex-shrink-0`}>
         <div className="px-3 py-2 border-b border-slate-200 bg-slate-50 flex items-center justify-between">
           {!builderCollapsed && (
             <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
@@ -620,7 +624,7 @@ const SkillsRegistryTab: React.FC = () => {
                 <button
                   type="button"
                   onClick={() => setGithubModalOpen(true)}
-                  className="inline-flex items-center gap-1 px-2 py-1 text-xs border border-slate-300 rounded hover:bg-slate-100"
+                  className={secondaryButtonClass}
                 >
                   <Github size={13} />
                   Import
@@ -628,7 +632,7 @@ const SkillsRegistryTab: React.FC = () => {
                 <button
                   type="button"
                   onClick={parseActionsFromMessages}
-                  className="inline-flex items-center gap-1 px-2 py-1 text-xs border border-slate-300 rounded hover:bg-slate-100"
+                  className={secondaryButtonClass}
                 >
                   <Wand2 size={13} />
                   Parse Actions
@@ -646,7 +650,7 @@ const SkillsRegistryTab: React.FC = () => {
                   type="button"
                   disabled={contextUploading}
                   onClick={() => attachmentInputRef.current?.click()}
-                  className="inline-flex items-center gap-1 px-2 py-1 text-xs bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-60"
+                  className={secondaryButtonClass}
                 >
                   {contextUploading ? <Loader2 size={12} className="animate-spin" /> : <Upload size={12} />}
                   Upload
@@ -712,14 +716,14 @@ const SkillsRegistryTab: React.FC = () => {
                   <button
                     type="button"
                     onClick={() => void handleRunDecision('approve')}
-                    className="px-2 py-1 text-xs bg-emerald-600 text-white rounded hover:bg-emerald-700"
+                  className="rounded px-2 py-1 text-xs bg-emerald-600 text-white hover:bg-emerald-700"
                   >
                     Approve
                   </button>
                   <button
                     type="button"
                     onClick={() => void handleRunDecision('reject')}
-                    className="px-2 py-1 text-xs bg-rose-600 text-white rounded hover:bg-rose-700"
+                  className="rounded px-2 py-1 text-xs bg-rose-600 text-white hover:bg-rose-700"
                   >
                     Reject
                   </button>
@@ -744,7 +748,7 @@ const SkillsRegistryTab: React.FC = () => {
                   type="button"
                   disabled={!builderReady || builderRunning || !builderPrompt.trim()}
                   onClick={() => void handleSendPrompt()}
-                  className="inline-flex items-center gap-1 px-3 py-1.5 text-sm bg-slate-900 text-white rounded-lg hover:bg-slate-800 disabled:opacity-60"
+                  className={primaryButtonClass}
                 >
                   <Play size={14} />
                   Send
@@ -759,7 +763,7 @@ const SkillsRegistryTab: React.FC = () => {
                   type="button"
                   disabled={!proposedActions.length || applyingAll}
                   onClick={() => void applyAllActions()}
-                  className="inline-flex items-center gap-1 px-2 py-1 text-xs bg-emerald-600 text-white rounded hover:bg-emerald-700 disabled:opacity-60"
+                  className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-60"
                 >
                   {applyingAll ? <Loader2 size={12} className="animate-spin" /> : <CheckCircle2 size={12} />}
                   Apply All
@@ -793,7 +797,7 @@ const SkillsRegistryTab: React.FC = () => {
       </div>
 
       <div className="flex-1 min-w-0 flex gap-4">
-        <div className="w-72 flex-shrink-0 flex flex-col bg-white border border-slate-200 rounded-xl overflow-hidden">
+        <div className={`w-72 flex-shrink-0 ${workbenchColumnClass}`}>
           <div className="p-3 border-b border-slate-200 bg-slate-50">
             <div className="flex items-center justify-between mb-3">
               <span className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Skills</span>
@@ -823,7 +827,7 @@ const SkillsRegistryTab: React.FC = () => {
                 setNewName('');
                 setNewDesc('');
               }}
-              className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-slate-900 text-white rounded-lg text-sm font-medium hover:bg-slate-800 transition-colors"
+              className={primaryButtonClass}
             >
               <Plus size={16} />
               Add Skill
@@ -901,7 +905,7 @@ const SkillsRegistryTab: React.FC = () => {
           </div>
         </div>
 
-        <div className="flex-1 flex flex-col bg-white border border-slate-200 rounded-xl overflow-hidden">
+        <div className={`flex-1 ${workbenchColumnClass}`}>
           {selectedSkill ? (
             <>
               <div className="flex items-center justify-between px-4 py-2.5 border-b border-slate-200 bg-slate-50">
@@ -955,7 +959,7 @@ const SkillsRegistryTab: React.FC = () => {
                   )}
                 </div>
 
-                <div className="flex-1 relative bg-[#1e1e1e]">
+                <div className="settings-workbench-editor flex-1 relative">
                   {fileLoading ? (
                     <div className="absolute inset-0 flex items-center justify-center bg-[#1e1e1e]">
                       <Loader2 size={24} className="animate-spin text-slate-500" />
@@ -995,8 +999,8 @@ const SkillsRegistryTab: React.FC = () => {
       </div>
 
       {githubModalOpen && (
-        <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center p-4">
-          <div className="w-full max-w-2xl bg-white rounded-xl border border-slate-200 shadow-xl">
+        <div className="settings-modal-overlay fixed inset-0 z-40 flex items-center justify-center p-4">
+          <div className="settings-modal-panel w-full max-w-2xl rounded-xl">
             <div className="px-4 py-3 border-b border-slate-200 flex items-center justify-between">
               <h3 className="text-sm font-semibold text-slate-800">Import Skill From GitHub</h3>
               <button onClick={() => setGithubModalOpen(false)} className="text-slate-400 hover:text-slate-600">

--- a/frontend/src/components/settings/ToolsTab.tsx
+++ b/frontend/src/components/settings/ToolsTab.tsx
@@ -1,9 +1,39 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Plus, Trash2, Save, Loader2, Server, Hammer, X, ExternalLink } from 'lucide-react';
 
+interface ToolDefinition {
+    name: string;
+    kind?: string;
+    description?: string;
+}
+
+interface McpServerConfig {
+    name: string;
+    transport?: 'stdio' | 'http';
+    default_access?: 'allow' | 'deny';
+    defaultAccess?: 'allow' | 'deny';
+    delegated_auth_provider?: '' | 'google';
+    delegatedAuthProvider?: '' | 'google';
+    command?: string;
+    args?: string[];
+    env?: Record<string, string>;
+    envPassthrough?: string[];
+    cwd?: string;
+    url?: string;
+    bearerTokenEnvVar?: string;
+    headers?: Record<string, string>;
+    headersFromEnv?: Record<string, string>;
+}
+
+export interface AgentConfig {
+    tools?: ToolDefinition[];
+    mcp_servers?: McpServerConfig[];
+    [key: string]: unknown;
+}
+
 interface ToolsTabProps {
-    config: any;
-    onSave: (config: any) => Promise<void>;
+    config: AgentConfig | null;
+    onSave: (config: AgentConfig) => Promise<void>;
     isSaving: boolean;
 }
 
@@ -45,6 +75,11 @@ const EmptyMcpForm: McpServerFormState = {
     headersFromEnv: [],
 };
 
+const primaryButtonClass = 'settings-button-primary inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition disabled:opacity-60';
+const secondaryButtonClass = 'settings-portal-button-secondary inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition disabled:opacity-60';
+const controlClass = 'settings-control w-full rounded-lg px-3 py-2 text-sm outline-none transition-all';
+const segmentedButtonClass = (active: boolean) => `settings-portal-nav-item flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition-colors ${active ? 'settings-portal-nav-item-active' : ''}`;
+
 const ToolsTab: React.FC<ToolsTabProps> = ({ config, onSave, isSaving }) => {
     const [activeSection, setActiveSection] = useState<'builtin' | 'mcp'>('mcp');
 
@@ -58,8 +93,8 @@ const ToolsTab: React.FC<ToolsTabProps> = ({ config, onSave, isSaving }) => {
     const [editingMcpIndex, setEditingMcpIndex] = useState<number | null>(null);
     const [mcpForm, setMcpForm] = useState<McpServerFormState>(EmptyMcpForm);
 
-    const tools = config?.tools || [];
-    const mcpServers = config?.mcp_servers || [];
+    const tools = useMemo(() => config?.tools ?? [], [config]);
+    const mcpServers = useMemo(() => config?.mcp_servers ?? [], [config]);
 
     // Initialize form when editing
     useEffect(() => {
@@ -108,7 +143,7 @@ const ToolsTab: React.FC<ToolsTabProps> = ({ config, onSave, isSaving }) => {
     const handleSaveMcp = async () => {
         if (!mcpForm.name) return;
 
-        const newServerConfig: any = {
+        const newServerConfig: McpServerConfig = {
             name: mcpForm.name,
             transport: mcpForm.transport,
             default_access: mcpForm.defaultAccess,
@@ -143,7 +178,7 @@ const ToolsTab: React.FC<ToolsTabProps> = ({ config, onSave, isSaving }) => {
             }
         }
 
-        let updatedMcpServers = [...mcpServers];
+        const updatedMcpServers = [...mcpServers];
         if (editingMcpIndex !== null) {
             updatedMcpServers[editingMcpIndex] = newServerConfig;
         } else {
@@ -217,24 +252,18 @@ const ToolsTab: React.FC<ToolsTabProps> = ({ config, onSave, isSaving }) => {
     };
 
     return (
-        <div>
-            <div className="flex gap-4 mb-6 border-b border-slate-200 pb-4">
+        <div className="settings-tools space-y-6">
+            <div className="settings-portal-surface-muted inline-flex flex-wrap items-center gap-1 rounded-2xl border border-slate-200 p-1">
                 <button
                     onClick={() => setActiveSection('mcp')}
-                    className={`flex items-center gap-2 text-sm font-medium pb-1 -mb-5 border-b-2 transition-colors ${activeSection === 'mcp'
-                        ? 'border-slate-900 text-slate-900'
-                        : 'border-transparent text-slate-500 hover:text-slate-700'
-                        }`}
+                    className={segmentedButtonClass(activeSection === 'mcp')}
                 >
                     <Server size={16} />
                     MCP Servers
                 </button>
                 <button
                     onClick={() => setActiveSection('builtin')}
-                    className={`flex items-center gap-2 text-sm font-medium pb-1 -mb-5 border-b-2 transition-colors ${activeSection === 'builtin'
-                        ? 'border-slate-900 text-slate-900'
-                        : 'border-transparent text-slate-500 hover:text-slate-700'
-                        }`}
+                    className={segmentedButtonClass(activeSection === 'builtin')}
                 >
                     <Hammer size={16} />
                     Built-in Tools
@@ -247,7 +276,7 @@ const ToolsTab: React.FC<ToolsTabProps> = ({ config, onSave, isSaving }) => {
                         <h3 className="text-lg font-semibold text-slate-900">Built-in Tools</h3>
                         <button
                             onClick={() => setIsAddingTool(true)}
-                            className="flex items-center gap-2 px-4 py-2 bg-slate-900 text-white rounded-lg text-sm font-medium hover:bg-slate-800"
+                            className={primaryButtonClass}
                         >
                             <Plus size={16} />
                             Add Tool
@@ -255,22 +284,22 @@ const ToolsTab: React.FC<ToolsTabProps> = ({ config, onSave, isSaving }) => {
                     </div>
 
                     {isAddingTool && (
-                        <div className="mb-6 p-4 bg-slate-50 rounded-xl border border-slate-200 shadow-sm">
+                        <div className="settings-soft-panel mb-6 rounded-xl p-4">
                             <div className="grid grid-cols-2 gap-4 mb-4">
                                 <div>
                                     <label className="block text-xs font-medium text-slate-700 mb-1">Tool Name</label>
                                     <input type="text" value={newToolName} onChange={(e) => setNewToolName(e.target.value)} placeholder="e.g., google_search"
-                                        className="w-full px-3 py-2 rounded-lg border border-slate-300 bg-white text-sm focus:border-slate-500 focus:ring-1 focus:ring-slate-500 outline-none transition-all" />
+                                        className={controlClass} />
                                 </div>
                                 <div>
                                     <label className="block text-xs font-medium text-slate-700 mb-1">Description</label>
                                     <input type="text" value={newToolDesc} onChange={(e) => setNewToolDesc(e.target.value)} placeholder="Description"
-                                        className="w-full px-3 py-2 rounded-lg border border-slate-300 bg-white text-sm focus:border-slate-500 focus:ring-1 focus:ring-slate-500 outline-none transition-all" />
+                                        className={controlClass} />
                                 </div>
                             </div>
                             <div className="flex justify-end gap-2">
-                                <button onClick={() => setIsAddingTool(false)} className="px-3 py-1.5 text-slate-600 text-sm hover:bg-slate-200 rounded-lg">Cancel</button>
-                                <button onClick={handleSaveTool} disabled={isSaving} className="flex items-center gap-2 px-3 py-1.5 bg-slate-900 text-white text-sm rounded-lg hover:bg-slate-800">
+                                <button onClick={() => setIsAddingTool(false)} className={secondaryButtonClass}>Cancel</button>
+                                <button onClick={handleSaveTool} disabled={isSaving} className={primaryButtonClass}>
                                     {isSaving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
                                     Save
                                 </button>
@@ -279,8 +308,8 @@ const ToolsTab: React.FC<ToolsTabProps> = ({ config, onSave, isSaving }) => {
                     )}
 
                     <div className="grid gap-3">
-                        {tools.map((tool: any, idx: number) => (
-                            <div key={idx} className="p-4 rounded-xl border border-slate-200 bg-white flex justify-between items-center shadow-sm">
+                        {tools.map((tool, idx: number) => (
+                            <div key={idx} className="settings-selection-card flex justify-between items-center rounded-xl p-4">
                                 <div>
                                     <p className="font-semibold text-slate-900">{tool.name}</p>
                                     <p className="text-sm text-slate-500">{tool.description}</p>
@@ -308,7 +337,7 @@ const ToolsTab: React.FC<ToolsTabProps> = ({ config, onSave, isSaving }) => {
                                 </div>
                                 <button
                                     onClick={() => { setMcpForm(EmptyMcpForm); setEditingMcpIndex(null); setIsEditingMcp(true); }}
-                                    className="flex items-center gap-2 px-4 py-2 bg-slate-900 text-white rounded-lg text-sm font-medium hover:bg-slate-800 shadow-sm transition-all"
+                                    className={primaryButtonClass}
                                 >
                                     <Plus size={16} />
                                     Add Server
@@ -316,8 +345,8 @@ const ToolsTab: React.FC<ToolsTabProps> = ({ config, onSave, isSaving }) => {
                             </div>
 
                             <div className="grid gap-3">
-                                {mcpServers.map((server: any, idx: number) => (
-                                    <div key={idx} className="group p-4 rounded-xl border border-slate-200 bg-white hover:border-slate-300 transition-all shadow-sm">
+                                {mcpServers.map((server, idx: number) => (
+                                    <div key={idx} className="settings-selection-card group rounded-xl p-4 transition-all">
                                         <div className="flex justify-between items-start">
                                             <div onClick={() => { setMcpForm(EmptyMcpForm); setEditingMcpIndex(idx); setIsEditingMcp(true); /* Will trigger effect */ }} className="cursor-pointer flex-1">
                                                 <div className="flex items-center gap-2 mb-1">
@@ -329,10 +358,10 @@ const ToolsTab: React.FC<ToolsTabProps> = ({ config, onSave, isSaving }) => {
                                                 </p>
                                             </div>
                                             <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                                <button onClick={() => { setMcpForm(EmptyMcpForm); setEditingMcpIndex(idx); setIsEditingMcp(true); }} className="p-2 text-slate-400 hover:text-slate-900 rounded-lg hover:bg-slate-50">
+                                                <button onClick={() => { setMcpForm(EmptyMcpForm); setEditingMcpIndex(idx); setIsEditingMcp(true); }} className="settings-portal-button-secondary rounded-lg p-2 transition">
                                                     <Hammer size={16} />
                                                 </button>
-                                                <button onClick={() => handleDeleteMcp(idx)} className="p-2 text-slate-400 hover:text-rose-600 rounded-lg hover:bg-rose-50">
+                                                <button onClick={() => handleDeleteMcp(idx)} className="settings-button-danger rounded-lg p-2 transition">
                                                     <Trash2 size={16} />
                                                 </button>
                                             </div>
@@ -340,7 +369,7 @@ const ToolsTab: React.FC<ToolsTabProps> = ({ config, onSave, isSaving }) => {
                                     </div>
                                 ))}
                                 {mcpServers.length === 0 && (
-                                    <div className="text-center py-12 bg-slate-50 rounded-xl border border-dashed border-slate-200">
+                                    <div className="settings-soft-panel rounded-xl border border-dashed py-12 text-center">
                                         <Server className="mx-auto text-slate-300 mb-3" size={32} />
                                         <p className="text-slate-500 font-medium">No MCP servers connected</p>
                                         <p className="text-slate-400 text-sm mt-1">Add a server to extend capabilities</p>
@@ -349,7 +378,7 @@ const ToolsTab: React.FC<ToolsTabProps> = ({ config, onSave, isSaving }) => {
                             </div>
                         </>
                     ) : (
-                        <div className="bg-[#1C1C1E] text-slate-200 rounded-xl border border-[#2C2C2E] overflow-hidden shadow-2xl">
+                        <div className="settings-tools-panel rounded-xl overflow-hidden text-slate-200">
                             <div className="p-6">
                                 <div className="flex justify-between items-center mb-6">
                                     <div>
@@ -613,7 +642,7 @@ const ToolsTab: React.FC<ToolsTabProps> = ({ config, onSave, isSaving }) => {
                                     <button
                                         onClick={handleSaveMcp}
                                         disabled={isSaving}
-                                        className="px-6 py-2 bg-[#F2F2F7] text-black rounded-lg font-medium hover:bg-white transition-colors disabled:opacity-50"
+                                        className="settings-button-primary rounded-lg px-6 py-2 font-medium transition disabled:opacity-50"
                                     >
                                         {isSaving ? 'Saving...' : 'Save'}
                                     </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,6 +24,22 @@
   --slate-900: #0f172a;
   --slate-950: #020617;
   --indigo-500: #6366f1;
+  --admin-shell-bg: radial-gradient(circle at top left, rgba(37, 99, 235, 0.14), transparent 32%),
+    radial-gradient(circle at top right, rgba(14, 165, 233, 0.12), transparent 24%),
+    linear-gradient(180deg, #f8fafc 0%, #eef4fb 100%);
+  --admin-sidebar-bg: rgba(255, 255, 255, 0.78);
+  --admin-panel-bg: rgba(255, 255, 255, 0.82);
+  --admin-surface-bg: rgba(255, 255, 255, 0.74);
+  --admin-surface-muted: rgba(241, 245, 249, 0.88);
+  --admin-card-bg: linear-gradient(135deg, rgba(255, 255, 255, 0.86) 0%, rgba(241, 245, 249, 0.94) 100%);
+  --admin-border-subtle: rgba(148, 163, 184, 0.22);
+  --admin-border-strong: rgba(148, 163, 184, 0.34);
+  --admin-shadow-soft: 0 22px 55px rgba(15, 23, 42, 0.08);
+  --admin-shadow-strong: 0 28px 80px rgba(15, 23, 42, 0.14);
+  --admin-ring: rgba(37, 99, 235, 0.18);
+  --admin-accent-soft: rgba(37, 99, 235, 0.1);
+  --admin-icon-bg: rgba(15, 23, 42, 0.92);
+  --admin-icon-muted-bg: rgba(15, 23, 42, 0.06);
 }
 
 :root[data-theme='dark'] {
@@ -48,6 +64,22 @@
   --slate-900: #0b1220;
   --slate-950: #050b16;
   --indigo-500: #a5b4ff;
+  --admin-shell-bg: radial-gradient(circle at top left, rgba(59, 130, 246, 0.18), transparent 32%),
+    radial-gradient(circle at top right, rgba(56, 189, 248, 0.16), transparent 24%),
+    linear-gradient(180deg, #060d19 0%, #0b1220 42%, #0d1629 100%);
+  --admin-sidebar-bg: rgba(5, 11, 22, 0.82);
+  --admin-panel-bg: rgba(11, 18, 32, 0.74);
+  --admin-surface-bg: rgba(15, 23, 42, 0.82);
+  --admin-surface-muted: rgba(17, 24, 39, 0.9);
+  --admin-card-bg: linear-gradient(135deg, rgba(15, 23, 42, 0.96) 0%, rgba(27, 38, 56, 0.94) 100%);
+  --admin-border-subtle: rgba(51, 65, 85, 0.54);
+  --admin-border-strong: rgba(71, 85, 105, 0.68);
+  --admin-shadow-soft: 0 22px 55px rgba(2, 6, 23, 0.44);
+  --admin-shadow-strong: 0 28px 80px rgba(2, 6, 23, 0.6);
+  --admin-ring: rgba(96, 165, 250, 0.24);
+  --admin-accent-soft: rgba(59, 130, 246, 0.18);
+  --admin-icon-bg: rgba(59, 130, 246, 0.18);
+  --admin-icon-muted-bg: rgba(148, 163, 184, 0.12);
 }
 
 body {
@@ -302,6 +334,379 @@ body {
 
 .to-slate-100 {
   --tw-gradient-to: var(--surface-subtle);
+}
+
+.settings-portal {
+  background: var(--admin-shell-bg);
+}
+
+.settings-portal-sidebar {
+  background: var(--admin-sidebar-bg);
+  border-color: var(--admin-border-subtle) !important;
+  box-shadow: inset -1px 0 0 var(--admin-border-subtle);
+  backdrop-filter: blur(28px);
+}
+
+.settings-portal-header {
+  background: var(--admin-panel-bg);
+  border: 1px solid var(--admin-border-subtle);
+  box-shadow: var(--admin-shadow-soft);
+  backdrop-filter: blur(24px);
+}
+
+.settings-portal-surface {
+  background: var(--admin-surface-bg);
+  border: 1px solid var(--admin-border-subtle);
+  box-shadow: var(--admin-shadow-soft);
+  backdrop-filter: blur(24px);
+}
+
+.settings-portal-surface-muted {
+  background: var(--admin-surface-muted);
+}
+
+.settings-portal-card {
+  background: var(--admin-card-bg);
+  border: 1px solid var(--admin-border-strong);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 16px 38px rgba(15, 23, 42, 0.08);
+}
+
+:root[data-theme='dark'] .settings-portal-card {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03), 0 16px 38px rgba(2, 6, 23, 0.35);
+}
+
+.settings-portal-chip {
+  background: var(--admin-accent-soft);
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
+  color: var(--accent);
+}
+
+.settings-portal-button-secondary {
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  border: 1px solid var(--admin-border-subtle);
+  color: var(--text-primary);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.settings-portal-button-secondary:hover {
+  background: color-mix(in srgb, var(--surface-hover) 82%, transparent);
+  border-color: var(--admin-border-strong);
+}
+
+.settings-portal-nav-item {
+  border: 1px solid transparent;
+  color: var(--text-secondary);
+}
+
+.settings-portal-nav-item:hover {
+  background: color-mix(in srgb, var(--surface-hover) 74%, transparent);
+  border-color: var(--admin-border-subtle);
+  color: var(--text-primary);
+}
+
+.settings-portal-nav-item-active {
+  background: color-mix(in srgb, var(--accent) 12%, var(--surface) 88%);
+  border-color: color-mix(in srgb, var(--accent) 24%, var(--admin-border-strong));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  color: var(--text-primary);
+}
+
+.settings-portal-icon {
+  background: var(--admin-icon-bg);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.18);
+  color: #f8fafc;
+}
+
+:root[data-theme='dark'] .settings-portal-icon {
+  color: #dbeafe;
+}
+
+.settings-portal-icon-muted {
+  background: var(--admin-icon-muted-bg);
+  color: var(--accent);
+}
+
+.settings-control {
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  border: 1px solid var(--admin-border-strong);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 8px 24px rgba(15, 23, 42, 0.05);
+  color: var(--text-primary);
+}
+
+.settings-control::placeholder {
+  color: var(--text-muted);
+}
+
+.settings-control:focus {
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--admin-border-strong));
+  box-shadow: 0 0 0 4px var(--admin-ring);
+  outline: none;
+}
+
+.settings-button-primary {
+  background: color-mix(in srgb, var(--slate-950) 86%, var(--accent) 14%);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.16);
+  color: #f8fafc;
+}
+
+.settings-button-primary:hover {
+  background: color-mix(in srgb, var(--slate-950) 80%, var(--accent) 20%);
+}
+
+.settings-button-danger {
+  background: color-mix(in srgb, var(--danger) 14%, var(--surface) 86%);
+  border: 1px solid color-mix(in srgb, var(--danger) 28%, transparent);
+  color: var(--danger);
+}
+
+.settings-button-danger:hover {
+  background: color-mix(in srgb, var(--danger) 18%, var(--surface) 82%);
+}
+
+.settings-button-danger-solid {
+  background: color-mix(in srgb, var(--danger) 82%, #020617 18%);
+  box-shadow: 0 10px 24px rgba(244, 63, 94, 0.18);
+  color: #fff1f2;
+}
+
+.settings-button-danger-solid:hover {
+  background: color-mix(in srgb, var(--danger) 88%, #020617 12%);
+}
+
+.settings-soft-panel {
+  background: var(--admin-surface-muted);
+  border: 1px solid var(--admin-border-subtle);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.settings-selection-card {
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  border: 1px solid var(--admin-border-subtle);
+}
+
+.settings-selection-card:hover {
+  background: color-mix(in srgb, var(--surface-hover) 84%, transparent);
+  border-color: var(--admin-border-strong);
+}
+
+.settings-selection-card-active {
+  background: color-mix(in srgb, var(--accent) 12%, var(--surface) 88%);
+  border-color: color-mix(in srgb, var(--accent) 24%, var(--admin-border-strong));
+}
+
+.settings-modal-overlay {
+  background: rgba(2, 6, 23, 0.55);
+  backdrop-filter: blur(10px);
+}
+
+.settings-modal-panel {
+  background: var(--admin-panel-bg);
+  border: 1px solid var(--admin-border-strong);
+  box-shadow: var(--admin-shadow-strong);
+  backdrop-filter: blur(24px);
+}
+
+.settings-workbench-column,
+.settings-workbench-pane,
+.settings-tools-panel {
+  background: var(--admin-surface-bg);
+  border: 1px solid var(--admin-border-subtle);
+  box-shadow: var(--admin-shadow-soft);
+  backdrop-filter: blur(20px);
+}
+
+.settings-workbench-pane {
+  overflow: hidden;
+}
+
+.settings-workbench-editor {
+  background: color-mix(in srgb, var(--slate-950) 92%, transparent);
+}
+
+.settings-tools input[type='text'],
+.settings-tools select,
+.settings-workbench input[type='text'],
+.settings-workbench input[type='password'],
+.settings-workbench select,
+.settings-workbench textarea {
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  border: 1px solid var(--admin-border-strong);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  color: var(--text-primary);
+}
+
+.settings-tools input[type='text']::placeholder,
+.settings-workbench input[type='text']::placeholder,
+.settings-workbench input[type='password']::placeholder,
+.settings-workbench textarea::placeholder {
+  color: var(--text-muted);
+}
+
+.settings-tools input[type='text']:focus,
+.settings-tools select:focus,
+.settings-workbench input[type='text']:focus,
+.settings-workbench input[type='password']:focus,
+.settings-workbench select:focus,
+.settings-workbench textarea:focus {
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--admin-border-strong));
+  box-shadow: 0 0 0 4px var(--admin-ring);
+  outline: none;
+}
+
+.settings-tools [class*='bg-[#1C1C1E]'],
+.settings-tools [class*='bg-[#2C2C2E]'],
+.settings-tools [class*='bg-[#F2F2F7]'] {
+  background: var(--admin-surface-muted) !important;
+}
+
+.settings-tools [class*='border-[#2C2C2E]'],
+.settings-tools [class*='border-[#3A3A3C]'] {
+  border-color: var(--admin-border-strong) !important;
+}
+
+.settings-tools [class*='bg-[#636366]'] {
+  background: color-mix(in srgb, var(--accent) 22%, var(--surface) 78%) !important;
+}
+
+.settings-tools [class*='text-[#8E8E93]'] {
+  color: var(--text-muted) !important;
+}
+
+.settings-tools [class*='text-black'] {
+  color: var(--text-primary) !important;
+}
+
+.settings-portal .bg-white {
+  background-color: color-mix(in srgb, var(--surface) 92%, transparent) !important;
+}
+
+.settings-portal .bg-white\/70 {
+  background-color: color-mix(in srgb, var(--surface) 70%, transparent) !important;
+}
+
+.settings-portal .bg-white\/92 {
+  background-color: color-mix(in srgb, var(--surface) 92%, transparent) !important;
+}
+
+.settings-portal .bg-slate-50 {
+  background-color: color-mix(in srgb, var(--surface-subtle) 90%, transparent) !important;
+}
+
+.settings-portal .bg-slate-50\/70 {
+  background-color: color-mix(in srgb, var(--surface-subtle) 70%, transparent) !important;
+}
+
+.settings-portal .bg-slate-50\/80 {
+  background-color: color-mix(in srgb, var(--surface-subtle) 80%, transparent) !important;
+}
+
+.settings-portal .bg-slate-50\/90 {
+  background-color: color-mix(in srgb, var(--surface-subtle) 90%, transparent) !important;
+}
+
+.settings-portal .bg-slate-100\/90 {
+  background-color: color-mix(in srgb, var(--surface-strong) 90%, transparent) !important;
+}
+
+.settings-portal .bg-slate-100 {
+  background-color: color-mix(in srgb, var(--surface-strong) 88%, transparent) !important;
+}
+
+.settings-portal .bg-amber-50 {
+  background-color: color-mix(in srgb, #f59e0b 12%, var(--surface) 88%) !important;
+}
+
+.settings-portal .bg-rose-50 {
+  background-color: color-mix(in srgb, #f43f5e 11%, var(--surface) 89%) !important;
+}
+
+.settings-portal .bg-emerald-50 {
+  background-color: color-mix(in srgb, #10b981 11%, var(--surface) 89%) !important;
+}
+
+.settings-portal .bg-emerald-100 {
+  background-color: color-mix(in srgb, #10b981 16%, var(--surface) 84%) !important;
+}
+
+.settings-portal .bg-rose-100 {
+  background-color: color-mix(in srgb, #f43f5e 15%, var(--surface) 85%) !important;
+}
+
+.settings-portal .border-amber-100,
+.settings-portal .border-amber-200 {
+  border-color: color-mix(in srgb, #f59e0b 26%, transparent) !important;
+}
+
+.settings-portal .border-rose-100,
+.settings-portal .border-rose-200 {
+  border-color: color-mix(in srgb, #f43f5e 26%, transparent) !important;
+}
+
+.settings-portal .border-emerald-100 {
+  border-color: color-mix(in srgb, #10b981 26%, transparent) !important;
+}
+
+.settings-portal .text-amber-700,
+.settings-portal .text-amber-800 {
+  color: color-mix(in srgb, #f59e0b 74%, var(--text-primary) 26%) !important;
+}
+
+.settings-portal .text-rose-700,
+.settings-portal .text-rose-800,
+.settings-portal .text-rose-600 {
+  color: color-mix(in srgb, #f43f5e 78%, var(--text-primary) 22%) !important;
+}
+
+.settings-portal .text-emerald-700,
+.settings-portal .text-emerald-800 {
+  color: color-mix(in srgb, #10b981 78%, var(--text-primary) 22%) !important;
+}
+
+.settings-portal .border-slate-300,
+.settings-portal .hover\:border-slate-300:hover,
+.settings-portal .focus\:border-slate-400:focus {
+  border-color: var(--admin-border-strong) !important;
+}
+
+.settings-portal .focus\:ring-slate-900\/5:focus,
+.settings-portal .focus\:ring-slate-900\/10:focus {
+  --tw-ring-color: var(--admin-ring) !important;
+}
+
+.settings-portal .hover\:bg-white:hover {
+  background-color: color-mix(in srgb, var(--surface) 96%, transparent) !important;
+}
+
+.settings-portal .hover\:bg-slate-50:hover {
+  background-color: color-mix(in srgb, var(--surface-subtle) 92%, transparent) !important;
+}
+
+.settings-portal .hover\:bg-slate-100:hover {
+  background-color: color-mix(in srgb, var(--surface-strong) 92%, transparent) !important;
+}
+
+.settings-portal .hover\:bg-slate-200:hover {
+  background-color: color-mix(in srgb, var(--surface-strong-hover) 92%, transparent) !important;
+}
+
+.settings-portal .hover\:bg-rose-50:hover {
+  background-color: color-mix(in srgb, #f43f5e 16%, var(--surface) 84%) !important;
+}
+
+.settings-portal .bg-slate-900 {
+  background-color: color-mix(in srgb, var(--slate-950) 86%, var(--accent) 14%) !important;
+}
+
+.settings-portal .hover\:bg-slate-800:hover {
+  background-color: color-mix(in srgb, var(--slate-950) 80%, var(--accent) 20%) !important;
+}
+
+.settings-portal .shadow-sm {
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08) !important;
+}
+
+.settings-portal .shadow-xl {
+  box-shadow: var(--admin-shadow-strong) !important;
 }
 
 .placeholder\:text-gray-500::placeholder {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,11 @@ import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App.tsx';
 import { AuthProvider } from './auth/AuthProvider';
+import { applyColorModeToDocument, resolveInitialColorMode } from './theme';
+
+// Apply the persisted color mode before React renders so direct-route loads
+// (for example /settings) honor the user's theme immediately.
+applyColorModeToDocument(resolveInitialColorMode());
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { Users2, Hammer, MessageCircle, Activity, Sparkles } from 'lucide-react';
+import { Users2, Hammer, MessageCircle, Activity, Sparkles, ArrowRight, ShieldCheck, BookOpen } from 'lucide-react';
 import SettingsShell from '../components/settings/SettingsShell';
 import {
   SettingsMetricCard,
@@ -21,46 +21,111 @@ const DashboardPage = () => {
     { title: 'New user invited', meta: 'Yesterday • sso-signup', icon: MessageCircle },
   ];
 
+  const focusAreas = [
+    {
+      title: 'Seed core skills',
+      description: 'The registry is still empty. Add starter skills so the workspace feels ready on first use.',
+      to: '/settings/agents',
+      action: 'Open skill registry',
+      icon: Sparkles,
+    },
+    {
+      title: 'Audit access coverage',
+      description: 'Only one user is active in the last 24 hours. Verify admin coverage and group mappings.',
+      to: '/settings/users',
+      action: 'Review users',
+      icon: ShieldCheck,
+    },
+    {
+      title: 'Track knowledge readiness',
+      description: 'Make ingestion health visible so indexed content is easy to trust and troubleshoot.',
+      to: '/settings/knowledge',
+      action: 'Review knowledge',
+      icon: BookOpen,
+    },
+  ];
+
   return (
     <SettingsShell
       eyebrow="Overview"
       title="Workspace Dashboard"
-      description="Pulse for your admin portal with quick access to skills, users, and tools."
+      description="Shared operational view for registry, people, knowledge, and tooling health."
     >
       <div className="space-y-6">
-        <SettingsSurface>
-          <SettingsSectionHeader
-            eyebrow="Snapshot"
-            title="Key workspace signals"
-            description="A compact overview of usage, adoption, and tool activity across the admin portal."
-          />
-          <SettingsMetricsGrid className="mt-6 md:grid-cols-3">
-            {stats.map(({ label, value, hint, icon: Icon }) => (
-              <SettingsMetricCard key={label} label={label} value={value} hint={hint} icon={Icon} />
-            ))}
-          </SettingsMetricsGrid>
-        </SettingsSurface>
+        <div className="grid gap-6 xl:grid-cols-[1.45fr_0.95fr]">
+          <SettingsSurface className="space-y-6">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="settings-portal-chip inline-flex rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em]">
+                Live workspace
+              </span>
+              <span className="inline-flex rounded-full border border-slate-200 bg-slate-50/80 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                Operations focus
+              </span>
+            </div>
+            <SettingsSectionHeader
+              eyebrow="Snapshot"
+              title="Key workspace signals"
+              description="A compact read on adoption, tooling activity, and admin readiness."
+            />
+            <SettingsMetricsGrid className="md:grid-cols-3">
+              {stats.map(({ label, value, hint, icon: Icon }) => (
+                <SettingsMetricCard key={label} label={label} value={value} hint={hint} icon={Icon} />
+              ))}
+            </SettingsMetricsGrid>
+          </SettingsSurface>
+
+          <SettingsSurface className="space-y-5">
+            <SettingsSectionHeader
+              eyebrow="Admin focus"
+              title="What needs attention"
+              description="Use the admin portal to tighten setup, access, and content coverage."
+            />
+            <div className="space-y-3">
+              {focusAreas.map(({ title, description, to, action, icon: Icon }) => (
+                <div key={title} className="settings-portal-card rounded-[22px] p-4">
+                  <div className="flex items-start gap-4">
+                    <span className="settings-portal-icon-muted inline-flex h-11 w-11 items-center justify-center rounded-2xl ring-1 ring-slate-200">
+                      <Icon size={18} />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-semibold text-slate-900">{title}</p>
+                      <p className="mt-1 text-sm leading-6 text-slate-600">{description}</p>
+                      <Link
+                        to={to}
+                        className="mt-3 inline-flex items-center gap-2 text-sm font-medium text-blue-600 transition hover:text-blue-700"
+                      >
+                        {action}
+                        <ArrowRight size={16} />
+                      </Link>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </SettingsSurface>
+        </div>
 
         <SettingsSurface>
           <SettingsSectionHeader
+            eyebrow="Activity"
             title="Recent activity"
             description="Stay on top of what changed across your workspace."
             actions={(
               <Link
                 to="/settings/agents"
-                className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-900 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800"
+                className="settings-portal-button-secondary inline-flex items-center gap-2 rounded-xl px-3.5 py-2.5 text-sm font-medium transition"
               >
                 Manage skills
               </Link>
             )}
           />
-          <div className="mt-6 divide-y divide-slate-200">
+          <div className="mt-6 space-y-3">
             {activities.map(({ title, meta, icon: Icon }) => (
-              <div key={title} className="flex items-center gap-3 py-3">
-                <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-slate-100 text-slate-700">
+              <div key={title} className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-4">
+                <span className="settings-portal-icon-muted inline-flex h-10 w-10 items-center justify-center rounded-2xl ring-1 ring-slate-200">
                   <Icon size={18} />
                 </span>
-                <div>
+                <div className="min-w-0">
                   <p className="text-sm font-medium text-slate-900">{title}</p>
                   <p className="text-xs text-slate-500">{meta}</p>
                 </div>

--- a/frontend/src/pages/KnowledgePage.tsx
+++ b/frontend/src/pages/KnowledgePage.tsx
@@ -25,8 +25,8 @@ type KnowledgeSource = {
   content?: string | null;
   fileId?: number | null;
   sourceUrl?: string | null;
-  tags?: any;
-  metadata?: Record<string, any> | null;
+  tags?: unknown;
+  metadata?: Record<string, unknown> | null;
   createdAt: string;
   updatedAt: string;
   file?: {
@@ -292,7 +292,7 @@ const KnowledgePage = () => {
     <div className="flex flex-wrap items-center gap-3">
       <div className="relative">
         <select
-          className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-900/10"
+          className="settings-control rounded-xl px-3 py-2 text-sm"
           value={selectedWorkspaceId}
           onChange={(event) => setSelectedWorkspaceId(event.target.value)}
           disabled={loadingWorkspaces}
@@ -311,7 +311,7 @@ const KnowledgePage = () => {
         type="button"
         onClick={handleRefresh}
         disabled={!selectedWorkspaceId || loadingKnowledge || loadingStatuses}
-        className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:opacity-60"
+        className="settings-portal-button-secondary inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition disabled:opacity-60"
       >
         {loadingKnowledge || loadingStatuses ? <Loader2 className="h-4 w-4 animate-spin" /> : <RotateCcw size={16} />}
         Refresh
@@ -382,7 +382,7 @@ const KnowledgePage = () => {
               description="Upload files and we’ll index supported documents automatically."
             />
 
-            <div className="mt-6 rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-6 text-center">
+            <div className="settings-soft-panel mt-6 rounded-2xl border border-dashed p-6 text-center">
               <input
                 ref={uploadInputRef}
                 type="file"
@@ -394,7 +394,7 @@ const KnowledgePage = () => {
                 type="button"
                 onClick={handleUploadClick}
                 disabled={!selectedWorkspaceId || uploading}
-                className="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-4 py-2.5 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800 disabled:opacity-60"
+                className="settings-button-primary inline-flex items-center gap-2 rounded-2xl px-4 py-2.5 text-sm font-medium transition disabled:opacity-60"
               >
                 {uploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus size={16} />}
                 Upload files
@@ -407,7 +407,7 @@ const KnowledgePage = () => {
               ) : null}
             </div>
 
-            <div className="mt-6 rounded-[24px] border border-slate-100 bg-white/70 p-5">
+            <div className="settings-portal-card mt-6 rounded-[24px] p-5">
               <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Tips</p>
               <ul className="mt-2 space-y-2 text-sm text-slate-600">
                 <li>RAG indexing runs for PDF, DOC/DOCX, and Markdown files.</li>
@@ -445,10 +445,10 @@ const KnowledgePage = () => {
               {knowledgeSources.map((item) => (
                 <div
                   key={item.id}
-                  className="rounded-[24px] border border-slate-200 bg-slate-50/70 p-4 shadow-[0_10px_22px_rgba(15,23,42,0.06)]"
+                  className="settings-portal-card rounded-[24px] p-4"
                 >
                   <div className="flex items-start gap-4">
-                    <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white text-slate-700 ring-1 ring-slate-200">
+                    <span className="settings-portal-icon-muted flex h-10 w-10 items-center justify-center rounded-2xl ring-1 ring-slate-200">
                       <FileIcon size={18} />
                     </span>
                     <div className="flex-1 space-y-2">
@@ -464,7 +464,7 @@ const KnowledgePage = () => {
                           {renderStatusBadge(item.file?.name)}
                           <button
                             type="button"
-                            className="inline-flex items-center gap-1 rounded-xl border border-slate-200 bg-white px-2.5 py-1.5 text-xs text-slate-600 transition hover:bg-slate-50"
+                            className="settings-portal-button-secondary inline-flex items-center gap-1 rounded-xl px-2.5 py-1.5 text-xs transition"
                             onClick={() => handleDeleteKnowledge(item)}
                           >
                             <Trash size={12} />
@@ -489,7 +489,7 @@ const KnowledgePage = () => {
             actions={(
               <Link
                 to="/settings/agents"
-                className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-900 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800"
+                className="settings-portal-button-secondary inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition"
               >
                 Configure skills
               </Link>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,37 +1,26 @@
 import { useEffect, useMemo, useState } from 'react';
+import type { PaletteMode } from '@mui/material';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Sun, Moon } from 'lucide-react';
 import { useAuth } from '../auth/AuthProvider';
+import { applyColorModeToDocument, resolveInitialColorMode } from '../theme';
 
 interface LocationState {
   from?: string;
 }
 
-type PaletteMode = 'light' | 'dark';
-
 const LoginPage = () => {
   const { user, googleReady, googleError, authMode, signInWithGoogle, signInWithHeaders } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const [colorMode, setColorMode] = useState<PaletteMode>(() => {
-    if (typeof window === 'undefined') return 'light';
-    const stored = window.localStorage.getItem('helpudoc-color-mode');
-    if (stored === 'light' || stored === 'dark') {
-      return stored;
-    }
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  });
+  const [colorMode, setColorMode] = useState<PaletteMode>(resolveInitialColorMode);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [headerName, setHeaderName] = useState('');
   const [headerEmail, setHeaderEmail] = useState('');
 
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', colorMode);
-    document.documentElement.classList.toggle('dark', colorMode === 'dark');
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('helpudoc-color-mode', colorMode);
-    }
+    applyColorModeToDocument(colorMode);
   }, [colorMode]);
 
   useEffect(() => {

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -338,7 +338,7 @@ const UsersPage = () => {
                 return (
                   <div
                     key={user.id}
-                    className="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3"
+                    className="settings-selection-card flex items-center justify-between gap-3 rounded-2xl px-4 py-3"
                   >
                     <div className="min-w-0">
                       <p className="truncate text-sm font-medium text-slate-900">{user.displayName}</p>
@@ -396,12 +396,12 @@ const UsersPage = () => {
                   value={newGroupName}
                   onChange={(event) => setNewGroupName(event.target.value)}
                   placeholder="Create group (e.g. analysts)"
-                  className="flex-1 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm shadow-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-900/5"
+                  className="settings-control flex-1 rounded-2xl px-4 py-3 text-sm"
                 />
                 <button
                   type="button"
                   onClick={handleCreateGroup}
-                  className="inline-flex items-center justify-center gap-2 rounded-2xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+                  className="settings-button-primary inline-flex items-center justify-center gap-2 rounded-2xl px-4 py-3 text-sm font-semibold transition"
                 >
                   <Plus size={14} />
                   Add group
@@ -421,10 +421,10 @@ const UsersPage = () => {
                     <div
                       key={group.id}
                       className={cx(
-                        'flex items-center justify-between rounded-2xl border px-4 py-3 transition',
+                        'flex items-center justify-between rounded-2xl px-4 py-3 transition',
                         group.id === selectedGroupId
-                          ? 'border-slate-900 bg-slate-100'
-                          : 'border-slate-200 bg-slate-50/70',
+                          ? 'settings-selection-card settings-selection-card-active'
+                          : 'settings-selection-card',
                       )}
                     >
                       <button
@@ -447,7 +447,7 @@ const UsersPage = () => {
               )}
 
               {selectedGroup ? (
-                <div className="space-y-5 rounded-[24px] border border-slate-200 bg-slate-50/80 p-5">
+                <div className="settings-soft-panel space-y-5 rounded-[24px] p-5">
                   {accessLoading ? <SettingsLoadingState label="Loading group details..." /> : null}
 
                   {!accessLoading ? (
@@ -465,7 +465,7 @@ const UsersPage = () => {
                       <div className="space-y-4">
                         <div className="flex flex-col gap-3 sm:flex-row">
                           <select
-                            className="flex-1 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm shadow-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-900/5"
+                            className="settings-control flex-1 rounded-2xl px-4 py-3 text-sm"
                             value={selectedUserId}
                             onChange={(event) => setSelectedUserId(event.target.value)}
                           >
@@ -477,7 +477,7 @@ const UsersPage = () => {
                           <button
                             type="button"
                             onClick={handleAddMember}
-                            className="rounded-2xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+                            className="settings-button-primary rounded-2xl px-4 py-3 text-sm font-semibold transition"
                           >
                             Add member
                           </button>
@@ -494,7 +494,7 @@ const UsersPage = () => {
                             groupMembers.map((member) => (
                               <div
                                 key={member.id}
-                                className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white px-4 py-3"
+                                className="settings-selection-card flex items-center justify-between rounded-2xl px-4 py-3"
                               >
                                 <span className="text-sm text-slate-800">{member.displayName}</span>
                                 <button
@@ -510,7 +510,7 @@ const UsersPage = () => {
                         </div>
                       </div>
 
-                      <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4">
+                      <div className="settings-portal-card space-y-4 rounded-2xl p-4">
                         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                           <div>
                             <p className="text-sm font-semibold text-slate-900">Prompt access</p>
@@ -527,7 +527,7 @@ const UsersPage = () => {
                                 'rounded-xl px-3 py-2 text-xs font-semibold transition',
                                 !isAccessDirty || accessSaving
                                   ? 'cursor-not-allowed bg-slate-100 text-slate-400'
-                                  : 'bg-slate-100 text-slate-700 hover:bg-slate-200',
+                                  : 'settings-portal-button-secondary',
                               )}
                             >
                               Reset
@@ -540,7 +540,7 @@ const UsersPage = () => {
                                 'inline-flex items-center gap-2 rounded-xl px-3 py-2 text-xs font-semibold transition',
                                 !isAccessDirty || accessSaving
                                   ? 'cursor-not-allowed bg-slate-200 text-slate-500'
-                                  : 'bg-slate-900 text-white hover:bg-slate-800',
+                                  : 'settings-button-primary',
                               )}
                             >
                               {accessSaving ? <Loader2 size={14} className="animate-spin" /> : <KeyRound size={14} />}
@@ -558,10 +558,10 @@ const UsersPage = () => {
                                 value={skillSearch}
                                 onChange={(event) => setSkillSearch(event.target.value)}
                                 placeholder="Filter skills"
-                                className="w-full rounded-xl border border-slate-300 bg-white py-2 pl-9 pr-3 text-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-900/5"
+                                className="settings-control w-full rounded-xl py-2 pl-9 pr-3 text-sm"
                               />
                             </div>
-                            <div className="max-h-80 space-y-2 overflow-y-auto rounded-2xl border border-slate-200 bg-slate-50 p-2">
+                            <div className="settings-soft-panel max-h-80 space-y-2 overflow-y-auto rounded-2xl p-2">
                               {catalogLoading ? <SettingsLoadingState label="Loading skills..." /> : null}
                               {!catalogLoading && filteredSkills.length === 0 ? (
                                 <SettingsEmptyState
@@ -580,12 +580,12 @@ const UsersPage = () => {
                                     className={cx(
                                       'w-full rounded-2xl border px-3 py-3 text-left transition',
                                       selected
-                                        ? 'border-slate-900 bg-slate-900 text-white'
-                                        : 'border-slate-200 bg-white text-slate-900 hover:border-slate-300',
+                                        ? 'settings-selection-card settings-selection-card-active text-slate-900'
+                                        : 'settings-selection-card text-slate-900',
                                     )}
                                   >
                                     <p className="text-sm font-semibold">{skill.name || skill.id}</p>
-                                    <p className={cx('mt-1 text-xs leading-5', selected ? 'text-slate-200' : 'text-slate-500')}>
+                                    <p className={cx('mt-1 text-xs leading-5', selected ? 'text-slate-600' : 'text-slate-500')}>
                                       {skill.description || skill.id}
                                     </p>
                                   </button>
@@ -602,10 +602,10 @@ const UsersPage = () => {
                                 value={mcpSearch}
                                 onChange={(event) => setMcpSearch(event.target.value)}
                                 placeholder="Filter MCP servers"
-                                className="w-full rounded-xl border border-slate-300 bg-white py-2 pl-9 pr-3 text-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-900/5"
+                                className="settings-control w-full rounded-xl py-2 pl-9 pr-3 text-sm"
                               />
                             </div>
-                            <div className="max-h-80 space-y-2 overflow-y-auto rounded-2xl border border-slate-200 bg-slate-50 p-2">
+                            <div className="settings-soft-panel max-h-80 space-y-2 overflow-y-auto rounded-2xl p-2">
                               {catalogLoading ? <SettingsLoadingState label="Loading MCP servers..." /> : null}
                               {!catalogLoading && filteredMcpServers.length === 0 ? (
                                 <SettingsEmptyState
@@ -624,12 +624,12 @@ const UsersPage = () => {
                                     className={cx(
                                       'w-full rounded-2xl border px-3 py-3 text-left transition',
                                       selected
-                                        ? 'border-slate-900 bg-slate-900 text-white'
-                                        : 'border-slate-200 bg-white text-slate-900 hover:border-slate-300',
+                                        ? 'settings-selection-card settings-selection-card-active text-slate-900'
+                                        : 'settings-selection-card text-slate-900',
                                     )}
                                   >
                                     <p className="text-sm font-semibold">{server.name}</p>
-                                    <p className={cx('mt-1 text-xs leading-5', selected ? 'text-slate-200' : 'text-slate-500')}>
+                                    <p className={cx('mt-1 text-xs leading-5', selected ? 'text-slate-600' : 'text-slate-500')}>
                                       {server.description || 'Allow prompts in this group to target this MCP server.'}
                                     </p>
                                   </button>
@@ -649,8 +649,8 @@ const UsersPage = () => {
       </div>
 
       {pendingDeleteUser ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/35 px-4">
-          <div className="w-full max-w-2xl rounded-[28px] border border-slate-200 bg-white p-6 shadow-[0_24px_80px_rgba(15,23,42,0.2)]">
+        <div className="settings-modal-overlay fixed inset-0 z-50 flex items-center justify-center px-4">
+          <div className="settings-modal-panel w-full max-w-2xl rounded-[28px] p-6">
             <div className="flex items-start justify-between gap-4">
               <div>
                 <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-rose-500">Destructive action</p>
@@ -710,7 +710,7 @@ const UsersPage = () => {
                   setPendingDeleteUser(null);
                   setDeletionImpact(null);
                 }}
-                className="rounded-2xl border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+                className="settings-portal-button-secondary rounded-2xl px-4 py-2.5 text-sm font-semibold transition"
               >
                 Cancel
               </button>
@@ -722,7 +722,7 @@ const UsersPage = () => {
                   'inline-flex items-center gap-2 rounded-2xl px-4 py-2.5 text-sm font-semibold text-white transition',
                   deletionImpactLoading || deletingUserId === pendingDeleteUser.id
                     ? 'cursor-not-allowed bg-rose-300'
-                    : 'bg-rose-600 hover:bg-rose-700',
+                    : 'settings-button-danger-solid',
                 )}
               >
                 {deletingUserId === pendingDeleteUser.id ? <Loader2 size={16} className="animate-spin" /> : <Trash2 size={16} />}

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -6,7 +6,6 @@ import {
   Box,
   CssBaseline,
   ThemeProvider,
-  createTheme,
   type PaletteMode,
 } from '@mui/material';
 import { CheckSquare, Copy, Edit, Trash, Plus, Minus, ChevronLeft, RotateCcw, X, Printer, Download, Link as LinkIcon, Loader2 } from 'lucide-react';
@@ -81,46 +80,9 @@ import {
 } from '../utils/workspaceFileTree';
 import { buildMessageMetadata, mapMessagesToAgentHistory, mergeMessageMetadata, sanitizeRunPolicy } from '../utils/messages';
 import { createMarkdownComponents } from '../components/markdown/MarkdownShared';
+import { applyColorModeToDocument, buildAppTheme, resolveInitialColorMode } from '../theme';
 
 const drawerWidth = 280;
-
-const buildTheme = (mode: PaletteMode) =>
-  createTheme({
-    palette: {
-      mode,
-      primary: {
-        main: mode === 'light' ? '#2563eb' : '#60a5fa',
-      },
-      background: {
-        default: mode === 'light' ? '#f8fafc' : '#0b1220',
-        paper: mode === 'light' ? '#ffffff' : '#0f172a',
-      },
-      text: {
-        primary: mode === 'light' ? '#0f172a' : '#e2e8f0',
-        secondary: mode === 'light' ? '#475569' : '#cbd5e1',
-      },
-      divider: mode === 'light' ? '#e2e8f0' : '#1f2937',
-    },
-    shape: {
-      borderRadius: 12,
-    },
-    components: {
-      MuiDrawer: {
-        styleOverrides: {
-          paper: {
-            backgroundColor: mode === 'light' ? '#f8fafc' : '#0f172a',
-          },
-        },
-      },
-      MuiPaper: {
-        styleOverrides: {
-          root: {
-            backgroundImage: 'none',
-          },
-        },
-      },
-    },
-  });
 
 const sanitizePresentationLabel = (value: string, fallback: string) => {
   const normalized = normalizeFilePath(value);
@@ -309,14 +271,7 @@ type PersistProgressRequest = {
 export default function WorkspacePage() {
   const navigate = useNavigate();
   const { signOut } = useAuth();
-  const [colorMode, setColorMode] = useState<PaletteMode>(() => {
-    if (typeof window === 'undefined') return 'light';
-    const stored = window.localStorage.getItem('helpudoc-color-mode');
-    if (stored === 'light' || stored === 'dark') {
-      return stored;
-    }
-    return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  });
+  const [colorMode, setColorMode] = useState<PaletteMode>(resolveInitialColorMode);
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [selectedWorkspace, setSelectedWorkspace] = useState<Workspace | null>(null);
   const [workspaceSettingsBusy, setWorkspaceSettingsBusy] = useState(false);
@@ -414,7 +369,7 @@ export default function WorkspacePage() {
   const ragStatusFetchedRef = useRef<Record<string, boolean>>({});
   const resumeInFlightRef = useRef<Set<string>>(new Set());
   const resumeAttemptedRef = useRef<Set<string>>(new Set());
-  const theme = useMemo(() => buildTheme(colorMode), [colorMode]);
+  const theme = useMemo(() => buildAppTheme(colorMode), [colorMode]);
   const messages = useMemo(
     () => (activeConversationId ? conversationMessages[activeConversationId] || [] : []),
     [activeConversationId, conversationMessages],
@@ -584,10 +539,7 @@ export default function WorkspacePage() {
   }, []);
 
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', colorMode);
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('helpudoc-color-mode', colorMode);
-    }
+    applyColorModeToDocument(colorMode);
   }, [colorMode]);
 
   useEffect(() => {

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -7,9 +7,13 @@ export const resolveInitialColorMode = (): PaletteMode => {
     return 'light';
   }
 
-  const stored = window.localStorage.getItem(APP_COLOR_MODE_STORAGE_KEY);
-  if (stored === 'light' || stored === 'dark') {
-    return stored;
+  try {
+    const stored = window.localStorage.getItem(APP_COLOR_MODE_STORAGE_KEY);
+    if (stored === 'light' || stored === 'dark') {
+      return stored;
+    }
+  } catch (error) {
+    console.warn('Failed to read persisted color mode', error);
   }
 
   return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
@@ -22,7 +26,11 @@ export const applyColorModeToDocument = (mode: PaletteMode) => {
   }
 
   if (typeof window !== 'undefined') {
-    window.localStorage.setItem(APP_COLOR_MODE_STORAGE_KEY, mode);
+    try {
+      window.localStorage.setItem(APP_COLOR_MODE_STORAGE_KEY, mode);
+    } catch (error) {
+      console.warn('Failed to persist color mode', error);
+    }
   }
 };
 

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,41 +1,85 @@
-import { createTheme } from '@mui/material/styles';
+import { createTheme, type PaletteMode } from '@mui/material/styles';
 
-const theme = createTheme({
-  palette: {
-    primary: {
-      main: '#1976d2',
+export const APP_COLOR_MODE_STORAGE_KEY = 'helpudoc-color-mode';
+
+export const resolveInitialColorMode = (): PaletteMode => {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  const stored = window.localStorage.getItem(APP_COLOR_MODE_STORAGE_KEY);
+  if (stored === 'light' || stored === 'dark') {
+    return stored;
+  }
+
+  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
+export const applyColorModeToDocument = (mode: PaletteMode) => {
+  if (typeof document !== 'undefined') {
+    document.documentElement.setAttribute('data-theme', mode);
+    document.documentElement.classList.toggle('dark', mode === 'dark');
+  }
+
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(APP_COLOR_MODE_STORAGE_KEY, mode);
+  }
+};
+
+export const buildAppTheme = (mode: PaletteMode) =>
+  createTheme({
+    palette: {
+      mode,
+      primary: {
+        main: mode === 'light' ? '#2563eb' : '#60a5fa',
+      },
+      background: {
+        default: mode === 'light' ? '#f8fafc' : '#0b1220',
+        paper: mode === 'light' ? '#ffffff' : '#0f172a',
+      },
+      text: {
+        primary: mode === 'light' ? '#0f172a' : '#e2e8f0',
+        secondary: mode === 'light' ? '#475569' : '#cbd5e1',
+      },
+      divider: mode === 'light' ? '#e2e8f0' : '#1f2937',
     },
-    background: {
-      default: '#ffffff',
-      paper: '#f5f5f5',
+    shape: {
+      borderRadius: 12,
     },
-    text: {
-      primary: '#212121',
-      secondary: '#757575',
+    typography: {
+      fontFamily: 'Inter, sans-serif',
     },
-  },
-  typography: {
-    fontFamily: 'Inter, sans-serif',
-  },
-  components: {
-    MuiButton: {
-      styleOverrides: {
-        root: {
-          borderRadius: '8px',
-          textTransform: 'none',
+    components: {
+      MuiDrawer: {
+        styleOverrides: {
+          paper: {
+            backgroundColor: mode === 'light' ? '#f8fafc' : '#0f172a',
+          },
         },
       },
-    },
-    MuiTextField: {
-      styleOverrides: {
-        root: {
-          '& .MuiOutlinedInput-root': {
-            borderRadius: '8px',
+      MuiPaper: {
+        styleOverrides: {
+          root: {
+            backgroundImage: 'none',
+          },
+        },
+      },
+      MuiButton: {
+        styleOverrides: {
+          root: {
+            borderRadius: 12,
+            textTransform: 'none',
+          },
+        },
+      },
+      MuiTextField: {
+        styleOverrides: {
+          root: {
+            '& .MuiOutlinedInput-root': {
+              borderRadius: 12,
+            },
           },
         },
       },
     },
-  },
-});
-
-export default theme;
+  });


### PR DESCRIPTION
## Summary
Unifies the workspace and admin portal under one shared theme system so dark mode, spacing, surfaces, and controls feel consistent across the app.

## What changed
- Centralized color-mode resolution and document syncing so direct admin routes honor the persisted theme on first paint.
- Refreshed the admin shell, dashboard, tools, knowledge, users, and login screens to use the same visual language as the workspace.
- Standardized surfaces, empty states, buttons, tabs, and panel treatments across the portal.

## Validation
- `npm run build` in `frontend`

## Notes
This is the visual/system pass only. Route structure and backend behavior stay the same.
