### PR TITLE
Remove Monaco from startup preload graph

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     postcss: './postcss.config.js',
   },
   build: {
+    modulePreload: false,
     rollupOptions: {
       output: {
         manualChunks(id) {


### PR DESCRIPTION
Summary
- disable Vite modulepreload so Monaco is no longer pulled into the login startup path
- keep Monaco lazy-loaded for editor routes only

Validation
- npm run build
- browser QA on /login with the rebuilt output
