### PR TITLE
Follow up local QA and tagged-file runtime fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ rag_storage/
 # CodeGraphContext local setup
 .cgcignore
 mcp.json
+.gstack/

--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ npm install
 npm run dev
 ```
 
+Local QA without Google login:
+
+```bash
+# Backend: force local header auth instead of OIDC
+cd backend
+AUTH_MODE=headers ENV_FILE=../env/local/dev.env npm run dev
+
+# Frontend: show the local app instead of the Google sign-in screen
+cd frontend
+VITE_AUTH_MODE=headers npm run dev
+```
+
+For browser automation, preload a local auth user in `localStorage` under
+`helpudoc-auth-user`. The Playwright clarification test already does this.
+
 Agent:
 
 ```bash

--- a/agent/helpudoc_agent/bigquery_export_tools.py
+++ b/agent/helpudoc_agent/bigquery_export_tools.py
@@ -20,6 +20,7 @@ from langchain_core.tools import Tool, tool
 
 from .configuration import REPO_ROOT
 from .state import WorkspaceState
+from .tagged_file_policy import tagged_files_mode_guard
 
 logger = logging.getLogger(__name__)
 
@@ -356,8 +357,9 @@ def build_export_bigquery_query_tool(workspace_state: WorkspaceState) -> Tool:
         callbacks: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Execute a read-only BigQuery query and save the result into the workspace."""
-        if workspace_state.context.get("tagged_files_only"):
-            return "Tool disabled: tagged files were provided, use rag_query only."
+        blocked = tagged_files_mode_guard(workspace_state.context, "export_bigquery_query")
+        if blocked:
+            return blocked
 
         try:
             validate_read_only_sql(sql)

--- a/agent/helpudoc_agent/configuration.py
+++ b/agent/helpudoc_agent/configuration.py
@@ -196,19 +196,20 @@ def _expand_env_vars(data):
     return data
 
 
-def _resolve_env_override_path(value: str) -> str:
+def _resolve_env_override_path(value: str, *, base_dir: Path) -> str:
     raw = (value or "").strip()
     if not raw:
         return raw
     path = Path(raw)
     if path.is_absolute():
         return str(path)
-    return str((Path.cwd() / path).resolve())
+    return str((base_dir / path).resolve())
 
 
 def load_settings(config_path: Path | None = None) -> Settings:
     path = config_path or DEFAULT_CONFIG_PATH
     config_dict = _expand_env_vars(_load_yaml(path))
+    override_base_dir = AGENT_ROOT
 
     # Allow runtime override for shared workspace volume paths (e.g., Docker Compose).
     workspace_root_override = os.getenv("WORKSPACE_ROOT")
@@ -216,12 +217,18 @@ def load_settings(config_path: Path | None = None) -> Settings:
     if workspace_root_override:
         backend_cfg = config_dict.get("backend") or {}
         if isinstance(backend_cfg, dict):
-            backend_cfg["workspace_root"] = _resolve_env_override_path(workspace_root_override)
+            backend_cfg["workspace_root"] = _resolve_env_override_path(
+                workspace_root_override,
+                base_dir=override_base_dir,
+            )
             config_dict["backend"] = backend_cfg
     if skills_root_override:
         backend_cfg = config_dict.get("backend") or {}
         if isinstance(backend_cfg, dict):
-            backend_cfg["skills_root"] = _resolve_env_override_path(skills_root_override)
+            backend_cfg["skills_root"] = _resolve_env_override_path(
+                skills_root_override,
+                base_dir=override_base_dir,
+            )
             config_dict["backend"] = backend_cfg
 
     payload = {

--- a/agent/helpudoc_agent/configuration.py
+++ b/agent/helpudoc_agent/configuration.py
@@ -196,16 +196,32 @@ def _expand_env_vars(data):
     return data
 
 
+def _resolve_env_override_path(value: str) -> str:
+    raw = (value or "").strip()
+    if not raw:
+        return raw
+    path = Path(raw)
+    if path.is_absolute():
+        return str(path)
+    return str((Path.cwd() / path).resolve())
+
+
 def load_settings(config_path: Path | None = None) -> Settings:
     path = config_path or DEFAULT_CONFIG_PATH
     config_dict = _expand_env_vars(_load_yaml(path))
 
     # Allow runtime override for shared workspace volume paths (e.g., Docker Compose).
     workspace_root_override = os.getenv("WORKSPACE_ROOT")
+    skills_root_override = os.getenv("SKILLS_ROOT")
     if workspace_root_override:
         backend_cfg = config_dict.get("backend") or {}
         if isinstance(backend_cfg, dict):
-            backend_cfg["workspace_root"] = workspace_root_override
+            backend_cfg["workspace_root"] = _resolve_env_override_path(workspace_root_override)
+            config_dict["backend"] = backend_cfg
+    if skills_root_override:
+        backend_cfg = config_dict.get("backend") or {}
+        if isinstance(backend_cfg, dict):
+            backend_cfg["skills_root"] = _resolve_env_override_path(skills_root_override)
             config_dict["backend"] = backend_cfg
 
     payload = {

--- a/agent/helpudoc_agent/data_agent_tools.py
+++ b/agent/helpudoc_agent/data_agent_tools.py
@@ -31,6 +31,7 @@ from .bigquery_export_tools import (
 )
 from .data_report_renderers import render_dashboard_html, render_summary_html
 from .state import WorkspaceState
+from .tagged_file_policy import tagged_files_mode_guard
 
 logger = logging.getLogger(__name__)
 
@@ -1216,8 +1217,9 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
         callbacks: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Materialize a read-only BigQuery query into cached and optionally stable workspace Parquet."""
