### PR TITLE
Tighten workspace page UI density

### DIFF
--- a/frontend/src/components/WorkspaceFileTree.tsx
+++ b/frontend/src/components/WorkspaceFileTree.tsx
@@ -80,7 +80,7 @@ const SlidingFileName: React.FC<{ name: string; colorMode: 'light' | 'dark' }> =
     <span ref={viewportRef} className="block min-w-0 overflow-hidden whitespace-nowrap">
       <span
         ref={textRef}
-        className={`block w-max max-w-full truncate text-sm leading-snug transition-transform duration-500 ease-out group-hover:truncate-none group-focus-within:truncate-none ${
+        className={`block w-max max-w-full truncate text-[13px] leading-snug transition-transform duration-500 ease-out group-hover:truncate-none group-focus-within:truncate-none ${
           colorMode === 'dark' ? 'text-slate-200' : 'text-slate-800'
         }`}
         style={overflowOffset > 0 ? { transform: `translateX(calc(${overflowOffset * -1}px * var(--file-name-slide, 0)))` } : undefined}
@@ -149,7 +149,7 @@ const TreeFileRow: React.FC<{
 
   return (
     <div
-      className={`group relative flex items-start gap-2 rounded-lg px-2 py-2 transition-colors ${rowClassName} ${
+      className={`group relative flex items-start gap-2 rounded-lg px-2 py-1.5 transition-colors ${rowClassName} ${
         isBeingDragged ? 'opacity-40' : ''
       }`}
       draggable={isDraggable}
@@ -278,7 +278,7 @@ const TreeFolderRow: React.FC<{
   return (
     <div className="select-none">
       <div
-        className={`group flex items-center gap-2 rounded-lg px-2 py-2 transition-colors ${containerClassName}`}
+        className={`group flex items-center gap-2 rounded-lg px-2 py-1.5 transition-colors ${containerClassName}`}
         onDragOver={(event) => {
           if (!canAcceptDrop) {
             return;
@@ -309,7 +309,7 @@ const TreeFolderRow: React.FC<{
         <button
           type="button"
           onClick={() => onToggle(node.path)}
-          className={`inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
+          className={`inline-flex h-6 w-6 items-center justify-center rounded-md transition-colors ${
             isDarkMode
               ? 'text-slate-400 hover:bg-slate-700/70 hover:text-slate-100'
               : 'text-slate-500 hover:bg-slate-200 hover:text-slate-800'
@@ -326,7 +326,7 @@ const TreeFolderRow: React.FC<{
           title={node.path || node.name}
         >
           <div className="flex items-center gap-2">
-            <span className={`truncate text-sm font-medium ${isDarkMode ? 'text-slate-200' : 'text-slate-800'}`}>{getFolderLabel(node)}</span>
+            <span className={`truncate text-[13px] font-medium ${isDarkMode ? 'text-slate-200' : 'text-slate-800'}`}>{getFolderLabel(node)}</span>
             <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
               isDarkMode ? 'bg-slate-800 text-slate-400' : 'bg-slate-200 text-slate-600'
             }`}>

--- a/frontend/src/components/chat/ChatHeader.tsx
+++ b/frontend/src/components/chat/ChatHeader.tsx
@@ -32,14 +32,14 @@ export default function ChatHeader({
 }) {
   const isDarkMode = colorMode === 'dark';
   return (
-    <div className={`sticky top-0 z-30 border-b px-4 py-3 backdrop-blur-md ${
+    <div className={`sticky top-0 z-30 border-b px-3 py-2.5 backdrop-blur-md ${
       isDarkMode ? 'border-slate-700/70 bg-slate-950/60' : 'border-slate-200/70 bg-white/80'
     }`}>
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <button
             onClick={onToggleVisibility}
-            className={`rounded-xl p-2 transition-all duration-200 ${
+            className={`rounded-xl p-1.5 transition-all duration-200 ${
               isDarkMode ? 'text-slate-300 hover:bg-slate-800' : 'text-slate-600 hover:bg-slate-100'
             }`}
             disabled={isEditMode}
@@ -52,13 +52,13 @@ export default function ChatHeader({
           </button>
           {isAgentPaneVisible && (
             <div className="flex items-center gap-2">
-              <span className={`text-[11px] font-semibold uppercase tracking-wide ${
+              <span className={`text-[10px] font-semibold uppercase tracking-wide ${
                 isDarkMode ? 'text-slate-400' : 'text-slate-500'
               }`}>Mode</span>
               <select
                 value={selectedPersona}
                 onChange={onModeChange}
-                className={`rounded-xl border px-2.5 py-1 text-sm font-semibold shadow-sm transition-all duration-200 focus:outline-none ${
+                className={`rounded-xl border px-2.5 py-1 text-xs font-semibold shadow-sm transition-all duration-200 focus:outline-none ${
                   isDarkMode
                     ? 'border-slate-700/80 bg-slate-800/90 text-slate-100 focus:border-sky-400 focus:ring-2 focus:ring-sky-400/20'
                     : 'border-slate-200/80 bg-slate-100/90 text-slate-700 focus:border-blue-400 focus:ring-2 focus:ring-blue-200'
@@ -80,7 +80,7 @@ export default function ChatHeader({
             <button
               type="button"
               onClick={onToggleHistory}
-              className={`rounded-xl p-2 transition-all duration-200 ${
+              className={`rounded-xl p-1.5 transition-all duration-200 ${
                 isHistoryOpen
                   ? isDarkMode
                     ? 'bg-sky-500/14 text-sky-200 ring-1 ring-sky-400/35'
@@ -98,7 +98,7 @@ export default function ChatHeader({
             <span className={`h-5 w-px ${isDarkMode ? 'bg-slate-700' : 'bg-slate-200'}`} aria-hidden="true" />
             <button
               onClick={onNewChat}
-              className={`rounded-xl p-2 transition-all duration-200 ${
+              className={`rounded-xl p-1.5 transition-all duration-200 ${
                 isDarkMode ? 'text-slate-300 hover:bg-slate-800' : 'text-slate-600 hover:bg-slate-100'
               }`}
               title="Start new chat"
@@ -108,7 +108,7 @@ export default function ChatHeader({
             </button>
             <button
               onClick={onToggleFullScreen}
-              className={`rounded-xl p-2 transition-all duration-200 ${
+              className={`rounded-xl p-1.5 transition-all duration-200 ${
                 isDarkMode ? 'text-slate-300 hover:bg-slate-800' : 'text-slate-600 hover:bg-slate-100'
               }`}
               title={isAgentPaneFullScreen ? 'Exit full screen chat' : 'Enter full screen chat'}

--- a/frontend/src/components/chat/ChatHistoryPanel.tsx
+++ b/frontend/src/components/chat/ChatHistoryPanel.tsx
@@ -55,7 +55,7 @@ export default function ChatHistoryPanel({
         />
       )}
       <div
-        className={`absolute inset-y-0 right-0 z-20 flex w-80 max-w-[90%] flex-col border-l shadow-2xl backdrop-blur-md transition-transform duration-200 ${
+        className={`absolute inset-y-0 right-0 z-20 flex w-72 max-w-[90%] flex-col border-l shadow-2xl backdrop-blur-md transition-transform duration-200 ${
           isDarkMode
             ? 'border-slate-700/70 bg-slate-950/92 ring-1 ring-white/5'
             : 'border-slate-200/80 bg-white/92 ring-1 ring-slate-200/60'
@@ -64,7 +64,7 @@ export default function ChatHistoryPanel({
         }`}
         aria-hidden={!isHistoryOpen}
       >
-        <div className={`flex items-center justify-between border-b px-4 py-3 ${
+        <div className={`flex items-center justify-between border-b px-3 py-2.5 ${
           isDarkMode ? 'border-slate-700/70' : 'border-slate-200/80'
         }`}>
           <div>
@@ -86,7 +86,7 @@ export default function ChatHistoryPanel({
             <X size={16} />
           </button>
         </div>
-        <div className="flex-1 space-y-2 overflow-y-auto p-4">
+        <div className="flex-1 space-y-2 overflow-y-auto p-3">
           {conversationHistory.length === 0 ? (
             <div className="flex h-full flex-col items-center justify-center text-center">
               <div className={`rounded-3xl border px-5 py-5 ${
@@ -125,7 +125,7 @@ export default function ChatHistoryPanel({
                       onSelectConversation(conversation.id);
                       onClose();
                     }}
-                    className={`w-full rounded-2xl border p-3 pr-9 text-left transition-all duration-200 ${
+                    className={`w-full rounded-2xl border p-2.5 pr-9 text-left transition-all duration-200 ${
                       isActive
                         ? isDarkMode
                           ? 'border-sky-500/45 bg-sky-500/10 shadow-[0_16px_40px_-28px_rgba(14,165,233,0.55)]'

--- a/frontend/src/components/chat/ChatInputArea.tsx
+++ b/frontend/src/components/chat/ChatInputArea.tsx
@@ -80,7 +80,7 @@ export default function ChatInputArea({
   const isDarkMode = colorMode === 'dark';
 
   return (
-    <div className={`sticky bottom-0 border-t p-4 backdrop-blur-md ${
+    <div className={`sticky bottom-0 border-t p-3 backdrop-blur-md ${
       isDarkMode ? 'border-slate-700/70 bg-slate-950/45' : 'border-slate-200/80 bg-white/80'
     }`}>
       <div className={`relative rounded-2xl border transition-all duration-200 ${
@@ -89,11 +89,11 @@ export default function ChatInputArea({
           : 'border-slate-200/90 bg-white shadow-[0_24px_60px_-36px_rgba(15,23,42,0.15)] focus-within:border-sky-400/70 focus-within:ring-2 focus-within:ring-sky-200/50'
       }`}>
         {chatAttachments.length > 0 && (
-          <div className="flex flex-wrap gap-2 px-3 pt-3">
+          <div className="flex flex-wrap gap-2 px-3 pt-2.5">
             {chatAttachments.map((file, index) => (
               <div
                 key={`${file.name}-${index}`}
-                className={`group flex items-center gap-2 rounded-lg border px-2 py-1 text-xs font-medium transition-all duration-200 ${
+                className={`group flex items-center gap-2 rounded-lg border px-2 py-1 text-[11px] font-medium transition-all duration-200 ${
                   isDarkMode ? 'border-slate-700/70 bg-slate-950/70 text-slate-200' : 'border-slate-200 bg-slate-50 text-slate-700'
                 }`}
               >
@@ -113,11 +113,11 @@ export default function ChatInputArea({
           </div>
         )}
         {commandTags.length > 0 && (
-          <div className="flex flex-wrap gap-2 px-3 pt-3">
+          <div className="flex flex-wrap gap-2 px-3 pt-2.5">
             {commandTags.map((tag) => (
               <div
                 key={tag.id}
-                className={`group flex items-center gap-2 rounded-full border px-2.5 py-1 text-xs font-medium ${
+                className={`group flex items-center gap-2 rounded-full border px-2.5 py-1 text-[11px] font-medium ${
                   isDarkMode
                     ? 'border-sky-400/25 bg-slate-950/75 text-sky-100'
                     : 'border-sky-200 bg-sky-50 text-sky-700'
@@ -146,28 +146,28 @@ export default function ChatInputArea({
           onKeyDown={onChatInputKeyDown}
           onKeyUp={onChatInputKeyUp}
           onSelect={onChatInputSelectionChange}
-          className={`w-full max-h-60 resize-none bg-transparent px-4 py-3 text-sm leading-relaxed focus:outline-none ${
+          className={`w-full max-h-52 resize-none bg-transparent px-3.5 py-2.5 text-sm leading-relaxed focus:outline-none ${
             isDarkMode ? 'text-slate-100 placeholder:text-slate-500' : 'text-slate-800 placeholder:text-slate-400'
           }`}
           rows={Math.min(5, Math.max(1, chatMessage.split('\n').length))}
-          style={{ minHeight: '56px' }}
+          style={{ minHeight: '50px' }}
         />
-        <div className="flex items-center justify-between px-2 pb-2">
+        <div className="flex items-center justify-between px-2 pb-1.5">
           <div className="flex items-center gap-1">
             <button
               type="button"
               onClick={onChatAttachmentButtonClick}
-              className={`rounded-lg p-2 transition-all duration-200 ${
+              className={`rounded-lg p-1.5 transition-all duration-200 ${
                 isDarkMode ? 'text-slate-400 hover:bg-slate-800 hover:text-slate-100' : 'text-slate-500 hover:bg-slate-100 hover:text-slate-800'
               }`}
               title="Attach files"
             >
-              <Plus size={18} />
+              <Plus size={16} />
             </button>
             <button
               type="button"
               onClick={onInsertSlashTrigger}
-              className={`rounded-lg p-2 transition-all duration-200 ${
+              className={`rounded-lg p-1.5 transition-all duration-200 ${
                 isDarkMode ? 'text-slate-400 hover:bg-slate-800 hover:text-slate-100' : 'text-slate-500 hover:bg-slate-100 hover:text-slate-800'
               }`}
               title="Commands"
@@ -181,7 +181,7 @@ export default function ChatInputArea({
                 <button
                   type="button"
                   onClick={onOpenPresentationModal}
-                  className={`rounded-lg p-2 transition-all duration-200 ${
+                  className={`rounded-lg p-1.5 transition-all duration-200 ${
                     presentationStatus === 'running'
                       ? isDarkMode
                         ? 'bg-sky-400/12 text-sky-100 ring-1 ring-sky-400/25'
@@ -193,7 +193,7 @@ export default function ChatInputArea({
                   title={`Configure Paper2Slides: ${presentationOptionSummary || 'Options'}`}
                   aria-label="Configure Paper2Slides"
                 >
-                  <MonitorPlay size={18} />
+                  <MonitorPlay size={16} />
                 </button>
               </>
             )}
@@ -205,7 +205,7 @@ export default function ChatInputArea({
             <button
               onClick={isStreaming ? onStopStreaming : onSendMessage}
               disabled={!chatMessage.trim() && !chatAttachments.length && !isStreaming}
-              className={`rounded-xl p-2 transition-all duration-200 ${
+              className={`rounded-xl p-1.5 transition-all duration-200 ${
                 !chatMessage.trim() && !chatAttachments.length && !isStreaming
                   ? isDarkMode
                     ? 'cursor-not-allowed bg-slate-800 text-slate-600'
@@ -218,7 +218,7 @@ export default function ChatInputArea({
               }`}
               title={isStreaming ? 'Stop current agent response' : 'Send message'}
             >
-              {isStreaming ? <StopCircle size={18} /> : <Send size={18} />}
+              {isStreaming ? <StopCircle size={16} /> : <Send size={16} />}
             </button>
           </div>
         </div>

--- a/frontend/src/components/chat/ChatMessageList.tsx
+++ b/frontend/src/components/chat/ChatMessageList.tsx
@@ -247,14 +247,14 @@ export default function ChatMessageList({
       <div
         ref={listRef}
         onScroll={handleScroll}
-        className="h-full overflow-y-auto px-4 py-4 min-h-0"
+        className="h-full overflow-y-auto px-3 py-3 min-h-0"
       >
-        <div className="mx-auto w-full max-w-5xl space-y-4">
+        <div className="mx-auto w-full max-w-[72rem] space-y-3">
           {messages.length === 0 ? (
             <div className={`flex h-full min-h-[40vh] flex-col items-center justify-center text-center ${
               isDarkMode ? 'text-slate-400' : 'text-slate-500'
             }`}>
-              <div className={`rounded-3xl border px-6 py-8 backdrop-blur-sm ${
+              <div className={`rounded-3xl border px-5 py-7 backdrop-blur-sm ${
                 isDarkMode
                   ? 'border-slate-700/70 bg-slate-900/75 shadow-[0_20px_50px_-32px_rgba(15,23,42,0.95)]'
                   : 'border-slate-200/80 bg-white/92 shadow-[0_24px_60px_-40px_rgba(15,23,42,0.16)]'

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -1064,10 +1064,10 @@ export default function WorkspacePage() {
   const agentPaneWidth = isAgentPaneFullScreen
     ? '100%'
     : isAgentPaneVisible
-      ? '24rem'
+      ? '22rem'
       : '3rem';
 
-  const filePaneWidth = isFilePaneVisible ? 360 : 56;
+  const filePaneWidth = isFilePaneVisible ? 320 : 52;
 
   const layoutHeight = '100%';
 
@@ -5429,7 +5429,7 @@ export default function WorkspacePage() {
           component="main"
           sx={{
             flexGrow: 1,
-            p: 3,
+            p: 2,
             height: '100%',
             maxHeight: '100%',
             minHeight: 0,
@@ -5466,7 +5466,7 @@ export default function WorkspacePage() {
               style={workspacePaneStyles}
             >
               {/* Workspace Header */}
-              <div className={`p-4 flex justify-between items-center ${
+              <div className={`px-4 py-3 flex justify-between items-center ${
                 isDarkMode ? 'border-b border-slate-800 bg-[#08111f]' : 'border-b border-gray-200'
               }`}>
                 {selectedWorkspace ? (
@@ -5489,7 +5489,7 @@ export default function WorkspacePage() {
                       }}
                       disabled={workspaceRenameBusy}
                       aria-label="Workspace name"
-                      className={`w-full max-w-[28rem] rounded-lg px-3 py-1.5 text-xl font-semibold outline-none ring-2 disabled:cursor-wait ${
+                      className={`w-full max-w-[24rem] rounded-lg px-3 py-1.5 text-lg font-semibold outline-none ring-2 disabled:cursor-wait ${
                         isDarkMode
                           ? 'border border-sky-500/40 bg-slate-900 text-slate-100 ring-sky-500/20'
                           : 'border border-blue-200 bg-white text-gray-800 ring-blue-100'
@@ -5503,7 +5503,7 @@ export default function WorkspacePage() {
                         setWorkspaceNameDraft(selectedWorkspace.name);
                         setIsWorkspaceRenameActive(true);
                       }}
-                      className={`flex items-center gap-2 text-left text-xl font-semibold ${
+                      className={`flex items-center gap-2 text-left text-lg font-semibold ${
                         selectedWorkspace.canEdit
                           ? isDarkMode ? 'text-slate-100 hover:text-sky-300' : 'text-gray-800 hover:text-blue-700'
                           : isDarkMode ? 'cursor-default text-slate-100' : 'cursor-default text-gray-800'
@@ -5514,7 +5514,7 @@ export default function WorkspacePage() {
                     </button>
                   )
                 ) : (
-                  <h2 className={`text-xl font-semibold ${isDarkMode ? 'text-slate-100' : 'text-gray-800'}`}>No workspace selected</h2>
+                  <h2 className={`text-lg font-semibold ${isDarkMode ? 'text-slate-100' : 'text-gray-800'}`}>No workspace selected</h2>
                 )}
               </div>
               <div className="flex-1 flex min-h-0">
@@ -5526,14 +5526,14 @@ export default function WorkspacePage() {
                   style={filePaneStyles}
                 >
                   <div
-                    className={`p-4 flex items-center ${isFilePaneVisible ? 'justify-between' : 'justify-center'
+                    className={`px-3 py-3 flex items-center ${isFilePaneVisible ? 'justify-between' : 'justify-center'
                       } ${isDarkMode ? 'border-b border-slate-800' : 'border-b border-gray-200'
                       }`}
                   >
                     <div className={`flex items-center ${isFilePaneVisible ? 'gap-3' : ''}`}>
                       <button
                         onClick={() => setIsFilePaneVisible(!isFilePaneVisible)}
-                        className={`p-1.5 border rounded-full ${
+                        className={`p-1 border rounded-full ${
                           isDarkMode
                             ? 'border-slate-700 text-slate-300 hover:bg-slate-800'
                             : 'border-gray-200 hover:bg-gray-100'
@@ -5548,7 +5548,7 @@ export default function WorkspacePage() {
                             }`}
                         />
                       </button>
-                      {isFilePaneVisible && <h3 className={`text-lg font-semibold ${isDarkMode ? 'text-slate-100' : 'text-gray-800'}`}>Files</h3>}
+                      {isFilePaneVisible && <h3 className={`text-base font-semibold ${isDarkMode ? 'text-slate-100' : 'text-gray-800'}`}>Files</h3>}
                     </div>
                     {isFilePaneVisible && (
                       <div className="flex items-center space-x-1.5">
@@ -5562,40 +5562,40 @@ export default function WorkspacePage() {
                         <button
                           onClick={() => document.getElementById('file-upload')?.click()}
                           disabled={!selectedWorkspace}
-                          className={`p-2 rounded-lg disabled:opacity-50 ${
+                          className={`p-1.5 rounded-lg disabled:opacity-50 ${
                             isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-gray-100'
                           }`}
                         >
-                          <Plus size={18} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
+                          <Plus size={16} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
                         </button>
                         <button
                           onClick={handleRefreshFiles}
                           disabled={!selectedWorkspace}
-                          className={`p-2 rounded-lg disabled:opacity-50 ${
+                          className={`p-1.5 rounded-lg disabled:opacity-50 ${
                             isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-gray-100'
                           }`}
                           title="Refresh files"
                         >
-                          <RotateCcw size={18} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
+                          <RotateCcw size={16} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
                         </button>
                         <button
                           onClick={handleSelectAllFiles}
                           disabled={visibleFiles.length === 0}
-                          className={`p-2 rounded-lg disabled:opacity-50 ${
+                          className={`p-1.5 rounded-lg disabled:opacity-50 ${
                             isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-gray-100'
                           }`}
                           title={allFilesSelected ? 'Clear selection' : 'Select all files'}
                         >
-                          <CheckSquare size={18} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
+                          <CheckSquare size={16} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
                         </button>
                         <button
                           onClick={handleBulkDelete}
                           disabled={selectedFiles.size === 0}
-                          className={`p-2 rounded-lg disabled:opacity-50 ${
+                          className={`p-1.5 rounded-lg disabled:opacity-50 ${
                             isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-gray-100'
                           }`}
                         >
-                          <Trash size={18} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
+                          <Trash size={16} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
                         </button>
                       </div>
                     )}
@@ -5623,7 +5623,7 @@ export default function WorkspacePage() {
                       }`}
                     aria-hidden={!isFilePaneVisible}
                   >
-                    <div className="h-full min-h-0 px-4 py-3">
+                    <div className="h-full min-h-0 px-3 py-2">
                       <WorkspaceFileTree
                         files={visibleFiles}
                         colorMode={colorMode}
@@ -5652,77 +5652,77 @@ export default function WorkspacePage() {
                 <div className={`flex-1 flex flex-col overflow-hidden min-w-0 min-h-0 ${
                   isDarkMode ? 'bg-[#0b1323]' : 'bg-gray-50'
                 }`}>
-                  <div className={`px-4 pt-4 pb-6 flex justify-between items-center ${
+                  <div className={`px-4 py-3 flex justify-between items-center ${
                     isDarkMode ? 'border-b border-slate-800' : 'border-b border-gray-200'
                   }`}>
                     <div className="flex items-center gap-3">
-                      <h3 className={`text-lg font-semibold ${isDarkMode ? 'text-slate-100' : 'text-gray-800'}`}>{canvasTitle}</h3>
+                      <h3 className={`text-base font-semibold ${isDarkMode ? 'text-slate-100' : 'text-gray-800'}`}>{canvasTitle}</h3>
                     </div>
                     <div className="flex items-center space-x-2">
                       {canCopyImageUrl && (
                         <button
                           type="button"
-                          className={`h-9 w-9 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
+                          className={`h-8 w-8 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
                             isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-gray-200'
                           }`}
                           onClick={handleCopyImageUrl}
                           title={copiedImageUrl ? 'Copied!' : 'Copy public URL'}
                         >
-                          <LinkIcon size={18} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
+                          <LinkIcon size={16} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
                         </button>
                       )}
                       <button
                         type="button"
-                        className={`h-9 w-9 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
+                        className={`h-8 w-8 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
                           isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-gray-200'
                         }`}
                         onClick={handleCopyWorkspaceContent}
                         disabled={!selectedFile}
                         title={copiedWorkspaceContent ? 'Copied!' : 'Copy file content'}
                       >
-                        <Copy size={18} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
+                        <Copy size={16} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
                       </button>
                       {canPrintOrDownloadFile && (
                         <>
                           <button
                             type="button"
-                            className={`h-9 w-9 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
+                            className={`h-8 w-8 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
                               isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-gray-200'
                             }`}
                             onClick={handlePrintActiveFile}
                             title="Print file"
                           >
-                            <Printer size={18} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
+                            <Printer size={16} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
                           </button>
                           <button
                             type="button"
-                            className={`h-9 w-9 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
+                            className={`h-8 w-8 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
                               isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-gray-200'
                             }`}
                             onClick={handleDownloadActiveFile}
                             title="Download file"
                           >
-                            <Download size={18} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
+                            <Download size={16} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
                           </button>
                         </>
                       )}
                       {isPdfFile && (
                         <button
                           type="button"
-                          className={`h-9 px-3 inline-flex items-center justify-center gap-2 rounded-lg text-sm font-medium disabled:opacity-50 ${
+                          className={`h-8 px-3 inline-flex items-center justify-center gap-2 rounded-lg text-xs font-medium disabled:opacity-50 ${
                             isDarkMode ? 'text-slate-200 hover:bg-slate-800' : 'text-slate-700 hover:bg-gray-200'
                           }`}
                           onClick={handleExportPptxFromPdf}
                           disabled={!activeFile || isPptxExporting}
                           title="Export PPTX from PDF"
                         >
-                          {isPptxExporting ? <Loader2 size={14} className="animate-spin" /> : null}
+                          {isPptxExporting ? <Loader2 size={13} className="animate-spin" /> : null}
                           {isPptxExporting ? 'Exporting PPTX' : 'Export PPTX'}
                         </button>
                       )}
                       {!shouldForceEditMode(selectedFile?.name || '') && (
                         <button
-                          className={`h-9 w-9 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
+                          className={`h-8 w-8 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
                             isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-gray-200'
                           }`}
                           onClick={() => {
@@ -5733,11 +5733,11 @@ export default function WorkspacePage() {
                           }}
                           disabled={!selectedFile || !isFileEditable(selectedFile.name)}
                         >
-                          <Edit size={18} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
+                          <Edit size={16} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
                         </button>
                       )}
                       <button
-                        className={`h-9 px-3 inline-flex items-center justify-center rounded-lg text-sm font-medium disabled:opacity-50 ${
+                        className={`h-8 px-3 inline-flex items-center justify-center rounded-lg text-xs font-medium disabled:opacity-50 ${
                           isDarkMode ? 'text-slate-200 hover:bg-slate-800' : 'text-slate-700 hover:bg-gray-200'
                         }`}
                         onClick={() => selectedFile && handleUpdateFile(selectedFile, fileContent)}
@@ -5749,18 +5749,18 @@ export default function WorkspacePage() {
                         <>
                           <button
                             type="button"
-                            className={`h-9 w-9 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
+                            className={`h-8 w-8 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
                               isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-gray-200'
                             }`}
                             onClick={handleCanvasZoomOut}
                             disabled={!canZoomOutCanvas}
                             title="Zoom out canvas"
                           >
-                            <Minus size={18} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
+                            <Minus size={16} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
                           </button>
                           <button
                             type="button"
-                            className={`h-9 px-2 inline-flex items-center justify-center rounded-lg text-xs font-semibold ${
+                            className={`h-8 px-2 inline-flex items-center justify-center rounded-lg text-[11px] font-semibold ${
                               isDarkMode ? 'text-slate-300 hover:bg-slate-800' : 'text-slate-700 hover:bg-gray-200'
                             }`}
                             onClick={handleCanvasZoomReset}
@@ -5770,14 +5770,14 @@ export default function WorkspacePage() {
                           </button>
                           <button
                             type="button"
-                            className={`h-9 w-9 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
+                            className={`h-8 w-8 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
                               isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-gray-200'
                             }`}
                             onClick={handleCanvasZoomIn}
                             disabled={!canZoomInCanvas}
                             title="Zoom in canvas"
                           >
-                            <Plus size={18} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
+                            <Plus size={16} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
                           </button>
                         </>
                       )}


### PR DESCRIPTION
## Summary
- tighten the workspace shell so the default 100% zoom feels closer to the previous 80% comfort level
- reduce header, toolbar, file tree, and chat chrome spacing instead of shrinking rendered document content
- slightly narrow the file pane, chat pane, and history panel for a denser default layout

## Testing
- npm run build