### PR TITLE
Load Plotly lazily from runtime asset URL

### DIFF
--- a/frontend/src/components/PlotlyChart.tsx
+++ b/frontend/src/components/PlotlyChart.tsx
@@ -13,6 +13,14 @@ type PlotlyRuntime = {
   purge: (el: HTMLDivElement) => void;
 };
 
+const getPlotlyModuleUrl = () => {
+  const link = document.querySelector<HTMLLinkElement>('link[rel="modulepreload"][href*="plotly"]');
+  if (!link?.href) {
+    throw new Error('Plotly asset URL is unavailable.');
+  }
+  return link.href;
+};
+
 interface PlotlyChartProps {
   spec: PlotlySpec;
   className?: string;
@@ -41,7 +49,7 @@ const PlotlyChart = ({ spec, className, minHeight = 320 }: PlotlyChartProps) => 
   useEffect(() => {
     let cancelled = false;
 
-    void import('plotly.js-dist-min')
+    void import(/* @vite-ignore */ getPlotlyModuleUrl())
       .then((module) => {
         if (cancelled) return;
         plotlyRef.current = (module as unknown as { default?: PlotlyRuntime }).default ?? (module as unknown as PlotlyRuntime);


### PR DESCRIPTION
Summary\n- stop the app entry from importing Plotly at startup\n- resolve the Plotly chunk URL at runtime from the generated preload link\n- keep the fallback error state if Plotly fails to load or render\n\nValidation\n- npm run build (frontend)\n\nNotes\n- this is the follow-up fix for the blank boot screen after the initial Plotly hotfix