-        if workspace_state.context.get("tagged_files_only"):
-            return "Tool disabled: tagged files were provided, use rag_query only."
+        blocked = tagged_files_mode_guard(workspace_state.context, "cache_bigquery_query")
+        if blocked:
+            return blocked
 
         normalized_sql = _coerce_text_arg(sql_query).strip().rstrip(";")
         if not normalized_sql:

--- a/agent/helpudoc_agent/tagged_file_policy.py
+++ b/agent/helpudoc_agent/tagged_file_policy.py
@@ -1,0 +1,38 @@
+"""Policy helpers for tagged-file RAG-only turns."""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+_ALLOWED_TOOLS_IN_TAGGED_FILES_MODE = frozenset({
+    "list_skills",
+    "load_skill",
+    "request_plan_approval",
+    "request_clarification",
+    "request_human_action",
+})
+
+_BLOCK_MESSAGE = "Tool disabled: tagged files were provided, use rag_query only."
+
+
+def is_tagged_files_only(context: Mapping[str, Any] | None) -> bool:
+    """Return true when the current turn is restricted to tagged-file RAG access."""
+    return bool((context or {}).get("tagged_files_only"))
+
+
+def is_tool_blocked_in_tagged_files_mode(tool_name: str) -> bool:
+    """Return true when a tool should be blocked during tagged-file RAG-only turns."""
+    normalized = (tool_name or "").strip()
+    return normalized not in _ALLOWED_TOOLS_IN_TAGGED_FILES_MODE
+
+
+def tagged_files_mode_block_message() -> str:
+    """Consistent user-facing message for blocked tools in tagged-file mode."""
+    return _BLOCK_MESSAGE
+
+
+def tagged_files_mode_guard(context: Mapping[str, Any] | None, tool_name: str) -> str | None:
+    """Return a block message when the tool should not run in tagged-file mode."""
+    if is_tagged_files_only(context) and is_tool_blocked_in_tagged_files_mode(tool_name):
+        return _BLOCK_MESSAGE
+    return None

--- a/agent/helpudoc_agent/tools_and_schemas.py
+++ b/agent/helpudoc_agent/tools_and_schemas.py
@@ -38,6 +38,7 @@ from .skills_registry import (
 )
 from .rag_indexer import RagConfig, WorkspaceRagStore
 from .state import WorkspaceState
+from .tagged_file_policy import is_tagged_files_only, tagged_files_mode_guard
 from .utils import SourceTracker, extract_web_url
 
 logger = logging.getLogger(__name__)
@@ -325,8 +326,9 @@ class ToolFactory:
         @tool
         def list_skills() -> str:
             """List available skills and their descriptions."""
