### PR TITLE
Harden Plotly rendering against runtime failures

### DIFF
--- a/frontend/src/components/PlotlyChart.tsx
+++ b/frontend/src/components/PlotlyChart.tsx
@@ -1,11 +1,17 @@
-import createPlotlyComponent from 'react-plotly.js/factory';
-import Plotly from 'plotly.js-dist-min';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { PlotParams } from 'react-plotly.js';
-import React from 'react';
-
-const Plot = createPlotlyComponent(Plotly);
 
 export type PlotlySpec = Partial<PlotParams>;
+
+type PlotlyRuntime = {
+  react: (el: HTMLDivElement, figure: {
+    data: PlotParams['data'];
+    layout: PlotParams['layout'];
+    config: PlotParams['config'];
+    frames?: PlotParams['frames'];
+  }) => Promise<unknown>;
+  purge: (el: HTMLDivElement) => void;
+};
 
 interface PlotlyChartProps {
   spec: PlotlySpec;
@@ -13,22 +19,82 @@ interface PlotlyChartProps {
   minHeight?: number;
 }
 
-const PlotlyChart: React.FC<PlotlyChartProps> = ({ spec, className, minHeight = 320 }) => {
+const PlotlyChart = ({ spec, className, minHeight = 320 }: PlotlyChartProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const plotlyRef = useRef<PlotlyRuntime | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
   const data = Array.isArray(spec?.data) ? spec.data : [];
   const layout = spec?.layout && typeof spec.layout === 'object' ? spec.layout : {};
   const config = spec?.config && typeof spec.config === 'object' ? spec.config : {};
   const frames = Array.isArray(spec?.frames) ? spec.frames : undefined;
+  const figure = useMemo(
+    () => ({
+      data,
+      layout: { autosize: true, ...layout },
+      config: { displaylogo: false, responsive: true, ...config },
+      frames,
+    }),
+    [config, data, frames, layout],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void import('plotly.js-dist-min')
+      .then((module) => {
+        if (cancelled) return;
+        plotlyRef.current = (module as unknown as { default?: PlotlyRuntime }).default ?? (module as unknown as PlotlyRuntime);
+        setLoadError(null);
+      })
+      .catch((error) => {
+        console.error('Failed to load Plotly', error);
+        if (!cancelled) {
+          setLoadError(error instanceof Error ? error.message : 'Failed to load chart renderer.');
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      if (plotlyRef.current && containerRef.current) {
+        try {
+          plotlyRef.current.purge(containerRef.current);
+        } catch (error) {
+          console.warn('Failed to purge Plotly chart', error);
+        }
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const Plotly = plotlyRef.current;
+    const el = containerRef.current;
+    if (!Plotly || !el || loadError) {
+      return;
+    }
+
+    let cancelled = false;
+    void Plotly.react(el, figure).catch((error) => {
+      console.error('Failed to render Plotly chart', error);
+      if (!cancelled) {
+        setLoadError(error instanceof Error ? error.message : 'Failed to render chart.');
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [figure, loadError]);
 
   return (
     <div className={className ?? 'h-full w-full'} style={{ minHeight }}>
-      <Plot
-        data={data}
-        layout={{ autosize: true, ...layout }}
-        config={{ displaylogo: false, responsive: true, ...config }}
-        frames={frames}
-        style={{ width: '100%', height: '100%' }}
-        useResizeHandler
-      />
+      {loadError ? (
+        <div className="flex h-full w-full items-center justify-center rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-500">
+          {loadError}
+        </div>
+      ) : (
+        <div ref={containerRef} className="h-full w-full" />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Summary\n- remove the eager React Plotly wrapper\n- load Plotly dynamically inside the chart component\n- show an inline fallback if Plotly fails to load or render\n\nValidation\n- npm run build (frontend)\n\nNotes\n- isolates the browser crash fix to a single Plotly component change