### PR TITLE
Load Mermaid lazily from runtime asset URL

### DIFF
--- a/frontend/src/components/markdown/MarkdownShared.tsx
+++ b/frontend/src/components/markdown/MarkdownShared.tsx
@@ -6,15 +6,6 @@ import type { PlotlySpec } from '../PlotlyChart';
 
 const PlotlyChart = lazy(() => import('../PlotlyChart'));
 
-let mermaidRuntimePromise: Promise<typeof import('mermaid')> | null = null;
-
-const loadMermaidRuntime = async () => {
-  if (!mermaidRuntimePromise) {
-    mermaidRuntimePromise = import('mermaid');
-  }
-  return mermaidRuntimePromise;
-};
-
 export type MermaidColorMode = 'light' | 'dark';
 
 type WorkspaceImagePreview = {
@@ -38,6 +29,23 @@ type MarkdownComponentOptions = {
     className?: string;
     children: ReactNode;
   }) => ReactNode;
+};
+
+const getMermaidModuleUrl = () => {
+  const link = document.querySelector<HTMLLinkElement>('link[rel="modulepreload"][href*="mermaid"]');
+  if (!link?.href) {
+    throw new Error('Mermaid asset URL is unavailable.');
+  }
+  return link.href;
+};
+
+let mermaidRuntimePromise: Promise<typeof import('mermaid')> | null = null;
+
+const loadMermaidRuntime = async () => {
+  if (!mermaidRuntimePromise) {
+    mermaidRuntimePromise = import(/* @vite-ignore */ getMermaidModuleUrl());
+  }
+  return mermaidRuntimePromise;
 };
 
 const BLOCK_LEVEL_TAGS = ['div', 'pre', 'table', 'blockquote', 'ul', 'ol', 'hr'];


### PR DESCRIPTION
Summary\n- stop the app shell from loading Mermaid eagerly\n- resolve the Mermaid chunk URL at runtime from the generated preload link\n- keep Mermaid rendering lazy for markdown/file preview paths only\n\nValidation\n- npm run build (frontend)\n\nNotes\n- follow-up to the Plotly startup fix; this removes the remaining diagram runtime from the login route boot path