-            if workspace_state.context.get("tagged_files_only"):
-                return "Tool disabled: tagged files were provided, use rag_query only."
+            blocked = tagged_files_mode_guard(workspace_state.context, "list_skills")
+            if blocked:
+                return blocked
             if skills_root is None or not skills_root.exists():
                 return "No skills directory configured."
             skills = [skill for skill in load_skills(skills_root) if is_skill_allowed(skill, workspace_state.context)]
@@ -349,8 +351,9 @@ class ToolFactory:
         @tool
         def load_skill(skill_id: str) -> str:
             """Load the full content of a skill by id or name."""
-            if workspace_state.context.get("tagged_files_only"):
-                return "Tool disabled: tagged files were provided, use rag_query only."
+            blocked = tagged_files_mode_guard(workspace_state.context, "load_skill")
+            if blocked:
+                return blocked
             if skills_root is None or not skills_root.exists():
                 return "No skills directory configured."
             skills = [skill for skill in load_skills(skills_root) if is_skill_allowed(skill, workspace_state.context)]
@@ -393,9 +396,6 @@ class ToolFactory:
             edited_plan_content: str = "",
         ) -> str:
             """Request human approval/edit/rejection for a proposed execution plan."""
-            if workspace_state.context.get("tagged_files_only"):
-                return "Tool disabled: tagged files were provided, use rag_query only."
-
             title = (plan_title or "").strip()
             summary = (plan_summary or "").strip()
             summary_markdown = (plan_summary_markdown or "").strip()
@@ -486,9 +486,6 @@ class ToolFactory:
             context_json: str = "{}",
         ) -> str:
             """Ask the human for clarification with optional selectable choices and typed feedback."""
-            if workspace_state.context.get("tagged_files_only"):
-                return "Tool disabled: tagged files were provided, use rag_query only."
-
             prompt_title = (title or "").strip()
             prompt_description = (description or "").strip()
             if not prompt_title:
@@ -649,6 +646,7 @@ class ToolFactory:
         request_clarification.name = "request_clarification"
         request_clarification.description = (
             "Pause execution to ask the human a clarification question. "
+            "If a loaded skill says AskUserQuestion, AskUserChoice, or otherwise requires a structured user choice, use this tool instead of asking in chat prose. "
             "Use options_json for clickable suggestions and allow_freeform for typed input. "
             "For multi-question discovery forms, pass questions_json with objects like "
             '{"header":"Purpose","question":"What is this presentation for?","options":[{"label":"Pitch deck","value":"Pitch deck","description":"Selling an idea to investors"}]}. '
@@ -670,9 +668,6 @@ class ToolFactory:
             context_json: str = "{}",
         ) -> str:
             """Ask the human to choose an action, optionally with scoped text input."""
-            if workspace_state.context.get("tagged_files_only"):
-                return "Tool disabled: tagged files were provided, use rag_query only."
-
             prompt_title = (title or "").strip()
             prompt_description = (description or "").strip()
             interrupt_kind = (kind or "approval").strip().lower()
@@ -777,8 +772,9 @@ class ToolFactory:
         @tool
         def append_to_report(source_path: str, target_path: str = "/Final_Proposal.md") -> str:
             """Append content from source_path into target_path with a separator."""
-            if workspace_state.context.get("tagged_files_only"):
-                return "Tool disabled: tagged files were provided, use rag_query only."
+            blocked = tagged_files_mode_guard(workspace_state.context, "append_to_report")
+            if blocked:
+                return blocked
             try:
                 source = _resolve(source_path)
                 target = _resolve(target_path)
