### PR TITLE
Hotfix editor sync and chat activity UX

### DIFF
--- a/frontend/src/components/FileEditor.tsx
+++ b/frontend/src/components/FileEditor.tsx
@@ -310,6 +310,21 @@ const FileEditor: React.FC<FileEditorProps> = ({
   }, [fileContent]);
 
   useEffect(() => {
+    if (!fileName || getLanguage(fileName) !== 'markdown' || isRawView) {
+      return;
+    }
+
+    const editorInstance = mdxEditorRef.current;
+    if (!editorInstance) {
+      return;
+    }
+
+    isApplyingRemoteRef.current = true;
+    editorInstance.setMarkdown(fileContent || '');
+    isApplyingRemoteRef.current = false;
+  }, [fileContent, fileName, isRawView]);
+
+  useEffect(() => {
     setMdxError(null);
   }, [fileId, isRawView]);
 
@@ -574,6 +589,7 @@ const FileEditor: React.FC<FileEditorProps> = ({
                 )}
                 <Suspense fallback={<EditorLoadingState className="min-h-[320px] flex-1" label="Loading rich editor..." />}>
                   <MarkdownRichEditor
+                    key={fileId ?? resolvedFileName}
                     ref={mdxEditorRef}
                     markdown={fileContent}
                     onChange={(value) => {

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -4,13 +4,17 @@ import remarkGfm from 'remark-gfm';
 import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
 
 import type { ConversationMessage, ConversationMessageMetadata } from '../../types';
-import ToolOutputFilePreview from './ToolOutputFilePreview';
 import type { RenderableInterruptAction } from './interruptActions';
 import { buildApprovalReview } from './approvalReview';
 
 const THOUGHT_PREVIEW_LIMIT = 320;
 const DEFAULT_THINKING_PLACEHOLDER = 'Working through your request based on the current workspace context.';
 const FRONTEND_SLIDES_DISCOVERY_HEADERS = ['purpose', 'length', 'content', 'images', 'editing'] as const;
+
+const isSkippedToolEvent = (event: NonNullable<ConversationMessage['toolEvents']>[number]): boolean => {
+  const summary = typeof event.summary === 'string' ? event.summary.trim() : '';
+  return /^Skipped\b/i.test(summary);
+};
 
 type ClarificationQuestionOption = {
   id: string;
@@ -413,7 +417,7 @@ export default function ChatMessageBubble({
   handleInterruptAction,
   enableTrustedPlanMode,
   isStreaming,
-  workspaceId,
+  workspaceId: _workspaceId,
 }: {
   colorMode: 'light' | 'dark';
   message: ConversationMessage;
@@ -469,7 +473,10 @@ export default function ChatMessageBubble({
   const isAgentMessage = message.sender === 'agent';
   const messageMetadata = (message.metadata as ConversationMessageMetadata | null | undefined) || undefined;
   const timestampLabel = formatMessageTimestamp(message.updatedAt || message.createdAt);
-  const toolEvents = message.toolEvents || [];
+  const toolEvents = useMemo(
+    () => (message.toolEvents || []).filter((event) => !isSkippedToolEvent(event)),
+    [message.toolEvents],
+  );
   const hasToolEvents = toolEvents.length > 0;
   const pendingInterrupt = messageMetadata?.pendingInterrupt;
   const interruptKind = getInterruptKind(pendingInterrupt);
@@ -934,7 +941,7 @@ export default function ChatMessageBubble({
                     <div className="min-w-0">
                       <div className="flex flex-wrap items-center gap-2">
                         <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-                          {approvalReview?.cardTitle || pendingInterrupt.title || 'Review Research Strategy'}
+                          {approvalReview?.cardTitle || pendingInterrupt.title || 'Review Proposed Action'}
                         </p>
                         <span className="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-700">
                           <CheckCircle2 size={12} />
@@ -945,7 +952,7 @@ export default function ChatMessageBubble({
                         {approvalReview?.planTitle || 'Proposed plan'}
                       </p>
                       <p className="mt-1 text-sm leading-relaxed text-slate-600">
-                        {approvalReview?.description || pendingInterrupt.description || 'Review the proposed research strategy before execution continues.'}
+                        {approvalReview?.description || pendingInterrupt.description || 'Review the proposed action before execution continues.'}
                       </p>
                     </div>
                     {approvalReview?.stepCount && approvalReview.stepCount > 1 ? (
@@ -1298,8 +1305,16 @@ export default function ChatMessageBubble({
                                       isDarkMode ? 'border-slate-700/70 bg-slate-950/80' : 'border-slate-200 bg-white'
                                     }`}
                                   >
-                                    <p className={`break-all text-xs font-semibold ${isDarkMode ? 'text-slate-200' : 'text-slate-700'}`}>{file.path}</p>
-                                    <ToolOutputFilePreview workspaceId={workspaceId} file={file} markdownComponents={markdownComponents} />
+                                    <div className="flex items-center justify-between gap-3">
+                                      <p className={`break-all text-xs font-semibold ${isDarkMode ? 'text-slate-200' : 'text-slate-700'}`}>{file.path}</p>
+                                      {file.mimeType ? (
+                                        <span className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+                                          isDarkMode ? 'bg-slate-800 text-slate-300' : 'bg-slate-100 text-slate-600'
+                                        }`}>
+                                          {file.mimeType}
+                                        </span>
+                                      ) : null}
+                                    </div>
                                   </div>
                                 ))}
                               </div>

--- a/frontend/src/components/chat/approvalReview.ts
+++ b/frontend/src/components/chat/approvalReview.ts
@@ -29,9 +29,9 @@ export type ApprovalReviewModel = {
 
 type PrimaryInterruptAction = { name?: string; args?: Record<string, unknown> } | undefined;
 
-const DEFAULT_CARD_TITLE = 'Review Research Strategy';
+const DEFAULT_CARD_TITLE = 'Review Proposed Action';
 const DEFAULT_BADGE_LABEL = 'Pending Approval';
-const DEFAULT_PLAN_PATH = 'research_plan.md';
+const DEFAULT_PLAN_PATH = 'draft.md';
 
 const coerceString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
 

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -2850,6 +2850,18 @@ export default function WorkspacePage() {
     const actions = Array.isArray(pendingInterrupt?.actions) ? pendingInterrupt.actions : [];
     const actionRequests = Array.isArray(pendingInterrupt?.actionRequests) ? pendingInterrupt.actionRequests : [];
     const reviewConfigs = Array.isArray(pendingInterrupt?.reviewConfigs) ? pendingInterrupt.reviewConfigs : [];
+    const interruptTitle = typeof pendingInterrupt?.title === 'string' ? pendingInterrupt.title.trim().toLowerCase() : '';
+    const interruptDescription = typeof pendingInterrupt?.description === 'string'
+      ? pendingInterrupt.description.trim().toLowerCase()
+      : '';
+    const hasClarificationRequest = actionRequests.some((request) => {
+      const name = typeof request?.name === 'string' ? request.name.trim().toLowerCase() : '';
+      return name.includes('clarification');
+    });
+    const hasClarificationReviewConfig = reviewConfigs.some((config) => {
+      const name = typeof config?.action_name === 'string' ? config.action_name.trim().toLowerCase() : '';
+      return name.includes('clarification');
+    });
     const hasApprovalConfig = actionRequests.length > 0 || reviewConfigs.length > 0;
     const hasClarificationAction = actions.some((action) => {
       if (!action || typeof action !== 'object') {
@@ -2863,6 +2875,15 @@ export default function WorkspacePage() {
       }
       return false;
     });
+
+    if (
+      hasClarificationRequest ||
+      hasClarificationReviewConfig ||
+      /clarification|need(s)? more detail|question/i.test(interruptTitle) ||
+      /clarification|need(s)? more detail|question/i.test(interruptDescription)
+    ) {
+      return 'clarification';
+    }
 
     if (hasClarificationAction && !hasApprovalConfig) {
       return 'clarification';

--- a/skills/general/SKILL.md
+++ b/skills/general/SKILL.md
@@ -33,4 +33,12 @@ Use this skill for general requests and as a router to other skills when special
    - Use `rag_query` first if it returns relevant chunks for those file paths.
    - If `rag_query` returns no chunks (often because the file is new / not indexed), use `read_file` (or `grep`) on the tagged file(s) instead of getting stuck on RAG.
 
+5. **Image generation and editing**
+
+   - Treat the request as authorizing `gemini_image` whenever the user asks for image generation or image editing in substance, even if they do not name the tool.
+   - This includes prompts asking for an image, PNG, JPG, diagram image, mockup, illustration, rendered visual, or requests such as `use gemini image`, `use gemini_image`, or `generate this as an image with Gemini`.
+   - If the user asks for an image derived from a tagged workspace file, read the tagged file first, extract the relevant content, then call `gemini_image` without adding an extra approval/planning detour unless essential information is missing.
+   - When making the image call, restate that the user asked for image generation or editing so downstream tool guards can see the authorization in context.
+   - Do not call `gemini_image` for routine document or code tasks unless the user explicitly wants a visual artifact.
+
 Always be concise, accurate, and efficient.

--- a/skills/proposal-writing/SKILL.md
+++ b/skills/proposal-writing/SKILL.md
@@ -10,6 +10,10 @@ description: Create a multi-section Statement of Work (SOW) proposal for data/an
 - Use write_file for every new file and append_to_report to stitch sections into /Final_Proposal.md.
 - If append_to_report is unavailable, read the section file and append it by rewriting /Final_Proposal.md with write_file.
 - Reply in chat only with short progress updates and final confirmation.
+- Default proposal visuals to Mermaid inside markdown. Do not switch to image generation unless the user explicitly asks for a static visual artifact such as PNG/JPG/diagram image.
+- If the user explicitly asks for a static image export from proposal content or names `gemini_image`, treat that as authorization to call `gemini_image` after reading the relevant section file and extracting the specific table/diagram to visualize.
+- For those explicit image-export requests, do not hand off to unrelated sales asset workflows unless the user asks for a broader customer-facing asset.
+- `Final_Proposal.md` must preserve the wording of each section file. Stitch from the section files exactly; do not paraphrase, compress, or rewrite section prose while assembling the final document.
 
 ## Workflow
 ### Phase 1 - Research
@@ -42,7 +46,7 @@ description: Create a multi-section Statement of Work (SOW) proposal for data/an
 ### Phase 3 - Write & Stitch (one section at a time)
 For each section in order:
 1. Read /proposal_config.json and focus on a single section.
-2. Resume logic: If the section file already exists or its content is already in /Final_Proposal.md, mark it complete and continue.
+2. Resume logic: If the section file already exists, prefer it as the source of truth. Do not trust /Final_Proposal.md as proof that the section is correct unless the wording materially matches the section file.
 3. Write the section file (400-800 words) using write_file:
    - /01_executive_summary.md
    - /02_business_requirements.md
@@ -52,11 +56,34 @@ For each section in order:
    - /06_success_criteria.md
    - /07_commercials.md
 4. Append the section into /Final_Proposal.md using append_to_report.
-5. Update todos after each section (mark in-progress then complete). If using /todos.md, rewrite it with write_file.
+5. After appending, verify the stitched content still matches the section file. If the wording was compressed, altered, or partially omitted, repair /Final_Proposal.md from the section file content before moving on.
+6. Update todos after each section (mark in-progress then complete). If using /todos.md, rewrite it with write_file.
+
+### Phase 3.5 - Optional Static Visual Exports
+Only run this phase if the user asked for static image outputs.
+1. Finish the markdown section files first, including Mermaid diagrams in /03_architecture.md and /04_scope_of_work.md.
+2. Then generate any requested static visuals from the completed markdown artifacts:
+   - architecture diagram image from /03_architecture.md
+   - Gantt chart image from /04_scope_of_work.md
+   - RACI matrix image from /04_scope_of_work.md
+3. Save these as separate workspace artifacts, for example:
+   - /architecture-diagram.png
+   - /gantt-chart.png
+   - /raci-matrix.png
+4. Treat the completed markdown files as the canonical source. The images are derivative exports, not replacements for the markdown artifacts.
 
 ### Phase 4 - Complete
 1. Verify /Final_Proposal.md exists.
-2. Respond with: Proposal complete. Check /Final_Proposal.md (includes Mermaid diagrams)
+2. Re-read every section file and rebuild /Final_Proposal.md from those exact contents in order if there is any mismatch, compression, paraphrase, or missing block.
+3. Confirm that the final file contains the same section wording as:
+   - /01_executive_summary.md
+   - /02_business_requirements.md
+   - /03_architecture.md
+   - /04_scope_of_work.md
+   - /05_assumptions_out_of_scope.md
+   - /06_success_criteria.md
+   - /07_commercials.md
+4. Respond with: Proposal complete. Check /Final_Proposal.md (includes Mermaid diagrams)
 
 ## Section requirements (exhaustive)
 ### 1) Executive Summary
@@ -99,5 +126,7 @@ For each section in order:
 - Do not write all sections at once.
 - Write and stitch exactly one section at a time.
 - Sections 3 and 4 must include Mermaid diagrams.
+- If the user asks for static chart or diagram images, generate them only after the markdown sections are complete.
 - Keep /proposal_config.json as the single source of truth.
 - If you resume mid-run, reuse existing files and skip completed sections.
+- Never let /Final_Proposal.md become a summarized version of the section files. The section files are canonical; the final proposal is a stitched copy of them.


### PR DESCRIPTION
## Summary
- fix markdown rich editor resync so Mermaid-heavy files do not appear blank when toggling edit mode
- reduce chat noise by hiding skipped tool events and replacing inline artifact previews with compact file entries
- improve interrupt classification so clarification flows do not render as plan approvals
- soften skill guidance so image-generation requests can call `gemini_image` without requiring the user to name Gemini explicitly
- tighten proposal-writing guidance so `Final_Proposal.md` is stitched from section files without compression drift

## Verification
- npm run build (frontend)

## Notes
- excludes unrelated local changes in frontend/Dockerfile and backend/src/services/fileService.ts