### PR TITLE
Defer heavy editor bundles and improve frontend chunking

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
-import WorkspacePage from './pages/WorkspacePage';
-import AgentSettingsPage from './pages/AgentSettingsPage';
-import DashboardPage from './pages/DashboardPage';
-import KnowledgePage from './pages/KnowledgePage';
-import UsersPage from './pages/UsersPage';
-import BillingPage from './pages/BillingPage';
-import LoginPage from './pages/LoginPage';
 import { useAuth } from './auth/AuthProvider';
+
+const WorkspacePage = lazy(() => import('./pages/WorkspacePage'));
+const AgentSettingsPage = lazy(() => import('./pages/AgentSettingsPage'));
+const DashboardPage = lazy(() => import('./pages/DashboardPage'));
+const KnowledgePage = lazy(() => import('./pages/KnowledgePage'));
+const UsersPage = lazy(() => import('./pages/UsersPage'));
+const BillingPage = lazy(() => import('./pages/BillingPage'));
+const LoginPage = lazy(() => import('./pages/LoginPage'));
 
 const RequireAuth: React.FC<{ children: React.ReactElement }> = ({ children }) => {
   const { user, loading } = useAuth();
@@ -30,58 +31,66 @@ const RequireAuth: React.FC<{ children: React.ReactElement }> = ({ children }) =
 
 const App: React.FC = () => {
   return (
-    <Routes>
-      <Route path="/login" element={<LoginPage />} />
-      <Route
-        path="/"
-        element={
-          <RequireAuth>
-            <WorkspacePage />
-          </RequireAuth>
-        }
-      />
-      <Route
-        path="/settings"
-        element={
-          <RequireAuth>
-            <DashboardPage />
-          </RequireAuth>
-        }
-      />
-      <Route
-        path="/settings/agents"
-        element={
-          <RequireAuth>
-            <AgentSettingsPage />
-          </RequireAuth>
-        }
-      />
-      <Route
-        path="/settings/knowledge"
-        element={
-          <RequireAuth>
-            <KnowledgePage />
-          </RequireAuth>
-        }
-      />
-      <Route
-        path="/settings/users"
-        element={
-          <RequireAuth>
-            <UsersPage />
-          </RequireAuth>
-        }
-      />
-      <Route
-        path="/settings/billing"
-        element={
-          <RequireAuth>
-            <BillingPage />
-          </RequireAuth>
-        }
-      />
-      <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
+    <Suspense
+      fallback={(
+        <div className="flex min-h-screen items-center justify-center bg-[var(--app-bg)] text-slate-500">
+          Loading page…
+        </div>
+      )}
+    >
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route
+          path="/"
+          element={
+            <RequireAuth>
+              <WorkspacePage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/settings"
+          element={
+            <RequireAuth>
+              <DashboardPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/settings/agents"
+          element={
+            <RequireAuth>
+              <AgentSettingsPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/settings/knowledge"
+          element={
+            <RequireAuth>
+              <KnowledgePage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/settings/users"
+          element={
+            <RequireAuth>
+              <UsersPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/settings/billing"
+          element={
+            <RequireAuth>
+              <BillingPage />
+            </RequireAuth>
+          }
+        />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </Suspense>
   );
 };
 

--- a/frontend/src/components/EditorLoadingState.tsx
+++ b/frontend/src/components/EditorLoadingState.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Loader2 } from 'lucide-react';
+
+type EditorLoadingStateProps = {
+  className?: string;
+  label?: string;
+};
+
+const EditorLoadingState: React.FC<EditorLoadingStateProps> = ({
+  className = 'h-full',
+  label = 'Loading editor...',
+}) => (
+  <div className={`flex items-center justify-center bg-slate-950/5 text-slate-500 ${className}`}>
+    <div className="flex items-center gap-2 text-sm">
+      <Loader2 size={16} className="animate-spin" />
+      <span>{label}</span>
+    </div>
+  </div>
+);
+
+export default EditorLoadingState;

--- a/frontend/src/components/FileEditor.tsx
+++ b/frontend/src/components/FileEditor.tsx
@@ -291,18 +291,23 @@ const FileEditor: React.FC<FileEditorProps> = ({
     const model = editorInstance.getModel();
     if (!model) return;
 
-    const { MonacoBinding } = await import('y-monaco');
-    if (collabSessionRef.current !== session || editorRef.current !== editorInstance) {
-      return;
-    }
+    try {
+      const { MonacoBinding } = await import('y-monaco');
+      if (collabSessionRef.current !== session || editorRef.current !== editorInstance) {
+        return;
+      }
 
-    monacoBindingRef.current?.destroy();
-    monacoBindingRef.current = new MonacoBinding(
-      session.yText,
-      model,
-      new Set([editorInstance]),
-      session.provider.awareness ?? undefined,
-    );
+      monacoBindingRef.current?.destroy();
+      monacoBindingRef.current = new MonacoBinding(
+        session.yText,
+        model,
+        new Set([editorInstance]),
+        session.provider.awareness ?? undefined,
+      );
+      setCollabReady(true);
+    } catch (error) {
+      console.error('Failed to initialize Monaco collaboration binding', error);
+    }
   }, [fileName]);
 
   useEffect(() => {
@@ -323,7 +328,7 @@ const FileEditor: React.FC<FileEditorProps> = ({
 
     const session = createCollabSession(workspaceId, fileId);
     collabSessionRef.current = session;
-    setCollabReady(true);
+    setCollabReady(false);
     setConnectionStatus('connecting');
     hasSeededRef.current = false;
 
@@ -559,7 +564,7 @@ const FileEditor: React.FC<FileEditorProps> = ({
           </div>
         ) : (
           <Suspense fallback={<EditorLoadingState />}>
-            <MonacoEditor
+          <MonacoEditor
               height="100%"
               language={getLanguage(file.name)}
               defaultValue={fileContent}
@@ -571,6 +576,7 @@ const FileEditor: React.FC<FileEditorProps> = ({
               }}
               theme={monacoTheme}
               options={{
+                readOnly: !collabReady,
                 wordWrap: 'on',
                 wrappingIndent: 'indent',
                 minimap: { enabled: false },

--- a/frontend/src/components/FileEditor.tsx
+++ b/frontend/src/components/FileEditor.tsx
@@ -1,42 +1,15 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import Editor, { type OnMount } from '@monaco-editor/react';
-import type { File as WorkspaceFile } from '../types';
-import { editor } from 'monaco-editor';
+import React, { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import type { editor as MonacoEditorNamespace } from 'monaco-editor';
 import { Eye, EyeOff } from 'lucide-react';
-import {
-  MDXEditor,
-  type CodeBlockEditorDescriptor,
-  type MDXEditorMethods,
-  useCodeBlockEditorContext,
-  headingsPlugin,
-  imagePlugin,
-  linkDialogPlugin,
-  linkPlugin,
-  listsPlugin,
-  markdownShortcutPlugin,
-  quotePlugin,
-  tablePlugin,
-  thematicBreakPlugin,
-  toolbarPlugin,
-  codeBlockPlugin,
-  codeMirrorPlugin,
-  UndoRedo,
-  BoldItalicUnderlineToggles,
-  BlockTypeSelect,
-  InsertCodeBlock,
-  CodeToggle,
-  CreateLink,
-  InsertImage,
-  InsertTable,
-  ListsToggle,
-  Separator,
-} from '@mdxeditor/editor';
-import '@mdxeditor/editor/style.css';
-import { MonacoBinding } from 'y-monaco';
-import { createCollabSession } from '../services/collabClient';
+import type { File as WorkspaceFile } from '../types';
 import { getAuthUser } from '../auth/authStore';
 import { createFile } from '../services/fileApi';
-import { MermaidDiagram, useMermaidColorMode } from './markdown/MarkdownShared';
+import { createCollabSession } from '../services/collabClient';
+import EditorLoadingState from './EditorLoadingState';
+import type { MarkdownRichEditorHandle } from './MarkdownRichEditor';
+
+const MonacoEditor = lazy(() => import('@monaco-editor/react'));
+const MarkdownRichEditor = lazy(() => import('./MarkdownRichEditor'));
 
 const COLLAB_COLORS = [
   '#0ea5e9',
@@ -120,100 +93,6 @@ interface FileEditorProps {
   colorMode: 'light' | 'dark';
 }
 
-const CODE_BLOCK_LANGUAGES: Record<string, string> = {
-  '': 'Plain text',
-  js: 'JavaScript',
-  ts: 'TypeScript',
-  jsx: 'JSX',
-  tsx: 'TSX',
-  json: 'JSON',
-  css: 'CSS',
-  html: 'HTML',
-  md: 'Markdown',
-  bash: 'Bash',
-  shell: 'Shell',
-  python: 'Python',
-  sql: 'SQL',
-  yaml: 'YAML',
-  mermaid: 'Mermaid',
-};
-
-const MermaidCodeBlockEditor = ({
-  code,
-  focusEmitter,
-}: {
-  code: string;
-  focusEmitter: { subscribe: (cb: () => void) => void };
-}) => {
-  const { lexicalNode, parentEditor, setCode } = useCodeBlockEditorContext();
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const [draft, setDraft] = useState(code);
-  const mermaidColorMode = useMermaidColorMode();
-
-  useEffect(() => {
-    setDraft(code);
-  }, [code]);
-
-  useEffect(() => {
-    focusEmitter.subscribe(() => {
-      textareaRef.current?.focus();
-    });
-  }, [focusEmitter]);
-
-  return (
-    <div className="helpudoc-mermaid-editor not-prose my-4 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
-      <div className="flex items-center justify-between border-b border-slate-200 bg-slate-50 px-4 py-2">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Mermaid</p>
-          <p className="text-xs text-slate-500">Edit the diagram source and preview it live.</p>
-        </div>
-        <button
-          type="button"
-          className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-600 hover:bg-slate-100"
-          onClick={() => {
-            parentEditor.update(() => {
-              lexicalNode.remove();
-            });
-          }}
-        >
-          Remove
-        </button>
-      </div>
-      <div className="grid gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-        <label className="flex min-h-[260px] flex-col gap-2">
-          <span className="text-xs font-medium text-slate-600">Source</span>
-          <textarea
-            ref={textareaRef}
-            value={draft}
-            onChange={(event) => {
-              const nextValue = event.target.value;
-              setDraft(nextValue);
-              setCode(nextValue);
-            }}
-            spellCheck={false}
-            className="min-h-[240px] w-full resize-y rounded-xl border border-slate-200 bg-slate-950 p-4 font-mono text-sm leading-relaxed text-slate-100 focus:border-blue-400 focus:outline-none"
-          />
-        </label>
-        <div className="flex min-h-[260px] flex-col gap-2">
-          <span className="text-xs font-medium text-slate-600">Preview</span>
-          <MermaidDiagram
-            chart={draft}
-            colorMode={mermaidColorMode}
-            className={`mermaid-container h-full min-h-[240px] overflow-auto rounded-xl border p-4 ${mermaidColorMode === 'dark' ? 'border-slate-700 bg-slate-950' : 'border-slate-200 bg-white'}`}
-            fallbackClassName="h-full min-h-[240px]"
-          />
-        </div>
-      </div>
-    </div>
-  );
-};
-
-const mermaidCodeBlockDescriptor: CodeBlockEditorDescriptor = {
-  priority: 100,
-  match: (language) => language === 'mermaid',
-  Editor: MermaidCodeBlockEditor,
-};
-
 const FileEditor: React.FC<FileEditorProps> = ({
   file,
   fileContent,
@@ -224,10 +103,10 @@ const FileEditor: React.FC<FileEditorProps> = ({
   const fileId = file?.id ? String(file.id) : null;
   const fileName = file?.name ?? '';
   const isDraftFile = Boolean(fileId && fileId.startsWith('draft:'));
-  const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
-  const mdxEditorRef = useRef<MDXEditorMethods | null>(null);
+  const editorRef = useRef<MonacoEditorNamespace.IStandaloneCodeEditor | null>(null);
+  const mdxEditorRef = useRef<MarkdownRichEditorHandle | null>(null);
   const collabSessionRef = useRef<ReturnType<typeof createCollabSession> | null>(null);
-  const monacoBindingRef = useRef<MonacoBinding | null>(null);
+  const monacoBindingRef = useRef<{ destroy: () => void } | null>(null);
   const presenceStyleRef = useRef<HTMLStyleElement | null>(null);
   const lastContentRef = useRef<string>(fileContent);
   const isApplyingRemoteRef = useRef(false);
@@ -250,93 +129,68 @@ const FileEditor: React.FC<FileEditorProps> = ({
     return created.publicUrl;
   }, [workspaceId]);
 
-  const mdxPlugins = useMemo(
-    () => [
-      headingsPlugin(),
-      listsPlugin(),
-      quotePlugin(),
-      thematicBreakPlugin(),
-      linkPlugin(),
-      linkDialogPlugin(),
-      tablePlugin(),
-      imagePlugin({ imageUploadHandler: handleImageUpload }),
-      codeBlockPlugin({
-        codeBlockEditorDescriptors: [mermaidCodeBlockDescriptor],
-      }),
-      codeMirrorPlugin({
-        codeBlockLanguages: CODE_BLOCK_LANGUAGES,
-      }),
-      markdownShortcutPlugin(),
-      toolbarPlugin({
-        toolbarContents: () => (
-          <>
-            <UndoRedo />
-            <Separator />
-            <BoldItalicUnderlineToggles />
-            <CodeToggle />
-            <Separator />
-            <ListsToggle />
-            <Separator />
-            <BlockTypeSelect />
-            <Separator />
-            <CreateLink />
-            <InsertImage />
-            <InsertTable />
-            <InsertCodeBlock />
-          </>
-        ),
-      }),
-    ],
-    [handleImageUpload]
-  );
-
   useEffect(() => {
-    if (isDarkMode) {
-      editor.defineTheme('helpudoc-nord', {
-        base: 'vs-dark',
-        inherit: true,
-        rules: [
-          { token: 'comment', foreground: '4c566a' },
-          { token: 'string', foreground: 'a3be8c' },
-          { token: 'number', foreground: 'b48ead' },
-          { token: 'keyword', foreground: '81a1c1' },
-          { token: 'type.identifier', foreground: '8fbcbb' },
-          { token: 'delimiter', foreground: 'd8dee9' },
-          { token: 'tag', foreground: '81a1c1' },
-          { token: 'attribute.name', foreground: '88c0d0' },
-          { token: 'attribute.value', foreground: 'a3be8c' },
-        ],
-        colors: {
-          'editor.background': '#2e3440',
-          'editor.foreground': '#d8dee9',
-          'editorLineNumber.foreground': '#4c566a',
-          'editorLineNumber.activeForeground': '#eceff4',
-          'editorCursor.foreground': '#d8dee9',
-          'editor.selectionBackground': '#434c5e',
-          'editor.inactiveSelectionBackground': '#3b4252',
-          'editorIndentGuide.background': '#3b4252',
-          'editorIndentGuide.activeBackground': '#4c566a',
-        },
-      });
-      editor.setTheme('helpudoc-nord');
-    } else {
-      editor.setTheme('vs');
-    }
-  }, [isDarkMode]);
+    let cancelled = false;
 
-  const handleEditorDidMount: OnMount = (editorInstance) => {
+    if (!fileName || getLanguage(fileName) === 'markdown') {
+      return undefined;
+    }
+
+    void import('monaco-editor').then(({ editor }) => {
+      if (cancelled) return;
+
+      if (isDarkMode) {
+        editor.defineTheme('helpudoc-nord', {
+          base: 'vs-dark',
+          inherit: true,
+          rules: [
+            { token: 'comment', foreground: '4c566a' },
+            { token: 'string', foreground: 'a3be8c' },
+            { token: 'number', foreground: 'b48ead' },
+            { token: 'keyword', foreground: '81a1c1' },
+            { token: 'type.identifier', foreground: '8fbcbb' },
+            { token: 'delimiter', foreground: 'd8dee9' },
+            { token: 'tag', foreground: '81a1c1' },
+            { token: 'attribute.name', foreground: '88c0d0' },
+            { token: 'attribute.value', foreground: 'a3be8c' },
+          ],
+          colors: {
+            'editor.background': '#2e3440',
+            'editor.foreground': '#d8dee9',
+            'editorLineNumber.foreground': '#4c566a',
+            'editorLineNumber.activeForeground': '#eceff4',
+            'editorCursor.foreground': '#d8dee9',
+            'editor.selectionBackground': '#434c5e',
+            'editor.inactiveSelectionBackground': '#3b4252',
+            'editorIndentGuide.background': '#3b4252',
+            'editorIndentGuide.activeBackground': '#4c566a',
+          },
+        });
+        editor.setTheme('helpudoc-nord');
+        return;
+      }
+
+      editor.setTheme('vs');
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fileName, isDarkMode]);
+
+  const handleEditorDidMount = (editorInstance: MonacoEditorNamespace.IStandaloneCodeEditor) => {
     editorRef.current = editorInstance;
-    bindMonaco();
+    void bindMonaco();
   };
 
   const applyFormat = (format: 'bold' | 'italic' | 'heading') => {
-    const editor = editorRef.current;
-    if (!editor) return;
+    const editorInstance = editorRef.current;
+    if (!editorInstance) return;
 
-    const selection = editor.getSelection();
+    const selection = editorInstance.getSelection();
     if (!selection) return;
 
-    const model = editor.getModel();
+    const model = editorInstance.getModel();
     if (!model) return;
 
     const text = model.getValueInRange(selection);
@@ -354,7 +208,7 @@ const FileEditor: React.FC<FileEditorProps> = ({
         break;
     }
 
-    editor.executeEdits('toolbar', [
+    editorInstance.executeEdits('toolbar', [
       {
         range: selection,
         text: formattedText,
@@ -377,6 +231,7 @@ const FileEditor: React.FC<FileEditorProps> = ({
       onContentChange(nextValue);
       return;
     }
+
     const yText = session.yText;
     const current = yText.toString();
     if (current === nextValue) {
@@ -420,14 +275,14 @@ const FileEditor: React.FC<FileEditorProps> = ({
     }
     const rules = users
       .map((user) => (
-        `.yRemoteSelection-${user.clientId} { background-color: ${user.color}33; }` +
-        `.yRemoteSelectionHead-${user.clientId} { border-left: 2px solid ${user.color}; border-right: 2px solid ${user.color}; }`
+        `.yRemoteSelection-${user.clientId} { background-color: ${user.color}33; }`
+        + `.yRemoteSelectionHead-${user.clientId} { border-left: 2px solid ${user.color}; border-right: 2px solid ${user.color}; }`
       ))
       .join('\n');
     presenceStyleRef.current.textContent = rules;
   }, []);
 
-  const bindMonaco = useCallback(() => {
+  const bindMonaco = useCallback(async () => {
     if (!fileName || getLanguage(fileName) === 'markdown') return;
     const session = collabSessionRef.current;
     if (!session) return;
@@ -435,6 +290,11 @@ const FileEditor: React.FC<FileEditorProps> = ({
     if (!editorInstance) return;
     const model = editorInstance.getModel();
     if (!model) return;
+
+    const { MonacoBinding } = await import('y-monaco');
+    if (collabSessionRef.current !== session || editorRef.current !== editorInstance) {
+      return;
+    }
 
     monacoBindingRef.current?.destroy();
     monacoBindingRef.current = new MonacoBinding(
@@ -523,7 +383,7 @@ const FileEditor: React.FC<FileEditorProps> = ({
     };
 
     yText.observe(handleTextChange);
-    bindMonaco();
+    void bindMonaco();
     updatePresence();
     session.provider.on('status', handleStatus);
     session.provider.on('awarenessChange', handleAwarenessChange);
@@ -639,7 +499,6 @@ const FileEditor: React.FC<FileEditorProps> = ({
       <div className="flex-grow overflow-auto">
         {isMarkdown ? (
           <div className="helpudoc-mdxeditor-shell h-full overflow-y-auto flex flex-col" style={{ maxHeight: 'calc(100vh - 200px)' }}>
-            {/* Raw/Rendered Toggle Toolbar */}
             <div className="flex items-center justify-between px-3 py-2 border-b border-gray-200 bg-gray-50">
               <span className="text-xs font-medium text-gray-500">
                 {isRawView ? 'Raw Markdown' : 'Rich Editor'}
@@ -647,9 +506,6 @@ const FileEditor: React.FC<FileEditorProps> = ({
               <button
                 type="button"
                 onClick={() => {
-                  // No need to manually sync content when toggling views
-                  // - When switching to raw: content is already synced via MDXEditor's onChange
-                  // - When switching to rich: MDXEditor will auto-sync from Yjs document via handleTextChange
                   setIsRawView(!isRawView);
                 }}
                 className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium text-gray-600 hover:bg-gray-200 transition-colors"
@@ -668,14 +524,12 @@ const FileEditor: React.FC<FileEditorProps> = ({
                 )}
               </button>
             </div>
-            {/* Editor Content */}
             {isRawView ? (
               <textarea
                 className="flex-1 w-full h-full p-4 font-mono text-sm border-none resize-none focus:outline-none focus:ring-0 bg-white"
                 value={fileContent}
-                onChange={(e) => {
-                  const newValue = e.target.value;
-                  applyTextUpdate(newValue);
+                onChange={(event) => {
+                  applyTextUpdate(event.target.value);
                 }}
                 placeholder="Enter markdown content..."
                 spellCheck={false}
@@ -687,45 +541,44 @@ const FileEditor: React.FC<FileEditorProps> = ({
                     {mdxError}
                   </div>
                 )}
-                <MDXEditor
-                  ref={mdxEditorRef}
-                  markdown={fileContent}
-                  className="mdxeditor helpudoc-mdxeditor flex-1"
-                  contentEditableClassName="prose prose-slate max-w-none helpudoc-markdown helpudoc-markdown-editor mdxeditor-root-contenteditable"
-                  onChange={(value) => {
-                    if (isApplyingRemoteRef.current) return;
-                    setMdxError(null);
-                    applyTextUpdate(value);
-                  }}
-                  onError={({ error, source }) => {
-                    console.error('MDXEditor markdown processing error:', { error, source });
-                    setMdxError(error);
-                  }}
-                  plugins={mdxPlugins}
-                />
+                <Suspense fallback={<EditorLoadingState className="min-h-[320px] flex-1" label="Loading rich editor..." />}>
+                  <MarkdownRichEditor
+                    ref={mdxEditorRef}
+                    markdown={fileContent}
+                    onChange={(value) => {
+                      if (isApplyingRemoteRef.current) return;
+                      setMdxError(null);
+                      applyTextUpdate(value);
+                    }}
+                    onError={setMdxError}
+                    onImageUpload={handleImageUpload}
+                  />
+                </Suspense>
               </>
             )}
           </div>
         ) : (
-          <Editor
-            height="100%"
-            language={getLanguage(file.name)}
-            defaultValue={fileContent}
-            value={collabReady ? undefined : fileContent}
-            onMount={handleEditorDidMount}
-            onChange={(value) => {
-              if (collabReady) return;
-              onContentChange(value || '');
-            }}
-            theme={monacoTheme}
-            options={{
-              wordWrap: 'on',
-              wrappingIndent: 'indent',
-              minimap: { enabled: false },
-              lineHeight: 22,
-              fontSize: 14,
-            }}
-          />
+          <Suspense fallback={<EditorLoadingState />}>
+            <MonacoEditor
+              height="100%"
+              language={getLanguage(file.name)}
+              defaultValue={fileContent}
+              value={collabReady ? undefined : fileContent}
+              onMount={handleEditorDidMount}
+              onChange={(value) => {
+                if (collabReady) return;
+                onContentChange(value || '');
+              }}
+              theme={monacoTheme}
+              options={{
+                wordWrap: 'on',
+                wrappingIndent: 'indent',
+                minimap: { enabled: false },
+                lineHeight: 22,
+                fontSize: 14,
+              }}
+            />
+          </Suspense>
         )}
       </div>
     </div>

--- a/frontend/src/components/FileRenderer.tsx
+++ b/frontend/src/components/FileRenderer.tsx
@@ -1,15 +1,16 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import mermaid from 'mermaid';
+import React, { Suspense, lazy, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import Papa from 'papaparse';
-import PlotlyChart, { type PlotlySpec } from './PlotlyChart';
+import type { PlotlySpec } from './PlotlyChart';
 import type { File } from '../types';
 import {
   configureMermaid,
   createMarkdownComponents,
   useMermaidColorMode,
 } from './markdown/MarkdownShared';
+
+const PlotlyChart = lazy(() => import('./PlotlyChart'));
 
 interface FileRendererProps {
   file: File | null;
@@ -145,9 +146,9 @@ const FileRenderer: React.FC<FileRendererProps> = ({
         setMermaidError(null);
         try {
           mermaidRef.current.innerHTML = '';
-          configureMermaid(colorMode);
+          const mermaid = await configureMermaid(colorMode);
           // Validate syntax before rendering to avoid Mermaid's error SVG
-          mermaid.parse(fileContent);
+          await mermaid.parse(fileContent);
           const renderId = `${mermaidIdRef.current}-${Date.now()}`;
           const { svg } = await mermaid.render(renderId, fileContent);
           if (!cancelled && mermaidRef.current) {
@@ -333,7 +334,11 @@ const FileRenderer: React.FC<FileRendererProps> = ({
         if (!Array.isArray(spec.data)) {
           throw new Error('Plotly spec must include a top-level "data" array.');
         }
-        return <PlotlyChart spec={spec} />;
+        return (
+          <Suspense fallback={<div className="flex h-full items-center justify-center text-sm text-slate-500">Loading chart…</div>}>
+            <PlotlyChart spec={spec} />
+          </Suspense>
+        );
       } catch (error) {
         return (
           <div className="flex h-full items-center justify-center px-4 text-sm text-red-600">

--- a/frontend/src/components/MarkdownRichEditor.tsx
+++ b/frontend/src/components/MarkdownRichEditor.tsx
@@ -1,0 +1,212 @@
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import {
+  MDXEditor,
+  type CodeBlockEditorDescriptor,
+  type MDXEditorMethods,
+  useCodeBlockEditorContext,
+  headingsPlugin,
+  imagePlugin,
+  linkDialogPlugin,
+  linkPlugin,
+  listsPlugin,
+  markdownShortcutPlugin,
+  quotePlugin,
+  tablePlugin,
+  thematicBreakPlugin,
+  toolbarPlugin,
+  codeBlockPlugin,
+  codeMirrorPlugin,
+  UndoRedo,
+  BoldItalicUnderlineToggles,
+  BlockTypeSelect,
+  InsertCodeBlock,
+  CodeToggle,
+  CreateLink,
+  InsertImage,
+  InsertTable,
+  ListsToggle,
+  Separator,
+} from '@mdxeditor/editor';
+import '@mdxeditor/editor/style.css';
+import { MermaidDiagram, useMermaidColorMode } from './markdown/MarkdownShared';
+
+const CODE_BLOCK_LANGUAGES: Record<string, string> = {
+  '': 'Plain text',
+  js: 'JavaScript',
+  ts: 'TypeScript',
+  jsx: 'JSX',
+  tsx: 'TSX',
+  json: 'JSON',
+  css: 'CSS',
+  html: 'HTML',
+  md: 'Markdown',
+  bash: 'Bash',
+  shell: 'Shell',
+  python: 'Python',
+  sql: 'SQL',
+  yaml: 'YAML',
+  mermaid: 'Mermaid',
+};
+
+type MermaidCodeBlockEditorProps = {
+  code: string;
+  focusEmitter: { subscribe: (cb: () => void) => void };
+};
+
+const MermaidCodeBlockEditor = ({
+  code,
+  focusEmitter,
+}: MermaidCodeBlockEditorProps) => {
+  const { lexicalNode, parentEditor, setCode } = useCodeBlockEditorContext();
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [draft, setDraft] = useState(code);
+  const mermaidColorMode = useMermaidColorMode();
+
+  useEffect(() => {
+    setDraft(code);
+  }, [code]);
+
+  useEffect(() => {
+    focusEmitter.subscribe(() => {
+      textareaRef.current?.focus();
+    });
+  }, [focusEmitter]);
+
+  return (
+    <div className="helpudoc-mermaid-editor not-prose my-4 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <div className="flex items-center justify-between border-b border-slate-200 bg-slate-50 px-4 py-2">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Mermaid</p>
+          <p className="text-xs text-slate-500">Edit the diagram source and preview it live.</p>
+        </div>
+        <button
+          type="button"
+          className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-600 hover:bg-slate-100"
+          onClick={() => {
+            parentEditor.update(() => {
+              lexicalNode.remove();
+            });
+          }}
+        >
+          Remove
+        </button>
+      </div>
+      <div className="grid gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <label className="flex min-h-[260px] flex-col gap-2">
+          <span className="text-xs font-medium text-slate-600">Source</span>
+          <textarea
+            ref={textareaRef}
+            value={draft}
+            onChange={(event) => {
+              const nextValue = event.target.value;
+              setDraft(nextValue);
+              setCode(nextValue);
+            }}
+            spellCheck={false}
+            className="min-h-[240px] w-full resize-y rounded-xl border border-slate-200 bg-slate-950 p-4 font-mono text-sm leading-relaxed text-slate-100 focus:border-blue-400 focus:outline-none"
+          />
+        </label>
+        <div className="flex min-h-[260px] flex-col gap-2">
+          <span className="text-xs font-medium text-slate-600">Preview</span>
+          <MermaidDiagram
+            chart={draft}
+            colorMode={mermaidColorMode}
+            className={`mermaid-container h-full min-h-[240px] overflow-auto rounded-xl border p-4 ${mermaidColorMode === 'dark' ? 'border-slate-700 bg-slate-950' : 'border-slate-200 bg-white'}`}
+            fallbackClassName="h-full min-h-[240px]"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const mermaidCodeBlockDescriptor: CodeBlockEditorDescriptor = {
+  priority: 100,
+  match: (language) => language === 'mermaid',
+  Editor: MermaidCodeBlockEditor,
+};
+
+export type MarkdownRichEditorHandle = {
+  setMarkdown: (value: string) => void;
+};
+
+type MarkdownRichEditorProps = {
+  markdown: string;
+  onChange: (value: string) => void;
+  onError: (error: string) => void;
+  onImageUpload: (image: File) => Promise<string>;
+};
+
+const MarkdownRichEditor = forwardRef<MarkdownRichEditorHandle, MarkdownRichEditorProps>(({
+  markdown,
+  onChange,
+  onError,
+  onImageUpload,
+}, ref) => {
+  const editorRef = useRef<MDXEditorMethods | null>(null);
+
+  useImperativeHandle(ref, () => ({
+    setMarkdown: (value: string) => {
+      editorRef.current?.setMarkdown(value);
+    },
+  }), []);
+
+  const plugins = useMemo(
+    () => [
+      headingsPlugin(),
+      listsPlugin(),
+      quotePlugin(),
+      thematicBreakPlugin(),
+      linkPlugin(),
+      linkDialogPlugin(),
+      tablePlugin(),
+      imagePlugin({ imageUploadHandler: onImageUpload }),
+      codeBlockPlugin({
+        codeBlockEditorDescriptors: [mermaidCodeBlockDescriptor],
+      }),
+      codeMirrorPlugin({
+        codeBlockLanguages: CODE_BLOCK_LANGUAGES,
+      }),
+      markdownShortcutPlugin(),
+      toolbarPlugin({
+        toolbarContents: () => (
+          <>
+            <UndoRedo />
+            <Separator />
+            <BoldItalicUnderlineToggles />
+            <CodeToggle />
+            <Separator />
+            <ListsToggle />
+            <Separator />
+            <BlockTypeSelect />
+            <Separator />
+            <CreateLink />
+            <InsertImage />
+            <InsertTable />
+            <InsertCodeBlock />
+          </>
+        ),
+      }),
+    ],
+    [onImageUpload],
+  );
+
+  return (
+    <MDXEditor
+      ref={editorRef}
+      markdown={markdown}
+      className="mdxeditor helpudoc-mdxeditor flex-1"
+      contentEditableClassName="prose prose-slate max-w-none helpudoc-markdown helpudoc-markdown-editor mdxeditor-root-contenteditable"
+      onChange={onChange}
+      onError={({ error }) => {
+        console.error('MDXEditor markdown processing error:', error);
+        onError(error);
+      }}
+      plugins={plugins}
+    />
+  );
+});
+
+MarkdownRichEditor.displayName = 'MarkdownRichEditor';
+
+export default MarkdownRichEditor;

--- a/frontend/src/components/UIBlockRenderer.tsx
+++ b/frontend/src/components/UIBlockRenderer.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import type { File } from '../types';
 import FileRenderer from './FileRenderer';
-import PlotlyChart, { type PlotlySpec } from './PlotlyChart';
+import type { PlotlySpec } from './PlotlyChart';
+
+const PlotlyChart = lazy(() => import('./PlotlyChart'));
 
 type BlockId = string | number;
 
@@ -76,7 +78,9 @@ const UIBlockRenderer: React.FC<UIBlockRendererProps> = ({ blocks, className, em
           case 'plotly':
             return (
               <div key={key} className="h-full w-full">
-                <PlotlyChart spec={block.spec} />
+                <Suspense fallback={<div className="flex h-full items-center justify-center text-sm text-slate-500">Loading chart…</div>}>
+                  <PlotlyChart spec={block.spec} />
+                </Suspense>
               </div>
             );
           case 'text':

--- a/frontend/src/components/chat/ToolOutputFilePreview.tsx
+++ b/frontend/src/components/chat/ToolOutputFilePreview.tsx
@@ -1,11 +1,14 @@
-import { useEffect, useState } from 'react';
+import { Suspense, lazy, useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import type { Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-import PlotlyChart, { type PlotlySpec } from '../PlotlyChart';
+import type { PlotlySpec } from '../PlotlyChart';
 import { getFiles, getFileContent, getWorkspaceFilePreview } from '../../services/fileApi';
 import type { File as WorkspaceFile, ToolOutputFile } from '../../types';
 import { inferPreviewEncoding } from '../../utils/files';
+
+const PlotlyChart = lazy(() => import('../PlotlyChart'));
 
 type FilePreviewPayload = {
   path: string;
@@ -29,7 +32,7 @@ export default function ToolOutputFilePreview({
 }: {
   workspaceId?: string;
   file: ToolOutputFile;
-  markdownComponents?: Record<string, any>;
+  markdownComponents?: Components;
 }) {
   const preBaseClass =
     'mt-2 w-full max-w-full min-w-0 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded p-3 text-xs';
@@ -160,7 +163,9 @@ export default function ToolOutputFilePreview({
       }
       return (
         <div className="mt-2 rounded border border-gray-200 bg-white p-2">
-          <PlotlyChart spec={spec} minHeight={280} />
+          <Suspense fallback={<div className="flex min-h-[280px] items-center justify-center text-sm text-slate-500">Loading chart…</div>}>
+            <PlotlyChart spec={spec} minHeight={280} />
+          </Suspense>
         </div>
       );
     } catch {

--- a/frontend/src/components/markdown/MarkdownShared.tsx
+++ b/frontend/src/components/markdown/MarkdownShared.tsx
@@ -1,9 +1,19 @@
 /* eslint-disable react-refresh/only-export-components */
-import { Children, isValidElement, useEffect, useRef, useState, type ReactNode } from 'react';
-import mermaid from 'mermaid';
+import { Children, Suspense, isValidElement, lazy, useEffect, useRef, useState, type ReactNode } from 'react';
 import type { Components } from 'react-markdown';
 import { getWorkspaceFilePreview } from '../../services/fileApi';
-import PlotlyChart, { type PlotlySpec } from '../PlotlyChart';
+import type { PlotlySpec } from '../PlotlyChart';
+
+const PlotlyChart = lazy(() => import('../PlotlyChart'));
+
+let mermaidRuntimePromise: Promise<typeof import('mermaid')> | null = null;
+
+const loadMermaidRuntime = async () => {
+  if (!mermaidRuntimePromise) {
+    mermaidRuntimePromise = import('mermaid');
+  }
+  return mermaidRuntimePromise;
+};
 
 export type MermaidColorMode = 'light' | 'dark';
 
@@ -133,7 +143,8 @@ export const useMermaidColorMode = () => {
   return colorMode;
 };
 
-export const configureMermaid = (mode: MermaidColorMode) => {
+export const configureMermaid = async (mode: MermaidColorMode) => {
+  const mermaid = (await loadMermaidRuntime()).default;
   mermaid.initialize({
     startOnLoad: false,
     securityLevel: 'loose',
@@ -141,6 +152,7 @@ export const configureMermaid = (mode: MermaidColorMode) => {
     themeVariables: buildMermaidTheme(mode),
     fontFamily: 'Inter, "Segoe UI", Arial, sans-serif',
   });
+  return mermaid;
 };
 
 export const extractCodeText = (value: ReactNode): string => {
@@ -230,7 +242,7 @@ export const MermaidDiagram = ({
       try {
         setErrorMessage(null);
         diagramRef.current.innerHTML = '';
-        configureMermaid(colorMode);
+        const mermaid = await configureMermaid(colorMode);
         await mermaid.parse(chart);
         const renderId = `${idRef.current}-${Date.now()}`;
         const { svg } = await mermaid.render(renderId, chart);
@@ -452,7 +464,9 @@ export const createMarkdownComponents = ({
         }
         return (
           <div className="my-4 overflow-hidden rounded-xl border border-gray-200 bg-white p-2">
-            <PlotlyChart spec={spec} minHeight={360} />
+            <Suspense fallback={<div className="flex min-h-[360px] items-center justify-center text-sm text-slate-500">Loading chart…</div>}>
+              <PlotlyChart spec={spec} minHeight={360} />
+            </Suspense>
           </div>
         );
       } catch (error) {

--- a/frontend/src/components/settings/AgentSettingsTabs.tsx
+++ b/frontend/src/components/settings/AgentSettingsTabs.tsx
@@ -1,11 +1,12 @@
-import { useState, useEffect, useCallback } from 'react';
+import { Suspense, lazy, useState, useEffect, useCallback } from 'react';
 import { Wrench, Library, Loader2 } from 'lucide-react';
 import { fetchAgentConfig, saveAgentConfig } from '../../services/settingsApi';
 import ToolsTab, { type AgentConfig } from './ToolsTab';
-import SkillsRegistryTab from './SkillsRegistryTab';
 import { SettingsEmptyState, SettingsLoadingState, SettingsTabPanel, SettingsTabs } from './SettingsScaffold';
 import YAML from 'yaml';
 import { getAuthUser } from '../../auth/authStore';
+
+const SkillsRegistryTab = lazy(() => import('./SkillsRegistryTab'));
 
 const AgentSettingsTabs = () => {
     const [activeTab, setActiveTab] = useState<'tools' | 'skills'>('skills');
@@ -106,7 +107,9 @@ const AgentSettingsTabs = () => {
                     <ToolsTab config={config} onSave={handleSave} isSaving={saving} />
                 )}
                 {activeTab === 'skills' && (
-                    <SkillsRegistryTab />
+                    <Suspense fallback={<SettingsLoadingState label="Loading skill registry..." />}>
+                        <SkillsRegistryTab />
+                    </Suspense>
                 )}
             </SettingsTabPanel>
         </div>

--- a/frontend/src/components/settings/SkillsRegistryTab.tsx
+++ b/frontend/src/components/settings/SkillsRegistryTab.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Plus,
   RefreshCw,
@@ -19,7 +19,6 @@ import {
   Minimize2,
   Maximize2,
 } from 'lucide-react';
-import Editor from '@monaco-editor/react';
 import {
   applyGithubSkillImport,
   applySkillBuilderActions,
@@ -43,6 +42,9 @@ import {
   type SkillBuilderContextFile,
 } from '../../services/settingsApi';
 import type { SkillDefinition } from '../../types';
+import EditorLoadingState from '../EditorLoadingState';
+
+const MonacoEditor = lazy(() => import('@monaco-editor/react'));
 
 const BUILDER_COLLAPSED_KEY = 'settings.skillBuilder.collapsed';
 
@@ -965,22 +967,24 @@ const SkillsRegistryTab: React.FC = () => {
                       <Loader2 size={24} className="animate-spin text-slate-500" />
                     </div>
                   ) : selectedFile ? (
-                    <Editor
-                      height="100%"
-                      theme="vs-dark"
-                      language={getLanguage(selectedFile)}
-                      value={fileContent}
-                      onChange={(value) => setFileContent(value || '')}
-                      options={{
-                        minimap: { enabled: false },
-                        fontSize: 13,
-                        lineHeight: 20,
-                        wordWrap: 'on',
-                        scrollBeyondLastLine: false,
-                        automaticLayout: true,
-                        padding: { top: 12, bottom: 12 },
-                      }}
-                    />
+                    <Suspense fallback={<EditorLoadingState />}>
+                      <MonacoEditor
+                        height="100%"
+                        theme="vs-dark"
+                        language={getLanguage(selectedFile)}
+                        value={fileContent}
+                        onChange={(value) => setFileContent(value || '')}
+                        options={{
+                          minimap: { enabled: false },
+                          fontSize: 13,
+                          lineHeight: 20,
+                          wordWrap: 'on',
+                          scrollBeyondLastLine: false,
+                          automaticLayout: true,
+                          padding: { top: 12, bottom: 12 },
+                        }}
+                      />
+                    </Suspense>
                   ) : (
                     <div className="flex flex-col items-center justify-center h-full text-slate-500 bg-slate-100">
                       <p className="text-sm">Select a file to edit</p>

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo, type ChangeEvent } from 'react';
+import { lazy, Suspense, useState, useEffect, useRef, useCallback, useMemo, type ChangeEvent } from 'react';
 import type { ComponentProps, CSSProperties } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { useNavigate } from 'react-router-dom';
@@ -56,8 +56,7 @@ import type {
   SkillDefinition,
 } from '../types';
 import CollapsibleDrawer from '../components/CollapsibleDrawer';
-import FileEditor from '../components/FileEditor';
-import UIBlockRenderer, { type UIBlock } from '../components/UIBlockRenderer';
+import type { UIBlock } from '../components/UIBlockRenderer';
 import ExpandableSidebar from '../components/ExpandableSidebar';
 import WorkspaceFileTree from '../components/WorkspaceFileTree';
 import AgentChatPane from '../components/chat/AgentChatPane';
@@ -81,6 +80,9 @@ import {
 import { buildMessageMetadata, mapMessagesToAgentHistory, mergeMessageMetadata, sanitizeRunPolicy } from '../utils/messages';
 import { createMarkdownComponents } from '../components/markdown/MarkdownShared';
 import { applyColorModeToDocument, buildAppTheme, resolveInitialColorMode } from '../theme';
+
+const FileEditor = lazy(() => import('../components/FileEditor'));
+const UIBlockRenderer = lazy(() => import('../components/UIBlockRenderer'));
 
 const drawerWidth = 280;
 
@@ -116,6 +118,18 @@ const STREAM_DEBUG_ENABLED =
   typeof import.meta !== 'undefined' &&
   typeof import.meta.env !== 'undefined' &&
   (import.meta.env.VITE_DEBUG_STREAM === '1' || import.meta.env.VITE_DEBUG_STREAM === 'true');
+
+const editorLoadingFallback = (
+  <div className="flex h-full items-center justify-center text-sm text-slate-500">
+    Loading editor…
+  </div>
+);
+
+const canvasLoadingFallback = (
+  <div className="flex h-full items-center justify-center text-sm text-slate-500">
+    Loading preview…
+  </div>
+);
 
 type Paper2SlidesStage = (typeof PAPER2SLIDES_STAGE_ORDER)[number];
 type Paper2SlidesStylePreset = (typeof PAPER2SLIDES_STYLE_PRESETS)[number];
@@ -5238,13 +5252,15 @@ export default function WorkspacePage() {
                   </div>
                   <div className="flex-1 overflow-hidden min-h-0">
                     {isEditMode && selectedWorkspace ? (
-                      <FileEditor
-                        file={selectedFileDetails || selectedFile}
-                        fileContent={fileContent}
-                        onContentChange={setFileContent}
-                        workspaceId={selectedWorkspace.id}
-                        colorMode={colorMode}
-                      />
+                      <Suspense fallback={editorLoadingFallback}>
+                        <FileEditor
+                          file={selectedFileDetails || selectedFile}
+                          fileContent={fileContent}
+                          onContentChange={setFileContent}
+                          workspaceId={selectedWorkspace.id}
+                          colorMode={colorMode}
+                        />
+                      </Suspense>
                     ) : (
                       <div className="h-full w-full overflow-y-auto overflow-x-hidden">
                         <div
@@ -5255,16 +5271,18 @@ export default function WorkspacePage() {
                             minHeight: `${100 / canvasZoom}%`,
                           }}
                         >
-                          <UIBlockRenderer
-                            blocks={canvasBlocks}
-                            workspaceId={selectedWorkspace?.id}
-                            className="h-full w-full"
-                            emptyState={
-                              <div className="text-center text-gray-400">
-                                <p>Select a file to view its content</p>
-                              </div>
-                            }
-                          />
+                          <Suspense fallback={canvasLoadingFallback}>
+                            <UIBlockRenderer
+                              blocks={canvasBlocks}
+                              workspaceId={selectedWorkspace?.id}
+                              className="h-full w-full"
+                              emptyState={
+                                <div className="text-center text-gray-400">
+                                  <p>Select a file to view its content</p>
+                                </div>
+                              }
+                            />
+                          </Suspense>
                         </div>
                       </div>
                     )}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,4 +7,53 @@ export default defineConfig({
   css: {
     postcss: './postcss.config.js',
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) {
+            return undefined
+          }
+
+          if (id.includes('monaco-editor') || id.includes('@monaco-editor')) {
+            return 'monaco'
+          }
+
+          if (id.includes('@mdxeditor')) {
+            return 'mdxeditor'
+          }
+
+          if (id.includes('@hocuspocus') || id.includes('y-monaco') || id.includes('/yjs/')) {
+            return 'collab'
+          }
+
+          if (id.includes('plotly.js') || id.includes('react-plotly.js')) {
+            return 'plotly'
+          }
+
+          if (id.includes('mermaid')) {
+            return 'mermaid'
+          }
+
+          if (id.includes('lucide-react')) {
+            return 'icons'
+          }
+
+          if (id.includes('react-markdown') || id.includes('remark-') || id.includes('rehype-')) {
+            return 'markdown'
+          }
+
+          if (id.includes('@mui') || id.includes('@emotion')) {
+            return 'mui'
+          }
+
+          if (id.includes('react') || id.includes('react-router')) {
+            return 'react-vendor'
+          }
+
+          return 'vendor'
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
Splits the heavier editor and preview workloads out of the initial app load so route navigation and workspace editing feel snappier.

## What changed
- Lazy-loads route pages instead of bundling every screen up front.
- Defers Monaco and MDX editor modules until the user opens the relevant editor surfaces.
- Pushes Plotly and Mermaid rendering behind lazy boundaries in the workspace and preview components.
- Adds focused Rollup chunking for Monaco, MDX editor, Plotly, Mermaid, collaboration, icons, markdown, MUI, and React vendor code.

## Validation
- `npm run build` in `frontend`

## Notes
This PR is stacked on the admin-theme PR so the visual-system change can land first.