@@ -824,8 +820,9 @@ class ToolFactory:
             Returns:
                 The public URL of the image if found, or an error message if not found.
             """
-            if workspace_state.context.get("tagged_files_only"):
-                return "Tool disabled: tagged files were provided, use rag_query only."
+            blocked = tagged_files_mode_guard(workspace_state.context, "get_image_url")
+            if blocked:
+                return blocked
             try:
                 import json
                 import os
@@ -962,7 +959,7 @@ class ToolFactory:
             if normalized and mode != "hybrid":
                 mode = "hybrid"
             cached_context = workspace_state.context.get("tagged_rag_context")
-            if cached_context and workspace_state.context.get("tagged_files_only"):
+            if cached_context and is_tagged_files_only(workspace_state.context):
                 return str(cached_context)
             keywords: List[str] = [query.strip()]
             if normalized:
@@ -1089,8 +1086,9 @@ def _build_grounded_google_search_tool(
     @tool
     def grounded_search(query: str, max_results: int = 5) -> str:
         """Run a Gemini native Google search for the given query."""
-        if workspace_state.context.get("tagged_files_only"):
-            return "Tool disabled: tagged files were provided, use rag_query only."
+        blocked = tagged_files_mode_guard(workspace_state.context, tool_name)
+        if blocked:
+            return blocked
         policy = _get_active_skill_policy(workspace_state)
         if policy.requires_hitl_plan and not _is_plan_approved(workspace_state):
             limit = max(0, int(policy.pre_plan_search_limit or 0))
@@ -1283,8 +1281,9 @@ def build_gemini_image_tool(
         if not prompt.strip():
             return "Skipped gemini_image: prompt is required for image generation/editing."
 
-        if workspace_state.context.get("tagged_files_only"):
-            return "Tool disabled: tagged files were provided, use rag_query only."
+        blocked = tagged_files_mode_guard(workspace_state.context, "gemini_image")
+        if blocked:
+            return blocked
 
         if not _is_explicit_image_request(prompt):
             return "Skipped gemini_image: user did not explicitly request image generation/editing."

--- a/backend/scripts/test_agent_interrupt_stop.ts
+++ b/backend/scripts/test_agent_interrupt_stop.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+
+import { persistInterruptAndStopRun } from '../src/services/agentRunService';
+
+async function main() {
+  const persisted: Array<{ runId: string; interruptPayload: string }> = [];
+  let destroyCalls = 0;
+
+  const upstream = {
+    destroyed: false,
+    destroy() {
+      destroyCalls += 1;
+      this.destroyed = true;
+    },
+  };
+
+  const state = {
+    sawInterruptPayload: null as Record<string, unknown> | null,
+    buffer: 'pending-stream-buffer',
+    upstream,
+  };
+
+  const interruptPayload = {
+    type: 'interrupt',
+    kind: 'clarification',
+    title: 'Presentation Discovery',
+  };
+
+  const stopped = await persistInterruptAndStopRun(
+    'run-123',
+    interruptPayload,
+    state,
+    async (runId, serializedPayload) => {
+      persisted.push({ runId, interruptPayload: serializedPayload });
+    },
+  );
+
+  assert.equal(stopped, true);
+  assert.equal(persisted.length, 1);
+  assert.equal(persisted[0]?.runId, 'run-123');
+  assert.deepEqual(JSON.parse(persisted[0]?.interruptPayload ?? '{}'), interruptPayload);
+  assert.equal(state.buffer, '');
+  assert.deepEqual(state.sawInterruptPayload, interruptPayload);
+  assert.equal(destroyCalls, 1);
+  assert.equal(upstream.destroyed, true);
+
+  const stoppedAgain = await persistInterruptAndStopRun(
+    'run-123',
+    { type: 'interrupt', kind: 'approval', title: 'Should not replace first interrupt' },
+    state,
+    async (runId, serializedPayload) => {
+      persisted.push({ runId, interruptPayload: serializedPayload });
+    },
+  );
+
+  assert.equal(stoppedAgain, false);
+  assert.equal(persisted.length, 1);
+  assert.deepEqual(state.sawInterruptPayload, interruptPayload);
+  assert.equal(destroyCalls, 1);
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/backend/src/services/agentRunService.ts
+++ b/backend/src/services/agentRunService.ts
@@ -339,6 +339,30 @@ const parseLine = (line: string): Record<string, unknown> | null => {
   }
 };
 
+type InterruptStopState = {
+  sawInterruptPayload: Record<string, unknown> | null;
+  buffer: string;
+  upstream: { destroy(): void; destroyed: boolean } | null;
+};
+
+export async function persistInterruptAndStopRun(
+  runId: string,
+  parsed: Record<string, unknown>,
+  state: InterruptStopState,
+  persistInterrupt: (runId: string, interruptPayload: string) => Promise<void> = markRunAwaitingApproval,
+): Promise<boolean> {
+  if (state.sawInterruptPayload) {
+    return false;
+  }
+  state.sawInterruptPayload = parsed;
+  await persistInterrupt(runId, JSON.stringify(parsed));
+  state.buffer = '';
+  if (state.upstream && !state.upstream.destroyed) {
+    state.upstream.destroy();
+  }
+  return true;
+}
+
 async function runAgentRunWorker(runId: string, params: StartRunParams, resumePayload?: ResumePayload) {
   const controller = new AbortController();
   runAbortControllers.set(runId, controller);
@@ -368,15 +392,30 @@ async function runAgentRunWorker(runId: string, params: StartRunParams, resumePa
   let processingQueue: Promise<void> = Promise.resolve();
 
   const stopAtInterrupt = async (parsed: Record<string, unknown>) => {
-    if (sawInterruptPayload) {
-      return;
-    }
-    sawInterruptPayload = parsed;
-    await markRunAwaitingApproval(runId, JSON.stringify(parsed));
-    buffer = '';
-    if (upstream && !upstream.destroyed) {
-      upstream.destroy();
-    }
+    await persistInterruptAndStopRun(
+      runId,
+      parsed,
+      {
+        get sawInterruptPayload() {
+          return sawInterruptPayload;
+        },
+        set sawInterruptPayload(value: Record<string, unknown> | null) {
+          sawInterruptPayload = value;
+        },
+        get buffer() {
+          return buffer;
+        },
+        set buffer(value: string) {
+          buffer = value;
+        },
+        get upstream() {
+          return upstream;
+        },
+        set upstream(value: IncomingMessage | null) {
+          upstream = value;
+        },
+      },
+    );
   };
 
   const processBuffer = async () => {

--- a/backend/src/services/agentRunService.ts
+++ b/backend/src/services/agentRunService.ts
@@ -367,6 +367,18 @@ async function runAgentRunWorker(runId: string, params: StartRunParams, resumePa
   let contractErrorMessage = '';
   let processingQueue: Promise<void> = Promise.resolve();
 
+  const stopAtInterrupt = async (parsed: Record<string, unknown>) => {
+    if (sawInterruptPayload) {
+      return;
+    }
+    sawInterruptPayload = parsed;
+    await markRunAwaitingApproval(runId, JSON.stringify(parsed));
+    buffer = '';
+    if (upstream && !upstream.destroyed) {
+      upstream.destroy();
+    }
+  };
+
   const processBuffer = async () => {
     try {
       let newlineIndex = buffer.indexOf('\n');
@@ -377,7 +389,8 @@ async function runAgentRunWorker(runId: string, params: StartRunParams, resumePa
           await appendStreamEvent(runId, line);
           const parsed = parseLine(line);
           if (parsed?.type === 'interrupt') {
-            sawInterruptPayload = parsed;
+            await stopAtInterrupt(parsed);
+            break;
           }
           if (parsed?.type === 'contract_error') {
             contractErrorMessage =
@@ -409,7 +422,8 @@ async function runAgentRunWorker(runId: string, params: StartRunParams, resumePa
       await appendStreamEvent(runId, line);
       const parsed = parseLine(line);
       if (parsed?.type === 'interrupt') {
-        sawInterruptPayload = parsed;
+        await stopAtInterrupt(parsed);
+        break;
       }
       if (parsed?.type === 'contract_error') {
         contractErrorMessage =
@@ -481,6 +495,11 @@ async function runAgentRunWorker(runId: string, params: StartRunParams, resumePa
       cleanupRun(runId, upstream || undefined);
     });
     upstream.on('error', async (error: Error) => {
+      if (sawInterruptPayload) {
+        await markRunAwaitingApproval(runId, JSON.stringify(sawInterruptPayload));
+        cleanupRun(runId, upstream || undefined);
+        return;
+      }
       const status: AgentRunStatus = controller.signal.aborted ? 'cancelled' : 'failed';
       if (!controller.signal.aborted) {
         const errorPayload = JSON.stringify({ type: 'error', message: error.message || 'Agent stream failed.' });

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -44,6 +44,26 @@ Notes:
 - The backend and agent read `ENV_FILE` if set; otherwise they fall back to a local `.env` in their folder.
 - Vite reads `VITE_*` values from the shell, so `VITE_GOOGLE_CLIENT_ID` in `env/local/dev.env` is enough.
 
+### Local QA without Google login
+
+If you want to test the workspace UI locally without going through Google OAuth,
+start the dev servers with header auth:
+
+```bash
+cd backend
+AUTH_MODE=headers ENV_FILE=../env/local/dev.env npm run dev
+```
+
+```bash
+cd frontend
+VITE_AUTH_MODE=headers npm run dev
+```
+
+This is useful for Playwright and manual browser QA. The frontend will use the
+local header-auth path instead of redirecting to the Google sign-in screen.
+For automated tests, preload a local user into `localStorage` with the key
+`helpudoc-auth-user`.
+
 ## Local development (Docker Compose full stack)
 
 ```bash

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -154,18 +154,22 @@ const FRONTEND_SLIDES_DISCOVERY_QUESTIONS: ClarificationQuestion[] = [
   },
 ];
 
+const getInterruptSkill = (
+  pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  activeSkill?: string,
+): string | undefined => {
+  const normalizedActiveSkill = activeSkill?.trim().toLowerCase();
+  if (normalizedActiveSkill) {
+    return normalizedActiveSkill;
+  }
+  const payloadSkill = pendingInterrupt?.displayPayload?.skill;
+  return typeof payloadSkill === 'string' ? payloadSkill.trim().toLowerCase() : undefined;
+};
+
 const isFrontendSlidesDiscoveryInterrupt = (
   pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
   activeSkill?: string,
-): boolean => {
-  const normalizedSkill = activeSkill?.trim().toLowerCase();
-  if (normalizedSkill === 'frontend-slides') {
-    return true;
-  }
-  const normalizedTitle = String(pendingInterrupt?.title || '').trim().toLowerCase();
-  return normalizedTitle === 'presentation context + images'
-    || normalizedTitle === 'presentation context and images';
-};
+): boolean => getInterruptSkill(pendingInterrupt, activeSkill) === 'frontend-slides';
 
 const getThinkingPlaceholder = (
   metadata?: ConversationMessageMetadata,

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -154,6 +154,19 @@ const FRONTEND_SLIDES_DISCOVERY_QUESTIONS: ClarificationQuestion[] = [
   },
 ];
 
+const isFrontendSlidesDiscoveryInterrupt = (
+  pendingInterrupt?: ConversationMessageMetadata['pendingInterrupt'],
+  activeSkill?: string,
+): boolean => {
+  const normalizedSkill = activeSkill?.trim().toLowerCase();
+  if (normalizedSkill === 'frontend-slides') {
+    return true;
+  }
+  const normalizedTitle = String(pendingInterrupt?.title || '').trim().toLowerCase();
+  return normalizedTitle === 'presentation context + images'
+    || normalizedTitle === 'presentation context and images';
+};
+
 const getThinkingPlaceholder = (
   metadata?: ConversationMessageMetadata,
   toolEvents: ConversationMessage['toolEvents'] = [],
@@ -307,13 +320,17 @@ const parseClarificationQuestions = (
     }
   }
 
-  const skill = activeSkill?.trim().toLowerCase();
   const responseChoices = Array.isArray(pendingInterrupt?.responseSpec?.choices) ? pendingInterrupt?.responseSpec?.choices : [];
   const normalizedChoiceLabels = responseChoices.map((choice) => choice.label.trim().toLowerCase());
   const looksLikeFrontendSlidesDiscovery =
-    skill === 'frontend-slides' &&
-    normalizedChoiceLabels.length === FRONTEND_SLIDES_DISCOVERY_HEADERS.length &&
-    normalizedChoiceLabels.every((label) => FRONTEND_SLIDES_DISCOVERY_HEADERS.includes(label as (typeof FRONTEND_SLIDES_DISCOVERY_HEADERS)[number]));
+    isFrontendSlidesDiscoveryInterrupt(pendingInterrupt, activeSkill)
+    && (
+      normalizedChoiceLabels.length === 0
+      || (
+        normalizedChoiceLabels.length === FRONTEND_SLIDES_DISCOVERY_HEADERS.length &&
+        normalizedChoiceLabels.every((label) => FRONTEND_SLIDES_DISCOVERY_HEADERS.includes(label as (typeof FRONTEND_SLIDES_DISCOVERY_HEADERS)[number]))
+      )
+    );
 
   return looksLikeFrontendSlidesDiscovery ? FRONTEND_SLIDES_DISCOVERY_QUESTIONS : [];
 };

--- a/tests/test_agent_configuration.py
+++ b/tests/test_agent_configuration.py
@@ -9,11 +9,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "agent"))
 from helpudoc_agent.configuration import load_settings  # noqa: E402
 
 
-def test_env_override_paths_resolve_from_current_working_directory(monkeypatch) -> None:
+def test_env_override_paths_resolve_from_agent_root(monkeypatch) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     agent_root = repo_root / "agent"
 
-    monkeypatch.chdir(agent_root)
+    monkeypatch.chdir(repo_root)
     monkeypatch.setenv("WORKSPACE_ROOT", "../backend/workspaces")
     monkeypatch.setenv("SKILLS_ROOT", "../skills")
 

--- a/tests/test_agent_configuration.py
+++ b/tests/test_agent_configuration.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "agent"))
+
+from helpudoc_agent.configuration import load_settings  # noqa: E402
+
+
+def test_env_override_paths_resolve_from_current_working_directory(monkeypatch) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    agent_root = repo_root / "agent"
+
+    monkeypatch.chdir(agent_root)
+    monkeypatch.setenv("WORKSPACE_ROOT", "../backend/workspaces")
+    monkeypatch.setenv("SKILLS_ROOT", "../skills")
+
+    settings = load_settings()
+
+    assert settings.backend.workspace_root == (repo_root / "backend" / "workspaces").resolve()
+    assert settings.backend.skills_root == (repo_root / "skills").resolve()

--- a/tests/test_interrupt_tools.py
+++ b/tests/test_interrupt_tools.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from helpudoc_agent.tagged_file_policy import is_tool_blocked_in_tagged_files_mode
+
+
+TOOLS_FILE = Path(__file__).resolve().parents[1] / "agent" / "helpudoc_agent" / "tools_and_schemas.py"
+
+
+def _method_block(name: str) -> str:
+    source = TOOLS_FILE.read_text(encoding="utf-8")
+    marker = f"def {name}("
+    start = source.index(marker)
+    next_method = source.find("\n    def _build_", start + len(marker))
+    if next_method == -1:
+        return source[start:]
+    return source[start:next_method]
+
+
+def test_request_clarification_not_blocked_by_tagged_files_only() -> None:
+    block = _method_block("request_clarification")
+    assert 'tagged_files_mode_guard(workspace_state.context, "request_clarification")' not in block
+    assert '"kind": "clarification"' in block
+
+
+def test_request_human_action_not_blocked_by_tagged_files_only() -> None:
+    block = _method_block("request_human_action")
+    assert 'tagged_files_mode_guard(workspace_state.context, "request_human_action")' not in block
+    assert "interrupt_kind" in block
+
+
+def test_tagged_file_policy_allows_control_flow_interrupt_tools() -> None:
+    assert is_tool_blocked_in_tagged_files_mode("list_skills") is False
+    assert is_tool_blocked_in_tagged_files_mode("load_skill") is False
+    assert is_tool_blocked_in_tagged_files_mode("request_plan_approval") is False
+    assert is_tool_blocked_in_tagged_files_mode("request_clarification") is False
+    assert is_tool_blocked_in_tagged_files_mode("request_human_action") is False
+
+
+def test_tagged_file_policy_blocks_context_expanding_tools() -> None:
+    assert is_tool_blocked_in_tagged_files_mode("append_to_report") is True
+    assert is_tool_blocked_in_tagged_files_mode("gemini_image") is True


### PR DESCRIPTION
## Summary
- document the local header-auth QA flow and ignore local gstack state
- centralize tagged-file mode tool policy so clarification and skill-loading flows remain available
- resolve local WORKSPACE_ROOT and SKILLS_ROOT overrides for relative dev env values
- harden backend/frontend interrupt fallbacks around pending clarification state

## Commits
- 67d6ff9 Document local QA header-auth flow
- b6409ca Centralize tagged-file tool policy
- 10d5f17 Resolve local env override paths
- 67501ac Harden interrupt handoff fallbacks

## Verification
- python3 -m pytest -q tests/test_interrupt_tools.py tests/test_agent_configuration.py

## Notes
- The env override path behavior currently resolves relative values from the current working directory.
- The chat fallback still includes a title-based frontend-slides discovery heuristic as a safety net.
