### PR TITLE
Add artifact-first document understanding and file grounding

### DIFF
--- a/agent/helpudoc_agent/app.py
+++ b/agent/helpudoc_agent/app.py
@@ -3,13 +3,19 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any, Dict, List, AsyncGenerator, Iterable, Sequence, Set, Optional, Tuple
+import base64
 import html as html_lib
+import importlib
 import json
 import logging
 import os
 import fnmatch
 import mimetypes
 import re
+import shutil
+import sys
+import tempfile
+from io import BytesIO
 from pathlib import Path
 from uuid import uuid4
 from dotenv import load_dotenv
@@ -17,8 +23,9 @@ from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Body, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
+from google.genai import types as genai_types
 
-from .configuration import load_settings
+from .configuration import describe_workspace_root, load_settings
 from .graph import AgentRegistry
 from .state import AgentRuntimeState
 from .tools_and_schemas import ToolFactory, GeminiClientManager
@@ -44,6 +51,7 @@ from .paper2slides_runner import run_paper2slides, export_pptx_from_pdf
 from .jwt_utils import decode_and_verify_hs256_jwt
 from langgraph.errors import GraphInterrupt
 from langgraph.types import Command
+from paper2slides.raganything.parser import DoclingParser
 
 
 logger = logging.getLogger(__name__)
@@ -100,6 +108,15 @@ def _normalize_tagged_file_paths(tagged_paths: Sequence[str]) -> List[str]:
     return sorted(set(normalized))
 
 
+def _allow_basename_match_for_path(path_value: str) -> bool:
+    normalized = str(path_value or "").strip().replace("\\", "/").lstrip("/")
+    if not normalized:
+        return False
+    if normalized.startswith(".system/"):
+        return False
+    return "/" not in normalized
+
+
 def _build_tagged_rag_keywords(prompt: str, tagged_paths: Sequence[str]) -> List[str]:
     keywords: List[str] = []
     if isinstance(prompt, str) and prompt.strip():
@@ -122,7 +139,7 @@ def _filter_rag_chunks_to_tagged_paths(chunks: Sequence[Dict[str, Any]], tagged_
     normalized = _normalize_tagged_file_paths(tagged_paths)
     if not normalized:
         return list(chunks)
-    basenames = {Path(item).name for item in normalized}
+    basenames = {Path(item).name for item in normalized if _allow_basename_match_for_path(item)}
     filtered: List[Dict[str, Any]] = []
     for chunk in chunks:
         file_path = str(chunk.get("file_path") or "").strip().replace("\\", "/")
@@ -222,10 +239,55 @@ def _append_tagged_file_guidance(prompt: str, tagged_paths: Sequence[str]) -> st
     return f"{prompt.rstrip()}\n\n{guidance}"
 
 
+def _append_artifact_first_guidance(
+    prompt: str,
+    file_context_refs: Sequence[Dict[str, Any]],
+    tagged_paths: Sequence[str],
+    *,
+    multimodal_active: bool,
+) -> str:
+    if not prompt:
+        return prompt
+    if "Artifact-first guidance:" in prompt:
+        return prompt
+    if not file_context_refs:
+        return prompt
+    ready_refs = [
+        item
+        for item in file_context_refs
+        if str(item.get("status") or "").strip().lower() in {"ready", "partial"}
+    ]
+    if not ready_refs:
+        return prompt
+    binary_ready = [
+        item
+        for item in ready_refs
+        if not str(item.get("sourceMimeType") or "").strip().lower().startswith("text/")
+    ]
+    if not binary_ready:
+        return prompt
+    guidance_lines = [
+        "Artifact-first guidance:",
+        "- Ready derived artifacts are available for the attached files and are the primary source of truth for this turn.",
+        "- Prefer the tagged derived artifact paths over the original source file when answering.",
+        "- Do not call read_file on the original binary source (.docx, .pptx, .pdf, etc.) if a ready derived artifact is already available.",
+    ]
+    if multimodal_active:
+        guidance_lines.append("- Use the current-turn multimodal attachment only for additional grounding; keep follow-up reasoning anchored to the derived artifact.")
+    else:
+        guidance_lines.append("- If you need to inspect content, read the derived artifact markdown first rather than the original binary file.")
+    if tagged_paths:
+        guidance_lines.append("- Tagged derived artifacts:")
+        guidance_lines.extend(f"  - {path}" for path in tagged_paths)
+    return f"{prompt.rstrip()}\n\n" + "\n".join(guidance_lines)
+
+
 class ChatRequest(BaseModel):
     message: str
     history: List[Dict[str, Any]] | None = None
     forceReset: bool = False
+    fileContextRefs: List[Dict[str, Any]] | None = None
+    messageContent: List[Dict[str, Any]] | None = None
 
 
 class ChatResponse(BaseModel):
@@ -263,6 +325,37 @@ class InterruptAction(BaseModel):
 
 class InterruptActionRequest(BaseModel):
     action: InterruptAction
+
+
+class AttachmentUnderstandingRequest(BaseModel):
+    fileName: str
+    mimeType: str
+    contentB64: str
+
+
+class AttachmentUnderstandingSection(BaseModel):
+    heading: str
+    body: str
+
+
+class AttachmentUnderstandingAsset(BaseModel):
+    name: str
+    mimeType: str
+    contentB64: str
+    sourcePath: Optional[str] = None
+    caption: Optional[str] = None
+    footnote: Optional[str] = None
+
+
+class AttachmentUnderstandingResponse(BaseModel):
+    title: str
+    summary: str
+    outline: List[str] = Field(default_factory=list)
+    markdown: str
+    sections: List[AttachmentUnderstandingSection] = Field(default_factory=list)
+    extractedAssets: List[AttachmentUnderstandingAsset] = Field(default_factory=list)
+    effectiveMode: str = "part"
+    status: str = "ready"
 
 
 class RagQueryRequest(BaseModel):
@@ -323,6 +416,359 @@ class Paper2SlidesExportRequest(BaseModel):
 
 class Paper2SlidesExportResponse(BaseModel):
     pptxB64: str
+
+
+def _extract_json_block(text: str) -> str:
+    fenced = re.search(r"```json\s*(.*?)```", text or "", flags=re.IGNORECASE | re.DOTALL)
+    if fenced:
+        return fenced.group(1).strip()
+    return (text or "").strip()
+
+
+def _response_text(response: Any) -> str:
+    text = getattr(response, "text", None)
+    if isinstance(text, str) and text.strip():
+        return text.strip()
+    parts: List[str] = []
+    for candidate in getattr(response, "candidates", []) or []:
+        content = getattr(candidate, "content", None)
+        if not content:
+            continue
+        for part in getattr(content, "parts", []) or []:
+            value = getattr(part, "text", None)
+            if isinstance(value, str) and value.strip():
+                parts.append(value.strip())
+    return "\n".join(parts).strip()
+
+
+def _split_sections_from_markdown(markdown: str) -> List[Dict[str, str]]:
+    sections: List[Dict[str, str]] = []
+    heading = "Overview"
+    body_lines: List[str] = []
+    for line in (markdown or "").splitlines():
+        match = re.match(r"^#{1,6}\s+(.*)$", line.strip())
+        if match:
+            if body_lines:
+                sections.append({"heading": heading, "body": "\n".join(body_lines).strip()})
+            heading = match.group(1).strip() or "Section"
+            body_lines = []
+            continue
+        body_lines.append(line)
+    if body_lines:
+        sections.append({"heading": heading, "body": "\n".join(body_lines).strip()})
+    return [section for section in sections if section.get("body")]
+
+
+def _markdown_from_attachment_payload(payload: Dict[str, Any]) -> str:
+    title = str(payload.get("title") or "Attachment").strip() or "Attachment"
+    summary = str(payload.get("summary") or "").strip()
+    outline = [str(item).strip() for item in (payload.get("outline") or []) if str(item).strip()]
+    raw_sections = payload.get("sections") or []
+    lines: List[str] = [f"# {title}", ""]
+    if summary:
+        lines.extend(["## Summary", "", summary, ""])
+    if outline:
+        lines.extend(["## Outline", ""])
+        lines.extend(f"- {item}" for item in outline)
+        lines.append("")
+    sections_added = False
+    if isinstance(raw_sections, list):
+        for item in raw_sections:
+            if not isinstance(item, dict):
+                continue
+            heading = str(item.get("heading") or "").strip() or "Section"
+            body = str(item.get("body") or "").strip()
+            if not body:
+                continue
+            lines.extend([f"## {heading}", "", body, ""])
+            sections_added = True
+    normalized_body = str(payload.get("normalizedBody") or "").strip()
+    if normalized_body and not sections_added:
+        lines.extend(["## Details", "", normalized_body, ""])
+    return "\n".join(lines).strip()
+
+
+def _build_partial_attachment_payload(file_name: str, text: str, *, effective_mode: str) -> Dict[str, Any]:
+    cleaned_lines = [line.strip() for line in (text or "").splitlines() if line.strip()]
+    summary = cleaned_lines[0] if cleaned_lines else f"Extracted content from {file_name}"
+    excerpt = "\n".join(cleaned_lines[:80]).strip() or f"Unable to extract detailed content from {file_name}."
+    sections = [{"heading": "Source Excerpt", "body": excerpt}]
+    payload = {
+        "title": file_name,
+        "summary": summary,
+        "outline": ["Source Excerpt"],
+        "sections": sections,
+        "effectiveMode": effective_mode,
+        "status": "partial",
+    }
+    payload["markdown"] = _markdown_from_attachment_payload(payload)
+    return payload
+
+
+def _docling_available() -> bool:
+    try:
+        __import__("docling")
+    except Exception:
+        return False
+    cli_path = shutil.which("docling")
+    if cli_path:
+        return True
+    venv_candidates = [
+        Path(sys.executable).parent / "docling",
+        Path(sys.prefix) / "bin" / "docling",
+    ]
+    return any(candidate.exists() for candidate in venv_candidates)
+
+
+def _docling_markdown_to_payload(file_name: str, markdown: str, *, effective_mode: str = "parser") -> Dict[str, Any]:
+    cleaned_markdown = (markdown or "").strip()
+    sections = _split_sections_from_markdown(cleaned_markdown)
+    title = file_name
+    title_match = re.search(r"^#\s+(.+)$", cleaned_markdown, flags=re.MULTILINE)
+    if title_match and title_match.group(1).strip():
+        title = title_match.group(1).strip()
+    summary = ""
+    for section in sections:
+        body = str(section.get("body") or "").strip()
+        if body:
+            summary = body.splitlines()[0].strip()
+            if summary:
+                break
+    outline = [str(section.get("heading") or "").strip() for section in sections if str(section.get("heading") or "").strip()]
+    payload = {
+        "title": title,
+        "summary": summary or f"Parsed content from {file_name}",
+        "outline": outline,
+        "sections": sections,
+        "normalizedBody": cleaned_markdown,
+        "effectiveMode": effective_mode,
+        "status": "ready",
+    }
+    payload["markdown"] = cleaned_markdown or _markdown_from_attachment_payload(payload)
+    return payload
+
+
+def _extract_docling_payload(file_name: str, mime_type: str, buffer: bytes) -> Tuple[str, List[Dict[str, Any]]]:
+    suffix = Path(file_name).suffix.lower()
+    guessed_suffix = mimetypes.guess_extension(mime_type or "") or ""
+    if not suffix and guessed_suffix:
+        suffix = guessed_suffix.lower()
+    if not suffix:
+        suffix = ".bin"
+    with tempfile.TemporaryDirectory(prefix="helpudoc-docling-") as temp_dir:
+        temp_root = Path(temp_dir)
+        temp_input = temp_root / f"source{suffix}"
+        temp_input.write_bytes(buffer)
+        output_dir = temp_root / "parsed"
+        parser = DoclingParser()
+        content_list = parser.parse_document(temp_input, output_dir=str(output_dir))
+        stem = temp_input.stem
+        docling_dir = output_dir / stem / "docling"
+        md_path = docling_dir / f"{stem}.md"
+        if not md_path.exists():
+            raise RuntimeError(f"Docling did not produce markdown for {file_name}")
+        markdown = md_path.read_text(encoding="utf-8", errors="replace").strip()
+        if not markdown:
+            raise RuntimeError(f"Docling produced empty markdown for {file_name}")
+        extracted_assets: List[Dict[str, Any]] = []
+        seen_paths: set[str] = set()
+        for item in content_list:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("type") or "").strip().lower() != "image":
+                continue
+            img_path_raw = str(item.get("img_path") or "").strip()
+            if not img_path_raw or img_path_raw in seen_paths:
+                continue
+            seen_paths.add(img_path_raw)
+            img_path = Path(img_path_raw)
+            if not img_path.exists():
+                continue
+            mime = mimetypes.guess_type(img_path.name)[0] or "image/png"
+            try:
+                source_path = str(img_path.relative_to(docling_dir)).replace("\\", "/")
+            except Exception:
+                source_path = img_path.name
+            extracted_assets.append(
+                {
+                    "name": img_path.name,
+                    "mimeType": mime,
+                    "contentB64": base64.b64encode(img_path.read_bytes()).decode("ascii"),
+                    "sourcePath": source_path,
+                    "caption": str(item.get("image_caption") or "").strip() or None,
+                    "footnote": str(item.get("image_footnote") or "").strip() or None,
+                }
+            )
+        return markdown, extracted_assets
+
+
+def _extract_text_from_docx(buffer: bytes) -> str:
+    from docx import Document  # type: ignore
+
+    document = Document(BytesIO(buffer))
+    chunks: List[str] = []
+    for paragraph in document.paragraphs:
+        text = (paragraph.text or "").strip()
+        if text:
+            chunks.append(text)
+    for table in document.tables:
+        for row in table.rows:
+            cells = [cell.text.strip() for cell in row.cells if cell.text and cell.text.strip()]
+            if cells:
+                chunks.append(" | ".join(cells))
+    return "\n".join(chunks).strip()
+
+
+def _extract_text_from_pptx(buffer: bytes) -> str:
+    from pptx import Presentation  # type: ignore
+
+    presentation = Presentation(BytesIO(buffer))
+    chunks: List[str] = []
+    for index, slide in enumerate(presentation.slides, start=1):
+        slide_lines: List[str] = [f"Slide {index}"]
+        for shape in slide.shapes:
+            text = getattr(shape, "text", None)
+            if isinstance(text, str) and text.strip():
+                slide_lines.append(text.strip())
+        if getattr(slide, "has_notes_slide", False):
+            try:
+                notes_text = slide.notes_slide.notes_text_frame.text
+            except Exception:
+                notes_text = ""
+            if notes_text and notes_text.strip():
+                slide_lines.append(f"Notes: {notes_text.strip()}")
+        chunks.append("\n".join(slide_lines))
+    return "\n\n".join(chunks).strip()
+
+
+def _extract_text_from_pdf(buffer: bytes) -> str:
+    from pypdf import PdfReader  # type: ignore
+
+    reader = PdfReader(BytesIO(buffer))
+    chunks: List[str] = []
+    for index, page in enumerate(reader.pages, start=1):
+        text = (page.extract_text() or "").strip()
+        if text:
+            chunks.append(f"Page {index}\n{text}")
+    return "\n\n".join(chunks).strip()
+
+
+def _guess_attachment_strategy(file_name: str, mime_type: str) -> Tuple[str, str]:
+    suffix = Path(file_name).suffix.lower()
+    normalized_mime = (mime_type or "").lower()
+    if normalized_mime.startswith("image/") or suffix in {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}:
+        return "image", "part"
+    if suffix == ".docx" or "wordprocessingml" in normalized_mime:
+        return "docx", "parser"
+    if suffix == ".pptx" or "presentationml" in normalized_mime:
+        return "pptx", "parser"
+    if suffix == ".pdf" or normalized_mime == "application/pdf":
+        return "pdf", "parser"
+    return "text", "part"
+
+
+def _attachment_understanding_prompt(file_name: str, extracted_text: str | None, kind: str) -> str:
+    base = (
+        "Return strict JSON only with keys: "
+        "title, summary, outline, sections, normalizedBody, effectiveMode, status. "
+        "sections must be an array of objects with heading and body. "
+        "effectiveMode must be one of part, parser, hybrid. "
+        "status must be ready or partial. "
+        "Preserve the document structure and factual detail instead of over-summarizing. "
+        f"File name: {file_name}. "
+        f"Kind: {kind}."
+    )
+    if extracted_text is None:
+        return (
+            f"{base} Understand the attached file directly. "
+            "If details are uncertain, say so briefly in the summary instead of inventing content."
+        )
+    excerpt = extracted_text[:30000]
+    return f"{base}\n\nSource content:\n{excerpt}"
+
+
+def _parse_attachment_payload(raw_text: str, file_name: str, *, fallback_text: str, fallback_mode: str) -> Dict[str, Any]:
+    try:
+        parsed = json.loads(_extract_json_block(raw_text))
+    except Exception:
+        return _build_partial_attachment_payload(file_name, fallback_text, effective_mode=fallback_mode)
+    if not isinstance(parsed, dict):
+        return _build_partial_attachment_payload(file_name, fallback_text, effective_mode=fallback_mode)
+    payload = {
+        "title": str(parsed.get("title") or file_name).strip() or file_name,
+        "summary": str(parsed.get("summary") or "").strip(),
+        "outline": [str(item).strip() for item in (parsed.get("outline") or []) if str(item).strip()],
+        "sections": [
+            {
+                "heading": str(item.get("heading") or "").strip() or "Section",
+                "body": str(item.get("body") or "").strip(),
+            }
+            for item in (parsed.get("sections") or [])
+            if isinstance(item, dict) and str(item.get("body") or "").strip()
+        ],
+        "normalizedBody": str(parsed.get("normalizedBody") or "").strip(),
+        "effectiveMode": str(parsed.get("effectiveMode") or fallback_mode).strip() or fallback_mode,
+        "status": "partial" if str(parsed.get("status") or "").strip().lower() == "partial" else "ready",
+    }
+    payload["markdown"] = _markdown_from_attachment_payload(payload)
+    return payload
+
+
+def _copy_content_block(block: Any) -> Any:
+    if isinstance(block, dict):
+        return dict(block)
+    return block
+
+
+def _extract_text_from_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: List[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+                continue
+            if isinstance(item, dict):
+                if isinstance(item.get("text"), str):
+                    parts.append(item["text"])
+                    continue
+                if item.get("type") == "text-plain" and isinstance(item.get("text"), str):
+                    parts.append(item["text"])
+                    continue
+                if "content" in item and isinstance(item.get("content"), str):
+                    parts.append(item["content"])
+        return "\n".join(part for part in parts if part).strip()
+    return str(content or "").strip()
+
+
+def _replace_content_text(content: Any, text: str) -> Any:
+    if isinstance(content, str):
+        return text
+    if isinstance(content, list):
+        updated: List[Any] = []
+        replaced = False
+        for item in content:
+            if isinstance(item, dict):
+                copied = dict(item)
+                block_type = str(copied.get("type") or "").strip().lower()
+                if block_type in {"text", "text-plain"} or isinstance(copied.get("text"), str):
+                    copied["text"] = text
+                    updated.append(copied)
+                    replaced = True
+                    continue
+                if isinstance(copied.get("content"), str):
+                    copied["content"] = text
+                    updated.append(copied)
+                    replaced = True
+                    continue
+                updated.append(copied)
+                continue
+            updated.append(item)
+        if replaced:
+            return updated
+        return [{"type": "text", "text": text}, *updated]
+    return text
 
 
 class EmbeddedDirective(BaseModel):
@@ -412,13 +858,62 @@ def create_app() -> FastAPI:
     config_path: Optional[Path] = None
     env_config_path = os.getenv("AGENT_CONFIG_PATH")
     if env_config_path:
-        candidate = Path(env_config_path)
+        candidate = Path(env_config_path).expanduser()
+        if not candidate.is_absolute():
+            candidate = (BASE_DIR.parent.parent / candidate).resolve()
         if candidate.exists():
             config_path = candidate
         else:
             logger.warning("AGENT_CONFIG_PATH is set but file does not exist; falling back to built-in config", extra={"path": env_config_path})
 
     settings = load_settings(config_path)
+    workspace_root_diagnostic = describe_workspace_root(settings)
+    workspace_root_message = (
+        f"[agent] Workspace root: {workspace_root_diagnostic['resolved_path']} "
+        f"(source={workspace_root_diagnostic['source']} "
+        f"raw={workspace_root_diagnostic['raw_value'] or '<config>'})"
+    )
+    print(workspace_root_message)
+    logger.info(workspace_root_message)
+    file_understanding_mode = (os.getenv("FILE_UNDERSTANDING_MODE", "part-first") or "part-first").strip()
+    rag_parser_pipeline = (os.getenv("RAG_PARSER_PIPELINE", "raganything") or "raganything").strip().lower()
+    raganything_parser = (os.getenv("RAGANYTHING_PARSER", "docling") or "docling").strip().lower()
+    parser_enrichment_mode = (
+        os.getenv("PARSER_ENRICHMENT_MODE")
+        or os.getenv("PARSER")
+        or raganything_parser
+    ).strip() or raganything_parser
+    dependency_diag = {
+        "lightrag": True,
+        "raganything": True,
+        "docling": _docling_available(),
+    }
+    try:
+        importlib.import_module("lightrag")
+    except Exception:
+        dependency_diag["lightrag"] = False
+    try:
+        importlib.import_module("raganything")
+    except Exception:
+        try:
+            importlib.import_module("paper2slides.raganything")
+        except Exception:
+            dependency_diag["raganything"] = False
+    if rag_parser_pipeline in {"raganything", "rag_anything", "rag-everything", "rageverything"} and raganything_parser == "docling":
+        if not dependency_diag["docling"]:
+            raise RuntimeError(
+                "Docling is configured as the global parser, but the docling package/CLI is unavailable. "
+                "Install docling and ensure the `docling` command is on PATH."
+            )
+    logger.info(
+        "[agent] File understanding: mode=%s parserPipeline=%s ragParser=%s parserEnrichment=%s deps=%s python=%s",
+        file_understanding_mode,
+        rag_parser_pipeline,
+        raganything_parser,
+        parser_enrichment_mode,
+        dependency_diag,
+        sys.executable,
+    )
     source_tracker = SourceTracker()
     gemini_manager = GeminiClientManager(settings)
     tool_factory = ToolFactory(settings, source_tracker, gemini_manager)
@@ -505,6 +1000,143 @@ def create_app() -> FastAPI:
         except Exception as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
+    @app.post("/attachments/understand", response_model=AttachmentUnderstandingResponse)
+    async def understand_attachment(req: AttachmentUnderstandingRequest = Body(...)):
+        if not req.fileName.strip():
+            raise HTTPException(status_code=400, detail="fileName is required")
+        if not req.contentB64.strip():
+            raise HTTPException(status_code=400, detail="contentB64 is required")
+        try:
+            buffer = base64.b64decode(req.contentB64)
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail="contentB64 must be valid base64") from exc
+
+        kind, fallback_mode = _guess_attachment_strategy(req.fileName, req.mimeType)
+        extracted_text: str | None = None
+        try:
+            contents: List[Any]
+            if kind in {"docx", "pptx", "pdf"}:
+                try:
+                    markdown, extracted_assets = await asyncio.to_thread(
+                        _extract_docling_payload,
+                        req.fileName,
+                        req.mimeType,
+                        buffer,
+                    )
+                    payload = _docling_markdown_to_payload(req.fileName, markdown, effective_mode="parser")
+                    return AttachmentUnderstandingResponse(
+                        title=str(payload.get("title") or req.fileName),
+                        summary=str(payload.get("summary") or ""),
+                        outline=[str(item) for item in (payload.get("outline") or [])],
+                        markdown=str(payload.get("markdown") or ""),
+                        sections=[
+                            AttachmentUnderstandingSection(
+                                heading=str(item.get("heading") or "Section"),
+                                body=str(item.get("body") or ""),
+                            )
+                            for item in (payload.get("sections") or [])
+                            if isinstance(item, dict) and str(item.get("body") or "").strip()
+                        ],
+                        extractedAssets=[
+                            AttachmentUnderstandingAsset(
+                                name=str(item.get("name") or "image.png"),
+                                mimeType=str(item.get("mimeType") or "image/png"),
+                                contentB64=str(item.get("contentB64") or ""),
+                                sourcePath=str(item.get("sourcePath") or "") or None,
+                                caption=str(item.get("caption") or "") or None,
+                                footnote=str(item.get("footnote") or "") or None,
+                            )
+                            for item in extracted_assets
+                            if str(item.get("contentB64") or "").strip()
+                        ],
+                        effectiveMode="parser",
+                        status="ready",
+                    )
+                except Exception:
+                    logger.exception("Docling extraction failed for %s; falling back to legacy extraction", req.fileName)
+                    if kind == "docx":
+                        extracted_text = _extract_text_from_docx(buffer)
+                    elif kind == "pptx":
+                        extracted_text = _extract_text_from_pptx(buffer)
+                    else:
+                        extracted_text = _extract_text_from_pdf(buffer)
+                    contents = [_attachment_understanding_prompt(req.fileName, extracted_text, kind)]
+            elif kind == "image":
+                contents = [
+                    genai_types.Part.from_bytes(data=buffer, mime_type=req.mimeType),
+                    _attachment_understanding_prompt(req.fileName, None, kind),
+                ]
+            else:
+                try:
+                    extracted_text = buffer.decode("utf-8", errors="replace")
+                except Exception:
+                    extracted_text = ""
+                contents = [_attachment_understanding_prompt(req.fileName, extracted_text, kind)]
+
+            fallback_text = extracted_text or f"Unable to extract textual content from {req.fileName}."
+            raw_response_text = ""
+            for attempt in range(2):
+                response = gemini_manager.client.models.generate_content(
+                    model=gemini_manager.model_name,
+                    contents=contents,
+                    config=genai_types.GenerateContentConfig(
+                        candidate_count=1,
+                        temperature=0.1,
+                    ),
+                )
+                raw_response_text = _response_text(response)
+                payload = _parse_attachment_payload(
+                    raw_response_text,
+                    req.fileName,
+                    fallback_text=fallback_text,
+                    fallback_mode=fallback_mode,
+                )
+                if payload.get("status") != "partial" or attempt == 1:
+                    return AttachmentUnderstandingResponse(
+                        title=str(payload.get("title") or req.fileName),
+                        summary=str(payload.get("summary") or ""),
+                        outline=[str(item) for item in (payload.get("outline") or [])],
+                        markdown=str(payload.get("markdown") or ""),
+                        sections=[
+                            AttachmentUnderstandingSection(
+                                heading=str(item.get("heading") or "Section"),
+                                body=str(item.get("body") or ""),
+                            )
+                            for item in (payload.get("sections") or [])
+                            if isinstance(item, dict) and str(item.get("body") or "").strip()
+                        ],
+                        effectiveMode=str(payload.get("effectiveMode") or fallback_mode),
+                        status=str(payload.get("status") or "partial"),
+                    )
+                contents = [
+                    "Repair the previous response into strict JSON only using the required schema.",
+                    raw_response_text,
+                ]
+        except Exception:
+            logger.exception("Attachment understanding failed for %s", req.fileName)
+
+        partial = _build_partial_attachment_payload(
+            req.fileName,
+            extracted_text or f"Unable to understand {req.fileName}.",
+            effective_mode=fallback_mode,
+        )
+        return AttachmentUnderstandingResponse(
+            title=str(partial.get("title") or req.fileName),
+            summary=str(partial.get("summary") or ""),
+            outline=[str(item) for item in (partial.get("outline") or [])],
+            markdown=str(partial.get("markdown") or ""),
+            sections=[
+                AttachmentUnderstandingSection(
+                    heading=str(item.get("heading") or "Section"),
+                    body=str(item.get("body") or ""),
+                )
+                for item in (partial.get("sections") or [])
+                if isinstance(item, dict) and str(item.get("body") or "").strip()
+            ],
+            effectiveMode=str(partial.get("effectiveMode") or fallback_mode),
+            status="partial",
+        )
+
     @app.get("/agents")
     def list_agents():
         skills = load_skills(settings.backend.skills_root) if settings.backend.skills_root else []
@@ -545,13 +1177,23 @@ def create_app() -> FastAPI:
         }
 
     def _prepare_payload(message: ChatRequest) -> List[Dict[str, Any]]:
+        payload: List[Dict[str, Any]] = []
         if message.history:
-            payload: List[Dict[str, Any]] = []
             for item in message.history:
                 if isinstance(item, dict):
                     payload.append(dict(item))
                 else:
                     payload.append({"role": "user", "content": str(item)})
+        if message.messageContent:
+            copied_blocks = [_copy_content_block(block) for block in message.messageContent]
+            for index in range(len(payload) - 1, -1, -1):
+                role = str(payload[index].get("role") or "").strip().lower()
+                if role in {"user", "human"}:
+                    payload[index]["content"] = copied_blocks
+                    return payload
+            payload.append({"role": "user", "content": copied_blocks})
+            return payload
+        if payload:
             return payload
         return [{"role": "user", "content": message.message}]
 
@@ -656,21 +1298,28 @@ def create_app() -> FastAPI:
             if role not in {"user", "human"}:
                 continue
             content = message.get("content")
-            if not isinstance(content, str):
+            latest_text = _extract_text_from_content(content)
+            if not latest_text:
                 break
-            directive, stripped_text = _extract_directive_from_text(content)
+            directive, stripped_text = _extract_directive_from_text(latest_text)
             latest_user_text = stripped_text
             if directive is None:
-                message["content"] = stripped_text
+                message["content"] = _replace_content_text(content, stripped_text)
                 break
             if directive.kind == "skill" and directive.skillId:
                 runtime.workspace_state.context.pop("preferred_mcp_server", None)
-                message["content"] = _build_preloaded_skill_prompt(runtime, directive.skillId, stripped_text)
+                message["content"] = _replace_content_text(
+                    content,
+                    _build_preloaded_skill_prompt(runtime, directive.skillId, stripped_text),
+                )
             elif directive.kind == "mcp" and directive.serverId:
                 runtime.workspace_state.context["preferred_mcp_server"] = directive.serverId
-                message["content"] = _build_preferred_mcp_prompt(directive.serverId, stripped_text)
+                message["content"] = _replace_content_text(
+                    content,
+                    _build_preferred_mcp_prompt(directive.serverId, stripped_text),
+                )
             else:
-                message["content"] = stripped_text
+                message["content"] = _replace_content_text(content, stripped_text)
             break
         return payload, latest_user_text
 
@@ -740,9 +1389,7 @@ def create_app() -> FastAPI:
             if role not in {"user", "human"}:
                 continue
             content = item.get("content")
-            if not isinstance(content, str):
-                break
-            directive, _ = _extract_directive_from_text(content)
+            directive, _ = _extract_directive_from_text(_extract_text_from_content(content))
             if directive is None:
                 break
             if directive.kind == "skill" and directive.skillId:
@@ -780,6 +1427,36 @@ def create_app() -> FastAPI:
                     break
         return tagged
 
+    def _normalize_file_context_refs(raw_refs: Any) -> List[Dict[str, Any]]:
+        normalized: List[Dict[str, Any]] = []
+        if not isinstance(raw_refs, list):
+            return normalized
+        for item in raw_refs:
+            if not isinstance(item, dict):
+                continue
+            source_name = str(item.get("sourceName") or "").strip()
+            fingerprint = str(item.get("sourceVersionFingerprint") or "").strip()
+            artifact_id = str(item.get("artifactId") or "").strip()
+            if not source_name or not fingerprint or not artifact_id:
+                continue
+            normalized.append(
+                {
+                    "sourceFileId": item.get("sourceFileId"),
+                    "sourceName": source_name,
+                    "sourceMimeType": str(item.get("sourceMimeType") or "").strip() or None,
+                    "sourceVersionFingerprint": fingerprint,
+                    "artifactId": artifact_id,
+                    "artifactVersion": item.get("artifactVersion"),
+                    "derivedArtifactFileId": item.get("derivedArtifactFileId"),
+                    "derivedArtifactPath": str(item.get("derivedArtifactPath") or "").strip() or None,
+                    "effectiveMode": str(item.get("effectiveMode") or "part").strip() or "part",
+                    "status": str(item.get("status") or "failed").strip() or "failed",
+                    "summary": str(item.get("summary") or "").strip() or None,
+                    "lastError": str(item.get("lastError") or "").strip() or None,
+                }
+            )
+        return normalized
+
     def _load_mineru_text(workspace_id: str, tagged_paths: List[str]) -> str | None:
         output_root = rag_worker.store.config.raganything_output_dir
         for raw in tagged_paths:
@@ -789,16 +1466,20 @@ def create_app() -> FastAPI:
             base = name
             if base.lower().endswith(".pdf"):
                 base = base[:-4]
-            md_path = output_root / workspace_id / base / "auto" / f"{base}.md"
-            if not md_path.exists():
-                continue
-            try:
-                text = md_path.read_text(encoding="utf-8", errors="replace").strip()
-            except Exception:
-                logger.exception("Failed reading MinerU markdown: %s", md_path)
-                continue
-            if text:
-                return text
+            candidates = [
+                output_root / workspace_id / base / "docling" / f"{base}.md",
+                output_root / workspace_id / base / "auto" / f"{base}.md",
+            ]
+            for md_path in candidates:
+                if not md_path.exists():
+                    continue
+                try:
+                    text = md_path.read_text(encoding="utf-8", errors="replace").strip()
+                except Exception:
+                    logger.exception("Failed reading parser markdown: %s", md_path)
+                    continue
+                if text:
+                    return text
         return None
 
     def _load_tagged_html_outline(workspace_id: str, tagged_paths: List[str]) -> str | None:
@@ -819,11 +1500,15 @@ def create_app() -> FastAPI:
                 return outline
         return None
 
-    async def _prefetch_rag_context(workspace_id: str, prompt: str) -> str | None:
+    async def _prefetch_rag_context(
+        workspace_id: str,
+        prompt: str,
+        tagged_paths_override: Sequence[str] | None = None,
+    ) -> str | None:
         # Use extraction rather than relying on an exact marker string so backend text can evolve.
-        if not prompt:
+        if not prompt and not tagged_paths_override:
             return None
-        tagged_paths = _extract_tagged_files(prompt)
+        tagged_paths = list(tagged_paths_override or _extract_tagged_files(prompt))
         rag_tagged_paths = _filter_rag_prefetchable_tagged_files(tagged_paths)
         if not rag_tagged_paths:
             return None
@@ -1364,27 +2049,69 @@ def create_app() -> FastAPI:
             _reset_turn_context(runtime)
         payload, latest_user_text = _apply_embedded_directives(runtime, payload)
 
-        prompt_for_tagged_files = latest_user_text or message.message or ""
-        tagged_files = _extract_tagged_files(prompt_for_tagged_files)
+        prompt_for_tagged_files = latest_user_text
+        if not prompt_for_tagged_files:
+            for index in range(len(payload) - 1, -1, -1):
+                role = str(payload[index].get("role") or "").strip().lower()
+                if role in {"user", "human"}:
+                    prompt_for_tagged_files = _extract_text_from_content(payload[index].get("content"))
+                    break
+        if not prompt_for_tagged_files:
+            prompt_for_tagged_files = message.message or ""
+        message_file_context_refs = _normalize_file_context_refs(message.fileContextRefs)
+        if message_file_context_refs:
+            runtime.workspace_state.context["file_context_refs"] = message_file_context_refs
+        active_file_context_refs = _normalize_file_context_refs(runtime.workspace_state.context.get("file_context_refs"))
+        explicit_artifact_paths = [
+            str(item.get("derivedArtifactPath") or "").strip()
+            for item in active_file_context_refs
+            if str(item.get("status") or "").strip().lower() in {"ready", "partial"}
+            and str(item.get("derivedArtifactPath") or "").strip()
+        ]
+        pending_files = [
+            str(item.get("sourceName") or "").strip()
+            for item in active_file_context_refs
+            if str(item.get("status") or "").strip().lower() == "pending"
+        ]
+        tagged_files = explicit_artifact_paths or _extract_tagged_files(prompt_for_tagged_files)
         guided_prompt = _append_tagged_file_guidance(prompt_for_tagged_files, tagged_files)
+        guided_prompt = _append_artifact_first_guidance(
+            guided_prompt,
+            active_file_context_refs,
+            tagged_files,
+            multimodal_active=bool(message.messageContent),
+        )
+        if pending_files:
+            pending_note = (
+                "Attached files still being processed: "
+                + ", ".join(pending_files)
+                + ". Be explicit that understanding is still in progress."
+            )
+            guided_prompt = f"{guided_prompt.rstrip()}\n\n{pending_note}".strip()
         if guided_prompt != prompt_for_tagged_files:
             for index in range(len(payload) - 1, -1, -1):
                 role = str(payload[index].get("role") or "").strip().lower()
                 if role in {"user", "human"}:
-                    payload[index]["content"] = guided_prompt
+                    payload[index]["content"] = _replace_content_text(payload[index].get("content"), guided_prompt)
                     break
             prompt_for_tagged_files = guided_prompt
         runtime.workspace_state.context["tagged_files"] = tagged_files
-        tagged_files_rag_only = (os.getenv("TAGGED_FILES_RAG_ONLY", "false") or "false").strip().lower() in {
+        env_tagged_files_rag_only = (os.getenv("TAGGED_FILES_RAG_ONLY", "false") or "false").strip().lower() in {
             "1",
             "true",
             "yes",
             "y",
             "on",
         }
+        artifact_only_guidance = bool(explicit_artifact_paths) and not bool(message.messageContent)
+        tagged_files_rag_only = env_tagged_files_rag_only or artifact_only_guidance
         runtime.workspace_state.context["tagged_files_only"] = bool(tagged_files) and tagged_files_rag_only
         if tagged_files:
-            rag_context = await _prefetch_rag_context(runtime.workspace_state.workspace_id, prompt_for_tagged_files)
+            rag_context = await _prefetch_rag_context(
+                runtime.workspace_state.workspace_id,
+                prompt_for_tagged_files,
+                tagged_paths_override=tagged_files,
+            )
             if rag_context:
                 runtime.workspace_state.context["tagged_rag_context"] = rag_context
                 if tagged_files_rag_only:
@@ -1392,7 +2119,10 @@ def create_app() -> FastAPI:
                         role = str(payload[index].get("role") or "").strip().lower()
                         if role in {"user", "human"}:
                             payload[index]["content"] = (
-                                f"{prompt_for_tagged_files}\n\nRAG_CONTEXT:\n{rag_context}\n\nAnswer using only RAG_CONTEXT."
+                                _replace_content_text(
+                                    payload[index].get("content"),
+                                    f"{prompt_for_tagged_files}\n\nRAG_CONTEXT:\n{rag_context}\n\nAnswer using only RAG_CONTEXT.",
+                                )
                             )
                             break
         return payload

--- a/agent/helpudoc_agent/configuration.py
+++ b/agent/helpudoc_agent/configuration.py
@@ -13,6 +13,11 @@ PACKAGE_ROOT = Path(__file__).resolve().parent
 AGENT_ROOT = PACKAGE_ROOT.parent
 REPO_ROOT = AGENT_ROOT.parent
 DEFAULT_CONFIG_PATH = AGENT_ROOT / "config" / "runtime.yaml"
+_LOCAL_DEV_ENVIRONMENTS = {"", "development", "test"}
+_SUSPICIOUS_WORKSPACE_ROOTS = {
+    (REPO_ROOT / "backend" / "backend" / "workspaces").resolve(),
+    (AGENT_ROOT / "backend" / "workspaces").resolve(),
+}
 
 
 class ModelConfig(BaseModel):
@@ -243,6 +248,53 @@ def _resolve_env_override_path(value: str, *, base_dir: Path) -> str:
     return str((base_dir / path).resolve())
 
 
+def _is_local_dev_environment() -> bool:
+    env = os.getenv("NODE_ENV", "").strip().lower()
+    return env in _LOCAL_DEV_ENVIRONMENTS
+
+
+def _validate_workspace_root(workspace_root: Path, *, raw_override: str | None = None) -> Path:
+    resolved = workspace_root.resolve()
+    if not _is_local_dev_environment():
+        return resolved
+
+    if raw_override:
+        raw_path = Path(raw_override.strip())
+        if not raw_path.is_absolute():
+            try:
+                relative = resolved.relative_to(REPO_ROOT)
+            except ValueError as exc:
+                raise RuntimeError(
+                    "Relative WORKSPACE_ROOT must stay within the repo in local/dev. "
+                    f'Got raw="{raw_override}" resolved="{resolved}".'
+                ) from exc
+            if str(relative).startswith(".."):
+                raise RuntimeError(
+                    "Relative WORKSPACE_ROOT resolved outside the repo in local/dev. "
+                    f'Got raw="{raw_override}" resolved="{resolved}".'
+                )
+
+    if resolved in _SUSPICIOUS_WORKSPACE_ROOTS:
+        raise RuntimeError(
+            "Resolved WORKSPACE_ROOT looks inconsistent for local/dev: "
+            f'"{resolved}". Use a repo-root-relative path such as "backend/workspaces" '
+            "or an absolute shared path."
+        )
+    return resolved
+
+
+def describe_workspace_root(settings: Settings) -> Dict[str, Any]:
+    raw_value = (os.getenv("WORKSPACE_ROOT") or "").strip() or None
+    resolved = _validate_workspace_root(settings.backend.workspace_root, raw_override=raw_value)
+    return {
+        "raw_value": raw_value,
+        "resolved_path": str(resolved),
+        "source": "env" if raw_value else "config",
+        "repo_root": str(REPO_ROOT.resolve()),
+        "is_local_dev": _is_local_dev_environment(),
+    }
+
+
 def load_settings(config_path: Path | None = None) -> Settings:
     path = config_path or DEFAULT_CONFIG_PATH
     base_config = _load_yaml(DEFAULT_CONFIG_PATH) if path != DEFAULT_CONFIG_PATH else {}
@@ -250,7 +302,7 @@ def load_settings(config_path: Path | None = None) -> Settings:
     if base_config:
         config_dict = _merge_runtime_config(base_config, config_dict)
     config_dict = _expand_env_vars(config_dict)
-    override_base_dir = AGENT_ROOT
+    override_base_dir = REPO_ROOT
 
     # Allow runtime override for shared workspace volume paths (e.g., Docker Compose).
     workspace_root_override = os.getenv("WORKSPACE_ROOT")
@@ -279,6 +331,13 @@ def load_settings(config_path: Path | None = None) -> Settings:
         "mcp_servers": {srv["name"]: srv for srv in config_dict.get("mcp_servers", [])},
     }
     try:
-        return Settings.model_validate(payload)  # type: ignore[attr-defined]
+        settings = Settings.model_validate(payload)  # type: ignore[attr-defined]
     except AttributeError:  # pragma: no cover - pydantic v1 fallback
-        return Settings.parse_obj(payload)  # type: ignore[call-arg]
+        settings = Settings.parse_obj(payload)  # type: ignore[call-arg]
+
+    raw_override = workspace_root_override if workspace_root_override else None
+    settings.backend.workspace_root = _validate_workspace_root(
+        settings.backend.workspace_root,
+        raw_override=raw_override,
+    )
+    return settings

--- a/agent/helpudoc_agent/graph.py
+++ b/agent/helpudoc_agent/graph.py
@@ -56,6 +56,32 @@ GENERAL_SYSTEM_PROMPT = (
 BASE_AGENT_PROMPT = "In order to complete the objective that the user asks of you, you have access to a number of standard tools."
 
 
+def _normalize_mcp_candidate_servers(server_names: Any) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_name in server_names or []:
+        name = str(raw_name or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        normalized.append(name)
+    return normalized
+
+
+def _clone_preservable_context(context: Dict[str, Any] | None) -> Dict[str, Any]:
+    cloned: Dict[str, Any] = {}
+    for key, value in (context or {}).items():
+        try:
+            cloned[key] = deepcopy(value)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.info(
+                "Skipping non-copyable workspace context key during runtime reuse: %s (%s)",
+                key,
+                exc,
+            )
+    return cloned
+
+
 class AgentRegistry:
     """Caches DeepAgents keyed by (agent_name, workspace_id)."""
 
@@ -120,12 +146,28 @@ class AgentRegistry:
         user_key = str(context_payload.get("user_id") or "")
         cache_scope_prefix = f"{user_key}:{policy_key}:"
         key = (resolved_name, workspace_id, f"{user_key}:{policy_key}:{mcp_auth_fingerprint}")
+        preserved_context: Dict[str, Any] = {}
         if key in self._cache:
             runtime = self._cache[key]
+            prospective_context = _clone_preservable_context(runtime.workspace_state.context)
             if context_payload:
-                runtime.workspace_state.context.update(context_payload)
-            return runtime
-        preserved_context: Dict[str, Any] = {}
+                prospective_context.update(context_payload)
+            desired_candidates = _normalize_mcp_candidate_servers(
+                get_candidate_mcp_servers(
+                    prospective_context.get("active_skill_scope"),
+                    preferred_server=prospective_context.get("preferred_mcp_server"),
+                )
+            )
+            bound_candidates = _normalize_mcp_candidate_servers(
+                runtime.workspace_state.context.get("_bound_mcp_candidates") or []
+            )
+            if desired_candidates == bound_candidates:
+                if context_payload:
+                    runtime.workspace_state.context.update(context_payload)
+                return runtime
+            preserved_context = prospective_context
+            self._cache.pop(key, None)
+
         # Prevent unbounded growth when delegated auth fingerprints rotate over time.
         stale_keys = [
             cache_key
@@ -137,9 +179,9 @@ class AgentRegistry:
         ]
         for stale_key in stale_keys:
             stale_runtime = self._cache.pop(stale_key, None)
-            if stale_runtime is not None:
+            if stale_runtime is not None and not preserved_context:
                 # Preserve in-flight thread/skill state when delegated auth refreshes.
-                preserved_context = deepcopy(stale_runtime.workspace_state.context)
+                preserved_context = _clone_preservable_context(stale_runtime.workspace_state.context)
 
         workspace_base = self.settings.backend.workspace_root
         workspace_base.mkdir(parents=True, exist_ok=True)
@@ -177,17 +219,23 @@ class AgentRegistry:
         ]
 
         active_skill = workspace_state.context.get("active_skill_scope")
-        candidate_mcp_servers = get_candidate_mcp_servers(active_skill)
+        preferred_mcp_server = workspace_state.context.get("preferred_mcp_server")
+        candidate_mcp_servers = get_candidate_mcp_servers(
+            active_skill,
+            preferred_server=str(preferred_mcp_server or "").strip() or None,
+        )
         mcp_manager = MCPServerManager(self.settings, workspace_state)
         logger.info(
-            "MCP bind candidates resolved (workspace=%s allowed_by_skill=%s)",
+            "MCP bind candidates resolved (workspace=%s allowed_by_skill=%s preferred=%s)",
             workspace_id,
             candidate_mcp_servers,
+            preferred_mcp_server,
         )
         await mcp_manager.initialize(
             candidate_server_names=candidate_mcp_servers,
             preflight_gemini=self.settings.model.provider == "gemini",
         )
+        workspace_state.context["_bound_mcp_candidates"] = list(candidate_mcp_servers)
         mcp_tools = []
         for server_name, server_tools in mcp_manager.get_tools_by_server().items():
             for tool in server_tools:

--- a/agent/helpudoc_agent/paper2slides_runner.py
+++ b/agent/helpudoc_agent/paper2slides_runner.py
@@ -13,6 +13,8 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+from .configuration import REPO_ROOT
+
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp"}
 _RUN_DIR_PATTERN = re.compile(r"^\d{8}_\d{6}$")
 
@@ -170,7 +172,10 @@ def _resolve_cache_root() -> Optional[Path]:
 
     workspace_root = os.getenv("WORKSPACE_ROOT")
     if workspace_root:
-        return (Path(workspace_root).expanduser().resolve() / ".paper2slides_cache")
+        root = Path(workspace_root).expanduser()
+        if not root.is_absolute():
+            root = REPO_ROOT / root
+        return root.resolve() / ".paper2slides_cache"
 
     return None
 

--- a/agent/helpudoc_agent/rag_indexer.py
+++ b/agent/helpudoc_agent/rag_indexer.py
@@ -11,7 +11,6 @@ import logging
 import os
 import re
 import hashlib
-import sys
 from datetime import datetime, timezone
 from dataclasses import dataclass
 from pathlib import Path
@@ -42,7 +41,7 @@ except Exception:  # pragma: no cover - optional dependency for some test enviro
 
 logger = logging.getLogger(__name__)
 
-RAG_INDEXABLE_SUFFIXES = {".pdf", ".doc", ".docx", ".md"}
+RAG_INDEXABLE_SUFFIXES = {".pdf", ".doc", ".docx", ".ppt", ".pptx", ".md", ".html", ".htm"}
 
 
 def _env(name: str, default: str | None = None) -> str | None:
@@ -103,7 +102,7 @@ class RagConfig:
         offline = offline_env in {"1", "true", "yes", "y", "on"} or not api_key
         pipeline = (_env("RAG_PARSER_PIPELINE", "raganything") or "raganything").strip().lower()
         use_raganything = pipeline in {"raganything", "rag_anything", "rag-everything", "rageverything"}
-        raganything_parser = (_env("RAGANYTHING_PARSER", "mineru") or "mineru").strip().lower()
+        raganything_parser = (_env("RAGANYTHING_PARSER", "docling") or "docling").strip().lower()
         raganything_parse_method = (_env("RAGANYTHING_PARSE_METHOD", "auto") or "auto").strip().lower()
         raganything_output_dir = Path(
             _env("RAGANYTHING_OUTPUT_DIR", str(workspace_root / ".raganything_output")) or str(workspace_root / ".raganything_output")
@@ -248,6 +247,57 @@ def _read_text(path: Path, max_chars: int) -> str:
     return text
 
 
+def _read_docling_markdown(output_dir: Path, stem: str) -> str:
+    markdown_path = output_dir / stem / "docling" / f"{stem}.md"
+    if not markdown_path.exists():
+        return ""
+    return markdown_path.read_text(encoding="utf-8", errors="replace").strip()
+
+
+def _multimodal_items_to_text(multimodal_items: list[dict[str, Any]]) -> str:
+    lines: list[str] = []
+    for item in multimodal_items:
+        item_type = str(item.get("type") or "").strip().lower()
+        if item_type == "image":
+            caption = str(item.get("image_caption") or "").strip()
+            footnote = str(item.get("image_footnote") or "").strip()
+            parts = [part for part in [caption, footnote] if part]
+            if parts:
+                lines.append(f"[Image] {' | '.join(parts)}")
+        elif item_type == "table":
+            caption = str(item.get("table_caption") or "").strip()
+            footnote = str(item.get("table_footnote") or "").strip()
+            body = item.get("table_body")
+            parts = [part for part in [caption, footnote] if part]
+            if parts:
+                lines.append(f"[Table] {' | '.join(parts)}")
+            if isinstance(body, list) and body:
+                preview_rows: list[str] = []
+                for row in body[:3]:
+                    if isinstance(row, dict):
+                        values = [
+                            str(value).strip()
+                            for value in row.values()
+                            if str(value).strip()
+                        ]
+                        if values:
+                            preview_rows.append(" | ".join(values))
+                    elif isinstance(row, list):
+                        values = [str(value).strip() for value in row if str(value).strip()]
+                        if values:
+                            preview_rows.append(" | ".join(values))
+                    else:
+                        row_text = str(row).strip()
+                        if row_text:
+                            preview_rows.append(row_text)
+                lines.extend(preview_rows)
+        elif item_type == "equation":
+            equation_text = str(item.get("text") or "").strip()
+            if equation_text:
+                lines.append(f"[Equation] {equation_text}")
+    return "\n".join(lines).strip()
+
+
 class WorkspaceRagStore:
     """Caches a LightRAG instance per workspace id."""
 
@@ -362,41 +412,21 @@ class WorkspaceRagStore:
         file_path: Path,
     ) -> str:
         try:
-            from raganything import RAGAnything, RAGAnythingConfig  # type: ignore
-            from raganything.utils import separate_content  # type: ignore
+            from paper2slides.raganything.parser import DoclingParser  # type: ignore
+            from paper2slides.raganything.utils import separate_content  # type: ignore
         except Exception as exc:  # pragma: no cover
-            raise RuntimeError("RAGAnything is not installed") from exc
+            raise RuntimeError("Vendored docling parser is not available") from exc
+
+        if self.config.raganything_parser != "docling":
+            raise RuntimeError(
+                f"Unsupported global parser '{self.config.raganything_parser}'. Only 'docling' is supported."
+            )
 
         doc_id = compute_mdhash_id(f"{workspace_id}:{relative_path}", prefix="doc-")
         rag = await self._get_rag(workspace_id)
 
         output_dir = self.config.raganything_output_dir / workspace_id
         output_dir.mkdir(parents=True, exist_ok=True)
-
-        config = RAGAnythingConfig(
-            working_dir=str(self.config.working_dir),
-            parser=self.config.raganything_parser,
-            parse_method=self.config.raganything_parse_method,
-            parser_output_dir=str(output_dir),
-            enable_image_processing=self.config.raganything_enable_image_processing,
-            enable_table_processing=self.config.raganything_enable_table_processing,
-            enable_equation_processing=self.config.raganything_enable_equation_processing,
-        )
-
-        rag_any = RAGAnything(
-            config=config,
-            lightrag=rag,
-            llm_model_func=_build_llm_func(self.config),
-        )
-
-        venv_bin = Path(sys.executable).parent
-        current_path = os.environ.get("PATH", "")
-        if str(venv_bin) not in current_path.split(os.pathsep):
-            os.environ["PATH"] = f"{venv_bin}{os.pathsep}{current_path}"
-
-        init_result = await rag_any._ensure_lightrag_initialized()
-        if isinstance(init_result, dict) and not init_result.get("success", True):
-            raise RuntimeError(init_result.get("error") or "RAGAnything initialization failed")
 
         def _build_status_payload(existing: Dict[str, Any] | None, status: DocStatus) -> Dict[str, Any]:
             now_iso = datetime.now(timezone.utc).isoformat()
@@ -424,47 +454,55 @@ class WorkspaceRagStore:
                 }
             }
         )
+        try:
+            parser = DoclingParser()
 
-        await rag_any.process_document_complete(
-            file_path=str(file_path),
-            output_dir=str(output_dir),
-            parse_method=self.config.raganything_parse_method,
-            doc_id=doc_id,
-        )
+            def _parse_document() -> tuple[list[dict[str, Any]], str]:
+                content_list = parser.parse_document(
+                    file_path,
+                    method=self.config.raganything_parse_method,
+                    output_dir=str(output_dir),
+                )
+                markdown = _read_docling_markdown(output_dir, file_path.stem)
+                return content_list, markdown
 
-        status = await rag.doc_status.get_by_id(doc_id)
-        chunks = status.get("chunks_list") if isinstance(status, dict) else None
-        if not chunks:
-            content_list, _content_doc_id = await rag_any.parse_document(
-                str(file_path),
-                str(output_dir),
-                self.config.raganything_parse_method,
-                config.display_content_stats,
-            )
-            text_content, _multimodal_items = separate_content(content_list)
-            text_content = text_content.strip()
-            if text_content:
-                text_content = f"SOURCE: /{relative_path.lstrip('/')}\n\n{text_content}"
-            else:
-                text_content = f"SOURCE: /{relative_path.lstrip('/')}\n\n[No extractable text found.]"
-            logger.info("LightRAG did not persist chunks; inserting text-only content.")
+            content_list, markdown = await asyncio.to_thread(_parse_document)
+            text_content, multimodal_items = separate_content(content_list)
+            combined_text = markdown.strip() or text_content.strip()
+            if not combined_text:
+                combined_text = _multimodal_items_to_text(multimodal_items)
+            if not combined_text:
+                combined_text = "[No extractable text found.]"
+
+            payload = f"SOURCE: /{relative_path.lstrip('/')}\n\n{combined_text}"
             await rag.ainsert(
-                input=text_content,
+                input=payload,
                 ids=doc_id,
                 file_paths="/" + relative_path.lstrip("/"),
             )
 
-        refreshed_status = await rag.doc_status.get_by_id(doc_id)
-        await rag.doc_status.upsert(
-            {
-                doc_id: {
-                    **_build_status_payload(refreshed_status, DocStatus.PROCESSED),
-                    "file_path": "/" + relative_path.lstrip("/"),
+            refreshed_status = await rag.doc_status.get_by_id(doc_id)
+            await rag.doc_status.upsert(
+                {
+                    doc_id: {
+                        **_build_status_payload(refreshed_status, DocStatus.PROCESSED),
+                        "file_path": "/" + relative_path.lstrip("/"),
+                    }
                 }
-            }
-        )
-
-        return doc_id
+            )
+            return doc_id
+        except Exception as exc:
+            refreshed_status = await rag.doc_status.get_by_id(doc_id)
+            await rag.doc_status.upsert(
+                {
+                    doc_id: {
+                        **_build_status_payload(refreshed_status, DocStatus.FAILED),
+                        "file_path": "/" + relative_path.lstrip("/"),
+                        "error_msg": str(exc),
+                    }
+                }
+            )
+            raise
 
     async def query(
         self,

--- a/agent/helpudoc_agent/skills_registry.py
+++ b/agent/helpudoc_agent/skills_registry.py
@@ -260,13 +260,17 @@ def expand_runtime_tool_names(tool_names: Iterable[str]) -> List[str]:
 
 def activate_skill_context(context: dict[str, Any], skill: SkillMetadata) -> None:
     runtime_tools = expand_runtime_tool_names(skill.tools)
+    allowed_mcp_servers = list(skill.mcp_servers)
+    preferred_mcp_server = str(context.get("preferred_mcp_server") or "").strip()
+    if preferred_mcp_server and preferred_mcp_server not in allowed_mcp_servers:
+        allowed_mcp_servers.append(preferred_mcp_server)
     context["active_skill"] = skill.skill_id
     context["active_skill_scope"] = {
         "skill_id": skill.skill_id,
         "name": skill.name,
         "tools": runtime_tools,
         "declared_tools": list(skill.tools),
-        "mcp_servers": list(skill.mcp_servers),
+        "mcp_servers": allowed_mcp_servers,
     }
     context["active_skill_policy"] = {
         "requires_hitl_plan": skill.policy.requires_hitl_plan,
@@ -409,6 +413,7 @@ def is_tool_allowed(
 
 def get_candidate_mcp_servers(
     active_skill: SkillMetadata | dict[str, Any] | None,
+    preferred_server: str | None = None,
 ) -> List[str]:
     """Return MCP servers eligible for binding for the active skill.
 
@@ -416,10 +421,14 @@ def get_candidate_mcp_servers(
     MCP servers for explicitly approved skills to keep Gemini-facing schemas
     small and reduce whole-run failures from incompatible MCP tool definitions.
     """
+    candidates: List[str] = []
     resolved_skill = _coerce_active_skill_scope(active_skill)
-    if resolved_skill is None:
-        return []
-    return list(SKILL_MCP_SERVER_ELIGIBILITY.get(resolved_skill.skill_id, ()))
+    if resolved_skill is not None:
+        candidates.extend(SKILL_MCP_SERVER_ELIGIBILITY.get(resolved_skill.skill_id, ()))
+    normalized_preferred = str(preferred_server or "").strip()
+    if normalized_preferred and normalized_preferred not in candidates:
+        candidates.append(normalized_preferred)
+    return candidates
 
 
 def sync_skills_to_workspace(skills_root: Path, workspace_root: Path) -> None:

--- a/agent/helpudoc_agent/tools_and_schemas.py
+++ b/agent/helpudoc_agent/tools_and_schemas.py
@@ -45,6 +45,10 @@ from .utils import SourceTracker, extract_web_url
 logger = logging.getLogger(__name__)
 
 
+class MissingToolBuilderError(RuntimeError):
+    """Raised when a configured tool builder cannot be loaded."""
+
+
 def _dict_has_keys(value: Any, keys: set[str]) -> bool:
     return isinstance(value, dict) and any(key in value for key in keys)
 
@@ -264,7 +268,11 @@ class ToolFactory:
         tools: List[Tool] = []
         for name in tool_names:
             config = self.settings.get_tool(name)
-            built = self._build_tool(config, workspace_state)
+            try:
+                built = self._build_tool(config, workspace_state)
+            except MissingToolBuilderError as exc:
+                logger.warning("Skipping unavailable tool '%s': %s", name, exc)
+                continue
             if isinstance(built, list):
                 tools.extend(built)
             else:
@@ -280,8 +288,20 @@ class ToolFactory:
 
     def _load_entrypoint(self, entrypoint: str, workspace_state: WorkspaceState) -> Tool | List[Tool]:
         module_path, attr = entrypoint.split(":")
-        module = import_module(module_path)
-        factory = getattr(module, attr)
+        try:
+            module = import_module(module_path)
+        except ModuleNotFoundError as exc:
+            if exc.name == module_path or module_path.startswith(f"{exc.name}."):
+                raise MissingToolBuilderError(
+                    f"module '{module_path}' could not be imported"
+                ) from exc
+            raise
+        try:
+            factory = getattr(module, attr)
+        except AttributeError as exc:
+            raise MissingToolBuilderError(
+                f"entrypoint '{entrypoint}' is missing attribute '{attr}'"
+            ) from exc
         try:
             return factory(workspace_state=workspace_state, source_tracker=self.source_tracker)
         except TypeError:
@@ -949,6 +969,14 @@ class ToolFactory:
                 normalized.append(cleaned)
             return sorted(set(normalized))
 
+        def _allow_basename_match(path_value: str) -> bool:
+            normalized = str(path_value or "").strip().replace("\\", "/").lstrip("/")
+            if not normalized:
+                return False
+            if normalized.startswith(".system/"):
+                return False
+            return "/" not in normalized
+
         @tool
         async def rag_query(
             query: str,
@@ -1003,7 +1031,7 @@ class ToolFactory:
                 data = response.get("data") if isinstance(response, dict) else None
                 chunks = data.get("chunks", []) if isinstance(data, dict) else []
             if normalized:
-                normalized_basenames = {Path(item).name for item in normalized if item}
+                normalized_basenames = {Path(item).name for item in normalized if _allow_basename_match(item)}
                 filtered = []
                 for chunk in chunks:
                     file_path = chunk.get("file_path") or ""

--- a/agent/paper2slides/rag/config.py
+++ b/agent/paper2slides/rag/config.py
@@ -87,7 +87,7 @@ class StorageConfig:
 class ParserConfig:
     """Paper parser settings."""
     
-    parser: str = field(default_factory=lambda: os.getenv("PARSER") or os.getenv("RAGANYTHING_PARSER") or "mineru")
+    parser: str = field(default_factory=lambda: os.getenv("PARSER") or os.getenv("RAGANYTHING_PARSER") or "docling")
     """Parser: 'mineru' or 'docling'."""
     
     parse_method: str = field(default_factory=lambda: os.getenv("PARSE_METHOD", "auto"))

--- a/agent/paper2slides/raganything/config.py
+++ b/agent/paper2slides/raganything/config.py
@@ -26,7 +26,7 @@ class RAGAnythingConfig:
     parser_output_dir: str = field(default=get_env_value("OUTPUT_DIR", "./output", str))
     """Default output directory for parsed content."""
 
-    parser: str = field(default=get_env_value("PARSER", "mineru", str))
+    parser: str = field(default=get_env_value("PARSER", get_env_value("RAGANYTHING_PARSER", "docling", str), str))
     """Parser selection: 'mineru' or 'docling'."""
 
     display_content_stats: bool = field(

--- a/agent/paper2slides/raganything/parser.py
+++ b/agent/paper2slides/raganything/parser.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 import json
 import argparse
 import base64
+import os
 import subprocess
+import sys
 import tempfile
 import logging
 from pathlib import Path
@@ -30,6 +32,20 @@ from typing import (
 )
 
 T = TypeVar("T")
+
+
+def _docling_env() -> dict[str, str]:
+    env = dict(os.environ)
+    path_entries = env.get("PATH", "").split(os.pathsep) if env.get("PATH") else []
+    candidate_dirs = [
+        str(Path(sys.executable).parent),
+        str(Path(sys.prefix) / "bin"),
+    ]
+    for candidate in reversed(candidate_dirs):
+        if candidate and candidate not in path_entries and Path(candidate, "docling").exists():
+            path_entries.insert(0, candidate)
+    env["PATH"] = os.pathsep.join(path_entries)
+    return env
 
 
 class MineruExecutionError(Exception):
@@ -1380,6 +1396,7 @@ class DoclingParser(Parser):
                 "check": True,
                 "encoding": "utf-8",
                 "errors": "ignore",
+                "env": _docling_env(),
             }
 
             # Hide console window on Windows

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -33,5 +33,6 @@ plotly
 kaleido
 lightrag-hku[api]
 raganything
+docling
 pypdf
 redis

--- a/backend/scripts/test_workspace_root_resolution.ts
+++ b/backend/scripts/test_workspace_root_resolution.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import path from 'path';
+
+import { REPO_ROOT, getWorkspaceRootDiagnostic, resolveWorkspaceRoot } from '../src/config/workspaceRoot';
+
+const expected = path.join(REPO_ROOT, 'backend', 'workspaces');
+
+assert.equal(
+  resolveWorkspaceRoot('backend/workspaces'),
+  expected,
+  'backend/workspaces should resolve from repo root',
+);
+
+const diagnostic = getWorkspaceRootDiagnostic('backend/workspaces');
+assert.equal(diagnostic.resolvedPath, expected);
+assert.equal(diagnostic.source, 'env');
+
+const defaultDiagnostic = getWorkspaceRootDiagnostic('');
+assert.equal(defaultDiagnostic.resolvedPath, expected);
+assert.equal(defaultDiagnostic.source, 'default');
+
+console.log('workspace root resolution ok');

--- a/backend/src/api/agent.ts
+++ b/backend/src/api/agent.ts
@@ -5,7 +5,7 @@ import { promises as fs } from 'fs';
 import { existsSync } from 'fs';
 import { z } from 'zod';
 import { parse as parseYaml } from 'yaml';
-import { runAgent, runAgentStream } from '../services/agentService';
+import { runAgent, runAgentStream, type AgentMessageContentBlock } from '../services/agentService';
 import { WorkspaceService } from '../services/workspaceService';
 import { FileService } from '../services/fileService';
 import { HttpError } from '../errors';
@@ -37,13 +37,21 @@ const DEBUG_AGENT_RUN_STREAM =
   process.env.DEBUG_AGENT_RUN_STREAM === '1' || process.env.DEBUG_AGENT_RUN_STREAM === 'true';
 const AUTH_MODE = (process.env.AUTH_MODE || 'headers').trim().toLowerCase();
 const BQ_DELEGATED_MCP_SERVER_ID = 'toolbox-bq-demo';
+const DEFAULT_CURRENT_TURN_MULTIMODAL_MAX_BYTES = 8 * 1024 * 1024;
 const repoRoot = path.resolve(__dirname, '../../..');
 const skillsRoot = process.env.SKILLS_ROOT || path.join(repoRoot, 'skills');
+const resolveRepoRelativePath = (value?: string | null): string | undefined => {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return path.isAbsolute(trimmed) ? trimmed : path.resolve(repoRoot, trimmed);
+};
 const defaultAgentConfigDir = existsSync('/agent/config')
   ? '/agent/config'
   : path.join(repoRoot, 'agent', 'config');
-const agentConfigPath = process.env.AGENT_CONFIG_PATH
-  || path.join(process.env.AGENT_CONFIG_DIR || defaultAgentConfigDir, 'runtime.yaml');
+const agentConfigPath = resolveRepoRelativePath(process.env.AGENT_CONFIG_PATH)
+  || path.join(resolveRepoRelativePath(process.env.AGENT_CONFIG_DIR) || defaultAgentConfigDir, 'runtime.yaml');
 const repoAgentConfigPath = path.join(repoRoot, 'agent', 'config', 'runtime.yaml');
 
 type RuntimeConfigShape = {
@@ -77,6 +85,13 @@ type EffectiveAgentPolicy = {
 };
 
 const normalizeUniqueIds = (values: string[]) => Array.from(new Set(values.map((value) => value.trim()).filter(Boolean))).sort((a, b) => a.localeCompare(b));
+
+const resolveCurrentTurnMultimodalMaxBytes = (): number => {
+  const raw = Number(process.env.CURRENT_TURN_MULTIMODAL_MAX_BYTES || DEFAULT_CURRENT_TURN_MULTIMODAL_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_CURRENT_TURN_MULTIMODAL_MAX_BYTES;
+};
+
+const CURRENT_TURN_MULTIMODAL_MAX_BYTES = resolveCurrentTurnMultimodalMaxBytes();
 
 const extractFrontmatterString = (frontmatter: Record<string, unknown>, key: string): string | undefined => {
   const value = frontmatter[key];
@@ -236,6 +251,22 @@ export default function(
     })).optional(),
     forceReset: z.boolean().optional(),
     turnId: z.string().optional(),
+    taggedFiles: z.array(z.string().min(1)).optional(),
+    currentTurnFileIds: z.array(z.number().int().positive()).optional(),
+    fileContextRefs: z.array(z.object({
+      sourceFileId: z.number().int().positive(),
+      sourceName: z.string().min(1),
+      sourceMimeType: z.string().nullable().optional(),
+      sourceVersionFingerprint: z.string().min(1),
+      artifactId: z.string().min(1),
+      artifactVersion: z.number().int().positive(),
+      derivedArtifactFileId: z.number().int().positive().nullable().optional(),
+      derivedArtifactPath: z.string().nullable().optional(),
+      effectiveMode: z.enum(['part', 'parser', 'hybrid']),
+      status: z.enum(['pending', 'partial', 'ready', 'failed', 'superseded']),
+      summary: z.string().nullable().optional(),
+      lastError: z.string().nullable().optional(),
+    }).strict()).optional(),
   });
 
   const presentationSchema = z.object({
@@ -599,12 +630,32 @@ export default function(
     return IMAGE_NAME_PATTERN.test(String(file.name || ''));
   };
 
-  const injectTaggedFileUrls = async (prompt: string, workspaceId: string, userId: string) => {
-    if (!prompt || !prompt.includes('@')) {
+  const normalizeTaggedValue = (value: string): string => value.trim().replace(/\\/g, '/').replace(/^\/+/, '');
+
+  const injectTaggedFileUrls = async (
+    prompt: string,
+    workspaceId: string,
+    userId: string,
+    explicitTaggedFiles?: string[],
+  ) => {
+    const normalizedExplicit = Array.from(
+      new Set((explicitTaggedFiles || []).map((value) => normalizeTaggedValue(String(value || ''))).filter(Boolean)),
+    );
+    if ((!prompt || !prompt.includes('@')) && !normalizedExplicit.length) {
       return prompt;
     }
     const files = await fileService.getFiles(workspaceId, userId);
-    const tagged = files.filter((file) => prompt.includes(`@${file.name}`));
+    const explicitBasenames = new Set(normalizedExplicit.map((value) => path.posix.basename(value)));
+    const tagged = files.filter((file) => {
+      const fileName = typeof file.name === 'string' ? normalizeTaggedValue(file.name) : '';
+      if (!fileName) {
+        return false;
+      }
+      if (normalizedExplicit.length) {
+        return normalizedExplicit.includes(fileName) || explicitBasenames.has(path.posix.basename(fileName));
+      }
+      return prompt.includes(`@${file.name}`);
+    });
     const withUrls = tagged.filter((file) => file.publicUrl && isImageFile(file));
     const taggedPaths = Array.from(
       new Set(
@@ -629,21 +680,99 @@ export default function(
     return `${prompt}${fileHint}${urlHint}`;
   };
 
+  const buildCurrentTurnMessageContent = async (
+    workspaceId: string,
+    userId: string,
+    prompt: string,
+    currentTurnFileIds?: number[],
+  ): Promise<AgentMessageContentBlock[] | undefined> => {
+    const normalizedIds = Array.from(
+      new Set(
+        (currentTurnFileIds || [])
+          .map((value) => Number(value))
+          .filter((value) => Number.isFinite(value) && value > 0),
+      ),
+    );
+    if (!normalizedIds.length) {
+      return undefined;
+    }
+
+    const fileBlocks: AgentMessageContentBlock[] = [];
+
+    for (const fileId of normalizedIds) {
+      const file = await fileService.getFileContent(fileId, userId);
+      const mimeType = typeof file.mimeType === 'string' && file.mimeType.trim()
+        ? file.mimeType.trim()
+        : 'application/octet-stream';
+      const encoded = typeof file.content === 'string' ? file.content : '';
+      if (!encoded) {
+        continue;
+      }
+      const byteLength = Buffer.byteLength(encoded, 'base64');
+      if (byteLength > CURRENT_TURN_MULTIMODAL_MAX_BYTES) {
+        console.info('Skipping oversized current-turn multimodal attachment', {
+          workspaceId,
+          fileId,
+          fileName: file.name,
+          mimeType,
+          byteLength,
+          maxBytes: CURRENT_TURN_MULTIMODAL_MAX_BYTES,
+        });
+        continue;
+      }
+      if (mimeType === 'application/pdf') {
+        fileBlocks.push({
+          type: 'file',
+          base64: encoded,
+          mime_type: mimeType,
+          filename: String(file.name || `attachment-${fileId}.pdf`),
+        });
+      } else if (mimeType.startsWith('image/')) {
+        fileBlocks.push({
+          type: 'image',
+          base64: encoded,
+          mime_type: mimeType,
+        });
+      }
+    }
+
+    if (!fileBlocks.length) {
+      return undefined;
+    }
+
+    const promptText = [
+      prompt.trim(),
+      'Use the attached file content as primary context for this turn before falling back to workspace search or web search.',
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+
+    return promptText
+      ? [{ type: 'text', text: promptText }, ...fileBlocks]
+      : fileBlocks;
+  };
+
   router.post('/run', async (req, res) => {
     try {
       const user = requireUserContext(req);
-      const { persona, prompt, workspaceId, history, forceReset } = runAgentSchema.parse(req.body);
+      const { persona, prompt, workspaceId, history, forceReset, taggedFiles, currentTurnFileIds, fileContextRefs } = runAgentSchema.parse(req.body);
       const workspacePolicy = await workspaceService.getMcpServerPolicy(workspaceId, user.userId, { requireEdit: true });
       const policy = await resolveEffectiveAgentPolicy(user.userId, workspacePolicy);
       const settings = await workspaceService.getWorkspaceSettings(workspaceId, user.userId, { requireEdit: true });
-      const enrichedPrompt = await injectTaggedFileUrls(prompt, workspaceId, user.userId);
+      const enrichedPrompt = await injectTaggedFileUrls(prompt, workspaceId, user.userId, taggedFiles);
       const authToken = await buildAgentAuthToken({
         userId: user.userId,
         workspaceId,
         policy,
         skipPlanApprovals: settings.skipPlanApprovals,
       });
-      const response = await runAgent(persona, workspaceId, enrichedPrompt, history, { forceReset, authToken: authToken || undefined });
+      const messageContent = await buildCurrentTurnMessageContent(workspaceId, user.userId, enrichedPrompt, currentTurnFileIds);
+      const response = await runAgent(persona, workspaceId, enrichedPrompt, history, {
+        forceReset,
+        authToken: authToken || undefined,
+        fileContextRefs,
+        messageContent,
+      });
       res.json(response);
     } catch (error: any) {
       if (error instanceof z.ZodError) {
@@ -678,21 +807,24 @@ export default function(
 
     try {
       const user = requireUserContext(req);
-      const { persona, prompt, workspaceId, history, forceReset } = runAgentSchema.parse(req.body);
+      const { persona, prompt, workspaceId, history, forceReset, taggedFiles, currentTurnFileIds, fileContextRefs } = runAgentSchema.parse(req.body);
       const workspacePolicy = await workspaceService.getMcpServerPolicy(workspaceId, user.userId, { requireEdit: true });
       const policy = await resolveEffectiveAgentPolicy(user.userId, workspacePolicy);
       const settings = await workspaceService.getWorkspaceSettings(workspaceId, user.userId, { requireEdit: true });
-      const enrichedPrompt = await injectTaggedFileUrls(prompt, workspaceId, user.userId);
+      const enrichedPrompt = await injectTaggedFileUrls(prompt, workspaceId, user.userId, taggedFiles);
       const authToken = await buildAgentAuthToken({
         userId: user.userId,
         workspaceId,
         policy,
         skipPlanApprovals: settings.skipPlanApprovals,
       });
+      const messageContent = await buildCurrentTurnMessageContent(workspaceId, user.userId, enrichedPrompt, currentTurnFileIds);
       streamResponse = await runAgentStream(persona, workspaceId, enrichedPrompt, history, {
         forceReset,
         signal: upstreamAbort.signal,
         authToken: authToken || undefined,
+        fileContextRefs,
+        messageContent,
       });
       res.setHeader('Content-Type', 'application/jsonl');
       streamResponse.data.on('data', (chunk: Buffer) => {
@@ -735,18 +867,19 @@ export default function(
   router.post('/runs', async (req, res) => {
     try {
       const user = requireUserContext(req);
-      const { persona, prompt, workspaceId, history, forceReset, turnId } = runAgentSchema.parse(req.body);
+      const { persona, prompt, workspaceId, history, forceReset, turnId, taggedFiles, currentTurnFileIds, fileContextRefs } = runAgentSchema.parse(req.body);
       await workspaceService.ensureMembership(workspaceId, user.userId, { requireEdit: true });
       const workspacePolicy = await workspaceService.getMcpServerPolicy(workspaceId, user.userId, { requireEdit: true });
       const policy = await resolveEffectiveAgentPolicy(user.userId, workspacePolicy);
       const settings = await workspaceService.getWorkspaceSettings(workspaceId, user.userId, { requireEdit: true });
-      const enrichedPrompt = await injectTaggedFileUrls(prompt, workspaceId, user.userId);
+      const enrichedPrompt = await injectTaggedFileUrls(prompt, workspaceId, user.userId, taggedFiles);
       const authToken = await buildAgentAuthToken({
         userId: user.userId,
         workspaceId,
         policy,
         skipPlanApprovals: settings.skipPlanApprovals,
       });
+      const messageContent = await buildCurrentTurnMessageContent(workspaceId, user.userId, enrichedPrompt, currentTurnFileIds);
       const { runId, status } = await startAgentRun({
         persona,
         workspaceId,
@@ -755,6 +888,8 @@ export default function(
         forceReset,
         turnId,
         authToken: authToken || undefined,
+        fileContextRefs,
+        messageContent,
       });
       res.json({ runId, status });
     } catch (error: any) {

--- a/backend/src/api/attachments.ts
+++ b/backend/src/api/attachments.ts
@@ -1,0 +1,71 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { WorkspaceService } from '../services/workspaceService';
+import { AttachmentPrepJobService } from '../services/attachmentPrepJobService';
+import { HttpError } from '../errors';
+
+export default function attachmentRoutes(
+  workspaceService: WorkspaceService,
+  attachmentPrepJobService: AttachmentPrepJobService,
+) {
+  const router = Router({ mergeParams: true });
+
+  const createJobSchema = z.object({
+    conversationId: z.string().min(1),
+    turnId: z.string().min(1),
+    driveFileIds: z.array(z.string().min(1)).optional(),
+    sourceFileIds: z.array(z.number().int().positive()).optional(),
+  });
+
+  const requireUserContext = (req: Request) => {
+    if (!req.userContext) {
+      throw new HttpError(401, 'Missing user context');
+    }
+    return req.userContext;
+  };
+
+  const handleError = (res: Response, error: unknown, fallbackMessage: string) => {
+    if (error instanceof HttpError) {
+      return res.status(error.statusCode).json({ error: error.message, details: error.details });
+    }
+    console.error(fallbackMessage, error);
+    return res.status(500).json({ error: fallbackMessage });
+  };
+
+  router.post('/jobs', async (req: Request<{ workspaceId: string }>, res: Response) => {
+    try {
+      const { workspaceId } = req.params;
+      const user = requireUserContext(req);
+      const payload = createJobSchema.parse(req.body);
+      await workspaceService.ensureMembership(workspaceId, user.userId, { requireEdit: true });
+      const job = await attachmentPrepJobService.createJob({
+        workspaceId,
+        conversationId: payload.conversationId,
+        turnId: payload.turnId,
+        userId: user.userId,
+        driveFileIds: payload.driveFileIds,
+        sourceFileIds: payload.sourceFileIds,
+      });
+      res.status(201).json(job);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: 'Invalid attachment prep payload' });
+      }
+      handleError(res, error, 'Failed to create attachment prep job');
+    }
+  });
+
+  router.get('/jobs/:jobId', async (req: Request<{ workspaceId: string; jobId: string }>, res: Response) => {
+    try {
+      const { workspaceId, jobId } = req.params;
+      const user = requireUserContext(req);
+      await workspaceService.ensureMembership(workspaceId, user.userId, { requireEdit: true });
+      const job = await attachmentPrepJobService.getJob(jobId, user.userId);
+      res.json(job);
+    } catch (error) {
+      handleError(res, error, 'Failed to fetch attachment prep job');
+    }
+  });
+
+  return router;
+}

--- a/backend/src/api/files.ts
+++ b/backend/src/api/files.ts
@@ -4,10 +4,20 @@ import multer from 'multer';
 import { FileService } from '../services/fileService';
 import { fetchRagStatuses } from '../services/agentService';
 import { HttpError } from '../errors';
+import { WorkspaceService } from '../services/workspaceService';
+import { GoogleOAuthService, GoogleOAuthTokenMissingError } from '../services/googleOAuthService';
+import { GoogleDriveService } from '../services/googleDriveService';
+import { DerivedArtifactService } from '../services/derivedArtifactService';
 
-export default function(fileService: FileService) {
+export default function(
+  fileService: FileService,
+  workspaceService: WorkspaceService,
+  googleOAuthService: GoogleOAuthService,
+  derivedArtifactService: DerivedArtifactService,
+) {
   const router = Router({ mergeParams: true });
   const upload = multer({ storage: multer.memoryStorage() });
+  const googleDriveService = new GoogleDriveService(googleOAuthService, fileService);
 
   const updateFileSchema = z.object({
     content: z.string(),
@@ -36,6 +46,20 @@ export default function(fileService: FileService) {
     path: z.string().min(1),
   });
 
+  const googleDriveSearchSchema = z.object({
+    query: z.string().optional(),
+    scope: z.enum(['recent', 'my-drive', 'shared']).optional(),
+    pageToken: z.string().optional(),
+  });
+
+  const googleDriveImportSchema = z.object({
+    fileIds: z.array(z.string().min(1)).min(1).max(20),
+  });
+
+  const fileContextSchema = z.object({
+    fileIds: z.array(z.number().int().positive()).min(1).max(20),
+  });
+
   const requireUserContext = (req: Request) => {
     if (!req.userContext) {
       throw new HttpError(401, 'Missing user context');
@@ -44,6 +68,9 @@ export default function(fileService: FileService) {
   };
 
   const handleError = (res: Response, error: unknown, fallbackMessage: string) => {
+    if (error instanceof GoogleOAuthTokenMissingError) {
+      return res.status(400).json({ error: error.message });
+    }
     if (error instanceof HttpError) {
       return res.status(error.statusCode).json({ error: error.message, details: error.details });
     }
@@ -51,12 +78,72 @@ export default function(fileService: FileService) {
     return res.status(500).json({ error: fallbackMessage });
   };
 
+  const decorateFilesWithUnderstanding = async (
+    workspaceId: string,
+    userId: string,
+    files: Array<Record<string, any>>,
+  ) => {
+    const fileIds = files
+      .map((file) => Number(file.id))
+      .filter((value) => Number.isFinite(value) && value > 0);
+    const states = await derivedArtifactService.listFileUnderstandingStates(workspaceId, userId, fileIds);
+    return files.map((file) => {
+      const state = states.get(Number(file.id));
+      if (!state) {
+        return file;
+      }
+      return {
+        ...file,
+        understandingStatus: state.status,
+        understandingMode: state.mode,
+        understandingError: state.error,
+        derivedArtifactFileId: state.derivedArtifactFileId,
+      };
+    });
+  };
+
+  router.get('/drive/search', async (req: Request<{ workspaceId: string }>, res: Response) => {
+    try {
+      const { workspaceId } = req.params;
+      const user = requireUserContext(req);
+      const payload = googleDriveSearchSchema.parse(req.query);
+      await workspaceService.ensureMembership(workspaceId, user.userId);
+      const result = await googleDriveService.searchFiles(user.userId, {
+        query: payload.query,
+        scope: payload.scope,
+        pageToken: payload.pageToken,
+      });
+      res.json(result);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: 'Invalid Google Drive search payload' });
+      }
+      handleError(res, error, 'Failed to search Google Drive');
+    }
+  });
+
+  router.post('/drive/import', async (req: Request<{ workspaceId: string }>, res: Response) => {
+    try {
+      const { workspaceId } = req.params;
+      const user = requireUserContext(req);
+      const payload = googleDriveImportSchema.parse(req.body);
+      await workspaceService.ensureMembership(workspaceId, user.userId, { requireEdit: true });
+      const files = await googleDriveService.importFiles(workspaceId, user.userId, payload.fileIds);
+      res.status(201).json({ files });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: 'Invalid Google Drive import payload' });
+      }
+      handleError(res, error, 'Failed to import Google Drive files');
+    }
+  });
+
   router.get('/', async (req: Request<{ workspaceId: string }>, res: Response) => {
     try {
       const { workspaceId } = req.params;
       const user = requireUserContext(req);
       const files = await fileService.getFiles(workspaceId, user.userId);
-      res.json(files);
+      res.json(await decorateFilesWithUnderstanding(workspaceId, user.userId, files));
     } catch (error) {
       handleError(res, error, 'Failed to list files');
     }
@@ -85,6 +172,25 @@ export default function(fileService: FileService) {
       res.json(file);
     } catch (error) {
       handleError(res, error, 'Failed to retrieve file content');
+    }
+  });
+
+  router.post('/context', async (req: Request<{ workspaceId: string }>, res: Response) => {
+    try {
+      const { workspaceId } = req.params;
+      const user = requireUserContext(req);
+      const payload = fileContextSchema.parse(req.body);
+      const fileContextRefs = await derivedArtifactService.ensureFileContextRefs(
+        workspaceId,
+        user.userId,
+        payload.fileIds,
+      );
+      res.status(201).json({ fileContextRefs });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: 'Invalid file context payload' });
+      }
+      handleError(res, error, 'Failed to build file context');
     }
   });
 
@@ -121,7 +227,27 @@ export default function(fileService: FileService) {
           req.file.mimetype,
           user.userId,
         );
-        res.status(201).json(newFile);
+        let understandingState = null;
+        if (derivedArtifactService.isAutoProcessEligibleFile(newFile.name, newFile.mimeType)) {
+          const refs = await derivedArtifactService.enqueueFileUnderstanding(
+            workspaceId,
+            user.userId,
+            [Number(newFile.id)],
+          );
+          const ref = refs[0];
+          if (ref) {
+            understandingState = {
+              understandingStatus: ref.status,
+              understandingMode: ref.effectiveMode,
+              understandingError: ref.lastError ?? null,
+              derivedArtifactFileId: ref.derivedArtifactFileId ?? null,
+            };
+          }
+        }
+        res.status(201).json({
+          ...newFile,
+          ...(understandingState || {}),
+        });
       } catch (error) {
         handleError(res, error, 'Failed to create file');
       }

--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -3,6 +3,7 @@ import agentRoutes from './agent';
 import authRoutes from './auth';
 import workspaceRoutes from './workspaces';
 import fileRoutes from './files';
+import attachmentRoutes from './attachments';
 import conversationRoutes from './conversations';
 import settingsRoutes from './settings';
 import knowledgeRoutes from './knowledge';
@@ -18,23 +19,37 @@ import { redisClient } from '../services/redisService';
 import { RagQueueService } from '../services/ragQueueService';
 import { UserOAuthTokenService } from '../services/userOAuthTokenService';
 import { GoogleOAuthService } from '../services/googleOAuthService';
+import { DerivedArtifactService } from '../services/derivedArtifactService';
+import { GoogleDriveService } from '../services/googleDriveService';
+import { AttachmentPrepJobService } from '../services/attachmentPrepJobService';
 
 export default function(dbService: DatabaseService, userService: UserService) {
   const router = Router();
   const ragQueueService = new RagQueueService(redisClient);
   const workspaceService = new WorkspaceService(dbService, ragQueueService);
   const fileService = new FileService(dbService, workspaceService, ragQueueService);
+  const derivedArtifactService = new DerivedArtifactService(dbService, fileService, workspaceService);
+  derivedArtifactService.logDiagnostics();
+  fileService.setDerivedArtifactCleanup(derivedArtifactService);
   const conversationService = new ConversationService(dbService, workspaceService);
   const knowledgeService = new KnowledgeService(dbService, workspaceService);
   const userOAuthTokenService = new UserOAuthTokenService(dbService);
   const googleOAuthService = new GoogleOAuthService(userOAuthTokenService);
+  const googleDriveService = new GoogleDriveService(googleOAuthService, fileService);
+  const attachmentPrepJobService = new AttachmentPrepJobService(
+    workspaceService,
+    googleDriveService,
+    fileService,
+    derivedArtifactService,
+  );
 
   router.use('/auth', authRoutes(userService, googleOAuthService));
   router.use('/agent', agentRoutes(workspaceService, fileService, googleOAuthService, userService));
   router.use('/settings', requireSystemAdmin(userService), settingsRoutes(workspaceService));
   router.use('/users', requireSystemAdmin(userService), usersRoutes(userService, workspaceService));
   router.use('/workspaces', workspaceRoutes(workspaceService, userService));
-  router.use('/workspaces/:workspaceId/files', fileRoutes(fileService));
+  router.use('/workspaces/:workspaceId/attachments', attachmentRoutes(workspaceService, attachmentPrepJobService));
+  router.use('/workspaces/:workspaceId/files', fileRoutes(fileService, workspaceService, googleOAuthService, derivedArtifactService));
   router.use('/workspaces/:workspaceId/knowledge', knowledgeRoutes(knowledgeService));
   router.use('/', conversationRoutes(conversationService));
 

--- a/backend/src/api/settings.ts
+++ b/backend/src/api/settings.ts
@@ -8,6 +8,7 @@ import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { existsSync } from 'fs';
 import type { WorkspaceService } from '../services/workspaceService';
 import { HttpError } from '../errors';
+import { resolveWorkspaceRoot } from '../config/workspaceRoot';
 import {
   cancelAgentRun,
   getRunMeta,
@@ -19,9 +20,14 @@ import { blockingRedisClient } from '../services/redisService';
 import { signAgentContextToken } from '../services/agentToken';
 
 const repoRoot = path.resolve(__dirname, '../../..');
-const workspaceRoot = process.env.WORKSPACE_ROOT
-  ? path.resolve(process.env.WORKSPACE_ROOT)
-  : path.join(repoRoot, 'workspaces');
+const workspaceRoot = resolveWorkspaceRoot();
+const resolveRepoRelativePath = (value?: string | null): string | undefined => {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return path.isAbsolute(trimmed) ? trimmed : path.resolve(repoRoot, trimmed);
+};
 
 // In production containers, the repo layout does not exist. Use explicit env vars.
 // In local dev, fall back to the checked-in agent config so the Settings UI reflects
@@ -29,8 +35,8 @@ const workspaceRoot = process.env.WORKSPACE_ROOT
 const defaultAgentConfigDir = existsSync('/agent/config')
   ? '/agent/config'
   : path.join(repoRoot, 'agent', 'config');
-const agentConfigPath = process.env.AGENT_CONFIG_PATH
-  || path.join(process.env.AGENT_CONFIG_DIR || defaultAgentConfigDir, 'runtime.yaml');
+const agentConfigPath = resolveRepoRelativePath(process.env.AGENT_CONFIG_PATH)
+  || path.join(resolveRepoRelativePath(process.env.AGENT_CONFIG_DIR) || defaultAgentConfigDir, 'runtime.yaml');
 const repoAgentConfigPath = path.join(repoRoot, 'agent', 'config', 'runtime.yaml');
 const skillsRoot = process.env.SKILLS_ROOT || path.join(repoRoot, 'skills');
 

--- a/backend/src/config/workspaceRoot.ts
+++ b/backend/src/config/workspaceRoot.ts
@@ -1,0 +1,76 @@
+import path from 'path';
+
+export const REPO_ROOT = path.resolve(__dirname, '../../..');
+const DEFAULT_WORKSPACE_ROOT = path.join(REPO_ROOT, 'backend', 'workspaces');
+const LOCAL_DEV_ENVIRONMENTS = new Set(['', 'development', 'test']);
+const SUSPICIOUS_LOCAL_PATHS = new Set([
+  path.resolve(REPO_ROOT, 'backend', 'backend', 'workspaces'),
+  path.resolve(REPO_ROOT, 'agent', 'backend', 'workspaces'),
+]);
+
+export type WorkspaceRootDiagnostic = {
+  rawValue: string | null;
+  resolvedPath: string;
+  source: 'env' | 'default';
+  repoRoot: string;
+  isLocalDev: boolean;
+};
+
+function isLocalDevEnvironment(): boolean {
+  const env = String(process.env.NODE_ENV || '').trim().toLowerCase();
+  return LOCAL_DEV_ENVIRONMENTS.has(env);
+}
+
+function assertWorkspaceRootLooksSane(rawValue: string | null, resolvedPath: string): void {
+  if (!isLocalDevEnvironment()) {
+    return;
+  }
+
+  if (rawValue && !path.isAbsolute(rawValue)) {
+    const relativeTarget = path.relative(REPO_ROOT, resolvedPath);
+    if (relativeTarget.startsWith('..') || path.isAbsolute(relativeTarget)) {
+      throw new Error(
+        `Relative WORKSPACE_ROOT must stay within the repo in local/dev. ` +
+        `Got raw="${rawValue}" resolved="${resolvedPath}".`,
+      );
+    }
+  }
+
+  if (SUSPICIOUS_LOCAL_PATHS.has(resolvedPath)) {
+    throw new Error(
+      `Resolved WORKSPACE_ROOT looks inconsistent for local/dev: "${resolvedPath}". ` +
+      `Use a repo-root-relative path such as "backend/workspaces" or an absolute shared path.`,
+    );
+  }
+}
+
+export function getWorkspaceRootDiagnostic(rawOverride = process.env.WORKSPACE_ROOT): WorkspaceRootDiagnostic {
+  const rawValue = String(rawOverride || '').trim() || null;
+  const resolvedPath = rawValue
+    ? path.resolve(path.isAbsolute(rawValue) ? rawValue : path.join(REPO_ROOT, rawValue))
+    : DEFAULT_WORKSPACE_ROOT;
+
+  assertWorkspaceRootLooksSane(rawValue, resolvedPath);
+
+  return {
+    rawValue,
+    resolvedPath,
+    source: rawValue ? 'env' : 'default',
+    repoRoot: REPO_ROOT,
+    isLocalDev: isLocalDevEnvironment(),
+  };
+}
+
+export function resolveWorkspaceRoot(rawOverride = process.env.WORKSPACE_ROOT): string {
+  return getWorkspaceRootDiagnostic(rawOverride).resolvedPath;
+}
+
+export function logWorkspaceRootDiagnostic(label: string): string {
+  const diagnostic = getWorkspaceRootDiagnostic();
+  const rawSuffix = diagnostic.rawValue ? ` raw=${diagnostic.rawValue}` : '';
+  console.log(
+    `[${label}] Workspace root: ${diagnostic.resolvedPath} ` +
+    `(source=${diagnostic.source}${rawSuffix})`,
+  );
+  return diagnostic.resolvedPath;
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,7 @@ import { UserService } from './services/userService';
 import { userContextMiddleware } from './middleware/userContext';
 import { blockingRedisClient, redisClient } from './services/redisService';
 import { startCollabServer } from './collab/collabServer';
+import { logWorkspaceRootDiagnostic } from './config/workspaceRoot';
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -46,6 +47,7 @@ function resolveSaveUninitialized(): boolean {
 }
 
 async function startServer() {
+  logWorkspaceRootDiagnostic('backend');
   const databaseService = new DatabaseService();
   await databaseService.initialize();
   const userService = new UserService(databaseService);

--- a/backend/src/services/agentRunService.ts
+++ b/backend/src/services/agentRunService.ts
@@ -7,10 +7,12 @@ import {
   resumeAgentActionStream,
   resumeAgentResponseStream,
   type AgentDecision,
+  type AgentMessageContentBlock,
   type AgentInterruptActionResponse,
   type AgentInterruptResponse,
   type AgentHistoryEntry,
 } from './agentService';
+import type { FileContextRef } from '../../../packages/shared/src/types';
 
 export type AgentRunStatus =
   | 'queued'
@@ -28,6 +30,8 @@ type StartRunParams = {
   forceReset?: boolean;
   turnId?: string;
   authToken?: string;
+  fileContextRefs?: FileContextRef[];
+  messageContent?: AgentMessageContentBlock[];
 };
 
 type RunPendingInterrupt = {
@@ -91,6 +95,8 @@ type PersistedRunContext = {
   history?: AgentHistoryEntry[];
   forceReset?: boolean;
   turnId?: string;
+  fileContextRefs?: FileContextRef[];
+  messageContent?: AgentMessageContentBlock[];
 };
 
 type ResumePayload =
@@ -112,6 +118,8 @@ const runContexts = new Map<string, RunContext>();
 
 const buildStreamKey = (runId: string) => `agent:run:${runId}`;
 const buildMetaKey = (runId: string) => `agent:run:${runId}:meta`;
+const buildRunDedupeKey = (workspaceId: string, persona: string, turnId: string) =>
+  `agent:run:key:${workspaceId}:${persona}:${turnId}`;
 
 const stableNormalize = (value: unknown): unknown => {
   if (Array.isArray(value)) {
@@ -324,6 +332,8 @@ const serializeRunContext = (params: StartRunParams): string =>
     history: params.history,
     forceReset: params.forceReset,
     turnId: params.turnId,
+    fileContextRefs: params.fileContextRefs,
+    messageContent: params.messageContent,
   } satisfies PersistedRunContext);
 
 const parseRunContext = (raw: string | undefined): RunContext | undefined => {
@@ -350,6 +360,8 @@ const parseRunContext = (raw: string | undefined): RunContext | undefined => {
         history: Array.isArray(parsed.history) ? parsed.history : undefined,
         forceReset: typeof parsed.forceReset === 'boolean' ? parsed.forceReset : undefined,
         turnId: typeof parsed.turnId === 'string' ? parsed.turnId : undefined,
+        fileContextRefs: Array.isArray(parsed.fileContextRefs) ? parsed.fileContextRefs as FileContextRef[] : undefined,
+        messageContent: Array.isArray(parsed.messageContent) ? parsed.messageContent as AgentMessageContentBlock[] : undefined,
       },
     };
   } catch {
@@ -404,6 +416,15 @@ const markRunAwaitingApproval = async (runId: string, interruptPayload: string) 
 };
 
 export async function startAgentRun(params: StartRunParams): Promise<{ runId: string; status: AgentRunStatus }> {
+  if (params.turnId?.trim()) {
+    const existingRunId = await redisClient.get(buildRunDedupeKey(params.workspaceId, params.persona, params.turnId.trim()));
+    if (existingRunId) {
+      const existingMeta = await getRunMeta(existingRunId);
+      if (existingMeta && !['completed', 'failed', 'cancelled'].includes(existingMeta.status)) {
+        return { runId: existingRunId, status: existingMeta.status };
+      }
+    }
+  }
   const runId = randomUUID();
   const streamKey = buildStreamKey(runId);
   const metaKey = buildMetaKey(runId);
@@ -419,6 +440,13 @@ export async function startAgentRun(params: StartRunParams): Promise<{ runId: st
     pendingInterrupt: '',
     runContext: serializeRunContext(params),
   });
+  if (params.turnId?.trim()) {
+    await redisClient.set(
+      buildRunDedupeKey(params.workspaceId, params.persona, params.turnId.trim()),
+      runId,
+      { EX: STREAM_TTL_SECONDS },
+    );
+  }
   runContexts.set(runId, { params });
 
   // Fire and forget worker
@@ -632,6 +660,8 @@ async function runAgentRunWorker(
           forceReset: params.forceReset,
           signal: controller.signal,
           authToken: params.authToken,
+          fileContextRefs: params.fileContextRefs,
+          messageContent: params.messageContent,
         });
     upstream = response.data;
     upstream.on('data', (chunk: Buffer) => {

--- a/backend/src/services/agentService.ts
+++ b/backend/src/services/agentService.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import type { AxiosResponse } from "axios";
 import type { IncomingMessage } from "http";
+import type { FileContextRef } from '../../../packages/shared/src/types';
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8001";
 
@@ -21,6 +22,11 @@ const PAPER2SLIDES_TIMEOUT_MS = resolvePaper2SlidesTimeoutMs();
 export type AgentHistoryEntry = {
   role: string;
   content: string;
+};
+
+export type AgentMessageContentBlock = {
+  type: string;
+  [key: string]: unknown;
 };
 
 export type AgentDecision = {
@@ -51,6 +57,32 @@ type RunAgentOptions = {
   forceReset?: boolean;
   signal?: AbortSignal;
   authToken?: string;
+  fileContextRefs?: FileContextRef[];
+  messageContent?: AgentMessageContentBlock[];
+};
+
+export type AttachmentUnderstandingPayload = {
+  fileName: string;
+  mimeType: string;
+  contentB64: string;
+};
+
+export type AttachmentUnderstandingResponse = {
+  title?: string;
+  summary?: string;
+  outline?: string[];
+  markdown: string;
+  sections?: Array<{ heading: string; body: string }>;
+  extractedAssets?: Array<{
+    name: string;
+    mimeType: string;
+    contentB64: string;
+    sourcePath?: string | null;
+    caption?: string | null;
+    footnote?: string | null;
+  }>;
+  effectiveMode?: 'part' | 'parser' | 'hybrid';
+  status?: 'ready' | 'partial';
 };
 
 export async function runAgent(
@@ -67,6 +99,12 @@ export async function runAgent(
 
   if (options?.forceReset) {
     payload.forceReset = true;
+  }
+  if (options?.fileContextRefs?.length) {
+    payload.fileContextRefs = options.fileContextRefs;
+  }
+  if (options?.messageContent?.length) {
+    payload.messageContent = options.messageContent;
   }
 
   const headers: Record<string, string> = {};
@@ -93,6 +131,12 @@ export async function runAgentStream(
 
   if (options?.forceReset) {
     payload.forceReset = true;
+  }
+  if (options?.fileContextRefs?.length) {
+    payload.fileContextRefs = options.fileContextRefs;
+  }
+  if (options?.messageContent?.length) {
+    payload.messageContent = options.messageContent;
   }
 
   const headers: Record<string, string> = {};
@@ -221,6 +265,17 @@ export async function exportPaper2SlidesPptx(payload: {
   contentB64: string;
 }): Promise<{ pptxB64: string }> {
   const res = await client.post(`/paper2slides/export-pptx`, payload, {
+    maxContentLength: Infinity,
+    maxBodyLength: Infinity,
+    timeout: PAPER2SLIDES_TIMEOUT_MS,
+  });
+  return res.data;
+}
+
+export async function understandAttachment(
+  payload: AttachmentUnderstandingPayload,
+): Promise<AttachmentUnderstandingResponse> {
+  const res = await client.post('/attachments/understand', payload, {
     maxContentLength: Infinity,
     maxBodyLength: Infinity,
     timeout: PAPER2SLIDES_TIMEOUT_MS,

--- a/backend/src/services/attachmentPrepJobService.ts
+++ b/backend/src/services/attachmentPrepJobService.ts
@@ -1,0 +1,198 @@
+import { randomUUID } from 'crypto';
+import type { FileContextRef } from '../../../packages/shared/src/types';
+import { redisClient } from './redisService';
+import { WorkspaceService } from './workspaceService';
+import { GoogleDriveService } from './googleDriveService';
+import { FileService } from './fileService';
+import { DerivedArtifactService } from './derivedArtifactService';
+import { HttpError } from '../errors';
+
+type JobStatus = 'pending' | 'running' | 'ready' | 'failed';
+
+type AttachmentPrepJobResult = {
+  files: Array<Record<string, unknown>>;
+  fileContextRefs: FileContextRef[];
+  multimodalFileIds: number[];
+};
+
+type AttachmentPrepJob = {
+  id: string;
+  workspaceId: string;
+  conversationId: string;
+  turnId: string;
+  userId: string;
+  driveFileIds: string[];
+  sourceFileIds: number[];
+  status: JobStatus;
+  createdAt: string;
+  updatedAt: string;
+  error?: string;
+  result?: AttachmentPrepJobResult;
+};
+
+const JOB_TTL_SECONDS = 60 * 60 * 24;
+const jobKey = (jobId: string) => `attachment-prep:job:${jobId}`;
+const dedupeKey = (workspaceId: string, conversationId: string, turnId: string) =>
+  `attachment-prep:key:${workspaceId}:${conversationId}:${turnId}`;
+
+const isMultimodalEligibleMimeType = (mimeType: unknown): boolean => {
+  const value = String(mimeType || '').toLowerCase();
+  return value === 'application/pdf' || value.startsWith('image/');
+};
+
+export class AttachmentPrepJobService {
+  constructor(
+    private readonly workspaceService: WorkspaceService,
+    private readonly googleDriveService: GoogleDriveService,
+    private readonly fileService: FileService,
+    private readonly derivedArtifactService: DerivedArtifactService,
+  ) {}
+
+  private async loadJob(jobId: string): Promise<AttachmentPrepJob | null> {
+    try {
+      const raw = await redisClient.get(jobKey(jobId));
+      if (!raw) {
+        return null;
+      }
+      return JSON.parse(raw) as AttachmentPrepJob;
+    } catch (error) {
+      console.error('Failed to load attachment prep job from Redis', error);
+      return null;
+    }
+  }
+
+  private async saveJob(job: AttachmentPrepJob): Promise<void> {
+    try {
+      await redisClient.set(jobKey(job.id), JSON.stringify(job), { EX: JOB_TTL_SECONDS });
+      await redisClient.set(
+        dedupeKey(job.workspaceId, job.conversationId, job.turnId),
+        job.id,
+        { EX: JOB_TTL_SECONDS },
+      );
+    } catch (error) {
+      console.error('Failed to persist attachment prep job', error);
+    }
+  }
+
+  async createJob(params: {
+    workspaceId: string;
+    conversationId: string;
+    turnId: string;
+    userId: string;
+    driveFileIds?: string[];
+    sourceFileIds?: number[];
+  }): Promise<AttachmentPrepJob> {
+    const {
+      workspaceId,
+      conversationId,
+      turnId,
+      userId,
+      driveFileIds = [],
+      sourceFileIds = [],
+    } = params;
+    await this.workspaceService.ensureMembership(workspaceId, userId, { requireEdit: true });
+
+    const existingJobId = await redisClient.get(dedupeKey(workspaceId, conversationId, turnId));
+    if (existingJobId) {
+      const existingJob = await this.loadJob(existingJobId);
+      if (existingJob) {
+        return existingJob;
+      }
+    }
+
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    const job: AttachmentPrepJob = {
+      id,
+      workspaceId,
+      conversationId,
+      turnId,
+      userId,
+      driveFileIds: Array.from(new Set(driveFileIds.map((item) => item.trim()).filter(Boolean))),
+      sourceFileIds: Array.from(
+        new Set(
+          sourceFileIds
+            .map((value) => Number(value))
+            .filter((value) => Number.isFinite(value) && value > 0),
+        ),
+      ),
+      status: 'pending',
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.saveJob(job);
+    void this.runJob(id);
+    return job;
+  }
+
+  async getJob(jobId: string, userId: string): Promise<AttachmentPrepJob> {
+    const job = await this.loadJob(jobId);
+    if (!job) {
+      throw new HttpError(404, 'Attachment prep job not found');
+    }
+    await this.workspaceService.ensureMembership(job.workspaceId, userId, { requireEdit: true });
+    return job;
+  }
+
+  private async runJob(jobId: string): Promise<void> {
+    const job = await this.loadJob(jobId);
+    if (!job) {
+      return;
+    }
+
+    job.status = 'running';
+    job.updatedAt = new Date().toISOString();
+    await this.saveJob(job);
+
+    try {
+      const importedFiles = job.driveFileIds.length
+        ? await this.googleDriveService.importFiles(job.workspaceId, job.userId, job.driveFileIds)
+        : [];
+      const allSourceFileIds = Array.from(
+        new Set([
+          ...job.sourceFileIds,
+          ...importedFiles
+            .map((file) => Number(file.id))
+            .filter((value) => Number.isFinite(value) && value > 0),
+        ]),
+      );
+      const fileContextRefs = allSourceFileIds.length
+        ? await this.derivedArtifactService.ensureFileContextRefs(
+            job.workspaceId,
+            job.userId,
+            allSourceFileIds,
+            { waitForReady: true },
+          )
+        : [];
+      const failedRefs = fileContextRefs.filter((ref) => ref.status === 'failed');
+      if (failedRefs.length) {
+        throw new Error(
+          `Failed to prepare file context for: ${failedRefs.map((ref) => ref.sourceName).join(', ')}`,
+        );
+      }
+
+      const multimodalFileIds: number[] = [];
+      for (const ref of fileContextRefs) {
+        const file = await this.fileService.getFileRecord(Number(ref.sourceFileId), job.userId);
+        if (isMultimodalEligibleMimeType(file.mimeType)) {
+          multimodalFileIds.push(Number(ref.sourceFileId));
+        }
+      }
+
+      job.status = 'ready';
+      job.updatedAt = new Date().toISOString();
+      job.result = {
+        files: importedFiles as Array<Record<string, unknown>>,
+        fileContextRefs,
+        multimodalFileIds: Array.from(new Set(multimodalFileIds)),
+      };
+      job.error = undefined;
+      await this.saveJob(job);
+    } catch (error: any) {
+      job.status = 'failed';
+      job.updatedAt = new Date().toISOString();
+      job.error = error?.message || String(error);
+      await this.saveJob(job);
+    }
+  }
+}

--- a/backend/src/services/databaseService.ts
+++ b/backend/src/services/databaseService.ts
@@ -33,6 +33,7 @@ export class DatabaseService {
     await this.createMcpConnectionsTable();
     await this.createMcpConnectionGrantsTable();
     await this.createFilesTable();
+    await this.createDerivedArtifactsTable();
     await this.createCollabDocumentsTable();
     await this.createKnowledgeSourcesTable();
     await this.createConversationsTable();
@@ -300,6 +301,10 @@ export class DatabaseService {
         table.string('path').notNullable();
         table.string('mimeType');
         table.string('publicUrl');
+        table.string('sourceProvider', 64);
+        table.string('sourceExternalId');
+        table.string('sourceVersionFingerprint');
+        table.string('sourceUrl');
         table.uuid('createdBy').references('id').inTable('users');
         table.uuid('updatedBy').references('id').inTable('users');
         table.integer('version').notNullable().defaultTo(1);
@@ -307,10 +312,46 @@ export class DatabaseService {
         table.timestamp('updatedAt').notNullable().defaultTo(this.db.fn.now());
         table.unique(['workspaceId', 'name']);
         table.index(['workspaceId', 'updatedAt'], 'files_workspace_updated_idx');
+        table.index(
+          ['workspaceId', 'sourceProvider', 'sourceExternalId', 'sourceVersionFingerprint'],
+          'files_workspace_source_version_idx',
+        );
       });
       console.log('Created "files" table.');
     } else {
       await this.ensureFilesTableColumns();
+    }
+  }
+
+  private async createDerivedArtifactsTable(): Promise<void> {
+    const exists = await this.db.schema.hasTable('derived_artifacts');
+    if (!exists) {
+      await this.db.schema.createTable('derived_artifacts', (table) => {
+        table.uuid('id').primary();
+        table.uuid('workspaceId').notNullable().references('id').inTable('workspaces').onDelete('CASCADE');
+        table.integer('sourceFileId').notNullable().references('id').inTable('files').onDelete('CASCADE');
+        table.string('sourceVersionFingerprint').notNullable();
+        table.string('pipelineStage', 32).notNullable();
+        table.integer('artifactVersion').notNullable().defaultTo(1);
+        table.string('understandingMode', 16).notNullable();
+        table.string('status', 16).notNullable();
+        table.integer('derivedArtifactFileId').references('id').inTable('files').onDelete('SET NULL');
+        table.jsonb('summaryMetadataJson');
+        table.text('lastError');
+        table.uuid('createdBy').references('id').inTable('users');
+        table.uuid('updatedBy').references('id').inTable('users');
+        table.timestamp('createdAt').notNullable().defaultTo(this.db.fn.now());
+        table.timestamp('updatedAt').notNullable().defaultTo(this.db.fn.now());
+        table.unique(
+          ['workspaceId', 'sourceFileId', 'sourceVersionFingerprint', 'pipelineStage'],
+          { indexName: 'derived_artifacts_source_stage_uidx' },
+        );
+        table.index(['workspaceId', 'sourceFileId'], 'derived_artifacts_workspace_source_idx');
+        table.index(['workspaceId', 'status'], 'derived_artifacts_workspace_status_idx');
+      });
+      console.log('Created "derived_artifacts" table.');
+    } else {
+      await this.ensureDerivedArtifactsColumns();
     }
   }
 
@@ -422,9 +463,38 @@ export class DatabaseService {
   private async ensureFilesTableColumns(): Promise<void> {
     await this.ensureColumn('files', 'mimeType', (table) => table.string('mimeType'));
     await this.ensureColumn('files', 'publicUrl', (table) => table.string('publicUrl'));
+    await this.ensureColumn('files', 'sourceProvider', (table) => table.string('sourceProvider', 64));
+    await this.ensureColumn('files', 'sourceExternalId', (table) => table.string('sourceExternalId'));
+    await this.ensureColumn('files', 'sourceVersionFingerprint', (table) => table.string('sourceVersionFingerprint'));
+    await this.ensureColumn('files', 'sourceUrl', (table) => table.string('sourceUrl'));
     await this.ensureColumn('files', 'createdBy', (table) => table.uuid('createdBy'));
     await this.ensureColumn('files', 'updatedBy', (table) => table.uuid('updatedBy'));
     await this.ensureColumn('files', 'version', (table) => table.integer('version').notNullable().defaultTo(1));
+    await this.db.raw(
+      'CREATE INDEX IF NOT EXISTS files_workspace_source_version_idx ON files ("workspaceId", "sourceProvider", "sourceExternalId", "sourceVersionFingerprint")',
+    );
+  }
+
+  private async ensureDerivedArtifactsColumns(): Promise<void> {
+    await this.ensureColumn('derived_artifacts', 'artifactVersion', (table) => table.integer('artifactVersion').notNullable().defaultTo(1));
+    await this.ensureColumn('derived_artifacts', 'understandingMode', (table) => table.string('understandingMode', 16).notNullable().defaultTo('part'));
+    await this.ensureColumn('derived_artifacts', 'status', (table) => table.string('status', 16).notNullable().defaultTo('pending'));
+    await this.ensureColumn('derived_artifacts', 'derivedArtifactFileId', (table) => table.integer('derivedArtifactFileId').references('id').inTable('files').onDelete('SET NULL'));
+    await this.ensureColumn('derived_artifacts', 'summaryMetadataJson', (table) => table.jsonb('summaryMetadataJson'));
+    await this.ensureColumn('derived_artifacts', 'lastError', (table) => table.text('lastError'));
+    await this.ensureColumn('derived_artifacts', 'createdBy', (table) => table.uuid('createdBy'));
+    await this.ensureColumn('derived_artifacts', 'updatedBy', (table) => table.uuid('updatedBy'));
+    await this.ensureColumn('derived_artifacts', 'createdAt', (table) => table.timestamp('createdAt').defaultTo(this.db.fn.now()));
+    await this.ensureColumn('derived_artifacts', 'updatedAt', (table) => table.timestamp('updatedAt').defaultTo(this.db.fn.now()));
+    await this.db.raw(
+      'CREATE UNIQUE INDEX IF NOT EXISTS derived_artifacts_source_stage_uidx ON derived_artifacts ("workspaceId", "sourceFileId", "sourceVersionFingerprint", "pipelineStage")',
+    );
+    await this.db.raw(
+      'CREATE INDEX IF NOT EXISTS derived_artifacts_workspace_source_idx ON derived_artifacts ("workspaceId", "sourceFileId")',
+    );
+    await this.db.raw(
+      'CREATE INDEX IF NOT EXISTS derived_artifacts_workspace_status_idx ON derived_artifacts ("workspaceId", "status")',
+    );
   }
 
   private async ensureConversationMessagesColumns(): Promise<void> {

--- a/backend/src/services/derivedArtifactService.ts
+++ b/backend/src/services/derivedArtifactService.ts
@@ -1,0 +1,737 @@
+import { createHash, randomUUID } from 'crypto';
+import * as path from 'path';
+import type { Knex } from 'knex';
+import type { DerivedArtifactMode, DerivedArtifactStatus, FileContextRef } from '../../../packages/shared/src/types';
+import { DatabaseService } from './databaseService';
+import { FileService } from './fileService';
+import { WorkspaceService } from './workspaceService';
+import { understandAttachment } from './agentService';
+
+type PipelineStage = 'part-base' | 'parser-enrichment';
+
+type DerivedArtifactRecord = {
+  id: string;
+  workspaceId: string;
+  sourceFileId: number;
+  sourceVersionFingerprint: string;
+  pipelineStage: PipelineStage;
+  artifactVersion: number;
+  understandingMode: DerivedArtifactMode;
+  status: DerivedArtifactStatus;
+  derivedArtifactFileId?: number | null;
+  summaryMetadataJson?: {
+    summary?: string | null;
+    outline?: string[] | null;
+    sections?: Array<{ heading: string; body: string }> | null;
+    title?: string | null;
+    extractedAssets?: Array<{
+      path: string;
+      name: string;
+      mimeType: string;
+      caption?: string | null;
+      footnote?: string | null;
+    }> | null;
+  } | null;
+  lastError?: string | null;
+  createdBy?: string | null;
+  updatedBy?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+type SourceFileRecord = {
+  id: number;
+  name: string;
+  workspaceId: string;
+  mimeType?: string | null;
+  storageType: 'local' | 's3';
+  path: string;
+  publicUrl?: string | null;
+};
+
+type ArtifactBuildResult = {
+  markdown: string;
+  summary?: string | null;
+  outline?: string[] | null;
+  sections?: Array<{ heading: string; body: string }> | null;
+  title?: string | null;
+  extractedAssets?: Array<{
+    name: string;
+    mimeType: string;
+    contentB64: string;
+    sourcePath?: string | null;
+    caption?: string | null;
+    footnote?: string | null;
+  }>;
+  effectiveMode: DerivedArtifactMode;
+  status: Extract<DerivedArtifactStatus, 'ready' | 'partial'>;
+};
+
+const PART_BASE_STAGE: PipelineStage = 'part-base';
+const SYSTEM_ARTIFACT_ROOT = '.system/derived-artifacts';
+const SYSTEM_EXTRACTED_ASSET_ROOT = '.system/extracted-assets';
+const DEFAULT_SYNC_MAX_BYTES = 10 * 1024 * 1024;
+
+const normalizeStatus = (value: string): DerivedArtifactStatus =>
+  value === 'pending' || value === 'partial' || value === 'ready' || value === 'failed' || value === 'superseded'
+    ? value
+    : 'failed';
+
+const normalizeMode = (value: string): DerivedArtifactMode =>
+  value === 'parser' || value === 'hybrid' ? value : 'part';
+
+const resolveSyncMaxBytes = (): number => {
+  const raw = Number(process.env.FILE_UNDERSTANDING_SYNC_MAX_BYTES || DEFAULT_SYNC_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_SYNC_MAX_BYTES;
+};
+
+const isMarkdownLike = (fileName: string, mimeType?: string | null): boolean => {
+  const ext = path.extname(fileName).toLowerCase();
+  if (['.md', '.txt', '.csv', '.json', '.html', '.htm'].includes(ext)) {
+    return true;
+  }
+  return typeof mimeType === 'string' && mimeType.startsWith('text/');
+};
+
+const buildHiddenArtifactPath = (artifactId: string, version: number): string =>
+  path.posix.join(SYSTEM_ARTIFACT_ROOT, artifactId, `v${version}.md`);
+
+const buildHiddenExtractedAssetPath = (artifactId: string, fileName: string): string =>
+  path.posix.join(SYSTEM_EXTRACTED_ASSET_ROOT, artifactId, fileName);
+
+const buildFingerprint = (buffer: Buffer): string => createHash('sha256').update(buffer).digest('hex');
+
+const slugifyFileStem = (value: string): string => {
+  const stem = path.parse(value).name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem || 'asset';
+};
+
+const sanitizeAssetFileName = (index: number, requestedName: string, mimeType: string): string => {
+  const extFromName = path.extname(requestedName).toLowerCase();
+  const extFromMime = mimeType.toLowerCase() === 'image/jpeg'
+    ? '.jpg'
+    : mimeType.toLowerCase() === 'image/png'
+      ? '.png'
+      : mimeType.toLowerCase() === 'image/webp'
+        ? '.webp'
+        : mimeType.toLowerCase() === 'image/gif'
+          ? '.gif'
+          : '';
+  const ext = extFromName || extFromMime || '.png';
+  return `${String(index + 1).padStart(2, '0')}-${slugifyFileStem(requestedName)}${ext}`;
+};
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const AUTO_PROCESS_EXTENSIONS = new Set(['.pdf', '.docx', '.pptx']);
+
+const splitMarkdownSections = (markdown: string): Array<{ heading: string; body: string }> => {
+  const sections: Array<{ heading: string; body: string }> = [];
+  let currentHeading = 'Overview';
+  let currentBody: string[] = [];
+  for (const line of markdown.split(/\r?\n/)) {
+    const headingMatch = /^(#{1,6})\s+(.*)$/.exec(line.trim());
+    if (headingMatch) {
+      if (currentBody.length) {
+        sections.push({ heading: currentHeading, body: currentBody.join('\n').trim() });
+      }
+      currentHeading = headingMatch[2].trim() || 'Section';
+      currentBody = [];
+      continue;
+    }
+    currentBody.push(line);
+  }
+  if (currentBody.length) {
+    sections.push({ heading: currentHeading, body: currentBody.join('\n').trim() });
+  }
+  return sections.filter((section) => section.body);
+};
+
+const rewriteMarkdownAssetLinks = (
+  markdown: string,
+  assets: Array<{
+    sourcePath?: string | null;
+    workspacePath: string;
+    caption?: string | null;
+  }>,
+): string => {
+  let rewritten = markdown;
+  for (const asset of assets) {
+    const sourcePath = String(asset.sourcePath || '').trim().replace(/\\/g, '/');
+    if (!sourcePath) {
+      continue;
+    }
+    rewritten = rewritten.replace(new RegExp(escapeRegExp(sourcePath), 'g'), asset.workspacePath);
+  }
+  if (!assets.length) {
+    return rewritten;
+  }
+  const appendixLines = ['## Extracted Figures', ''];
+  for (const asset of assets) {
+    appendixLines.push(`### ${String(asset.caption || '').trim() || path.basename(asset.workspacePath)}`);
+    appendixLines.push('');
+    appendixLines.push(`![](${asset.workspacePath})`);
+    appendixLines.push('');
+  }
+  return `${rewritten.trim()}\n\n${appendixLines.join('\n').trim()}\n`;
+};
+
+export class DerivedArtifactService {
+  private db: Knex;
+  private fileService: FileService;
+  private workspaceService: WorkspaceService;
+  private inFlightJobs = new Map<string, Promise<void>>();
+  private readonly syncMaxBytes = resolveSyncMaxBytes();
+
+  constructor(databaseService: DatabaseService, fileService: FileService, workspaceService: WorkspaceService) {
+    this.db = databaseService.getDb();
+    this.fileService = fileService;
+    this.workspaceService = workspaceService;
+  }
+
+  logDiagnostics() {
+    const understandingMode = (process.env.FILE_UNDERSTANDING_MODE || 'part-first').trim() || 'part-first';
+    const parserPipeline = (process.env.RAG_PARSER_PIPELINE || 'raganything').trim() || 'raganything';
+    const parserMode = (
+      process.env.PARSER_ENRICHMENT_MODE
+      || process.env.RAGANYTHING_PARSER
+      || process.env.PARSER
+      || 'docling'
+    ).trim() || 'docling';
+    console.log(
+      `[backend] File understanding: mode=${understandingMode} parserPipeline=${parserPipeline} parserEnrichment=${parserMode} syncMaxBytes=${this.syncMaxBytes}`,
+    );
+  }
+
+  async ensureFileContextRefs(
+    workspaceId: string,
+    userId: string,
+    sourceFileIds: number[],
+    options?: { waitForReady?: boolean; timeoutMs?: number },
+  ): Promise<FileContextRef[]> {
+    await this.workspaceService.ensureMembership(workspaceId, userId, { requireEdit: true });
+    const refs: FileContextRef[] = [];
+    for (const sourceFileId of sourceFileIds) {
+      let ref = await this.ensureFileContextRef(workspaceId, userId, sourceFileId);
+      if (options?.waitForReady && ref.status === 'pending') {
+        ref = await this.waitForFileContextRef(workspaceId, userId, sourceFileId, ref.artifactId, options.timeoutMs);
+      }
+      refs.push(ref);
+    }
+    return refs;
+  }
+
+  isAutoProcessEligibleFile(fileName: string, mimeType?: string | null): boolean {
+    const ext = path.extname(String(fileName || '')).toLowerCase();
+    if (AUTO_PROCESS_EXTENSIONS.has(ext)) {
+      return true;
+    }
+    const normalizedMime = String(mimeType || '').toLowerCase();
+    return normalizedMime === 'application/pdf'
+      || normalizedMime === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+      || normalizedMime === 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+  }
+
+  async enqueueFileUnderstanding(
+    workspaceId: string,
+    userId: string,
+    sourceFileIds: number[],
+  ): Promise<FileContextRef[]> {
+    await this.workspaceService.ensureMembership(workspaceId, userId, { requireEdit: true });
+    const refs: FileContextRef[] = [];
+    for (const sourceFileId of sourceFileIds) {
+      const sourceFile = await this.fileService.getFileRecord(sourceFileId, userId) as SourceFileRecord;
+      if (!this.isAutoProcessEligibleFile(sourceFile.name, sourceFile.mimeType)) {
+        continue;
+      }
+      refs.push(await this.ensureFileContextRef(workspaceId, userId, sourceFileId, { forceAsync: true }));
+    }
+    return refs;
+  }
+
+  async listFileUnderstandingStates(
+    workspaceId: string,
+    userId: string,
+    sourceFileIds: number[],
+  ): Promise<Map<number, {
+    status: DerivedArtifactStatus;
+    mode: DerivedArtifactMode;
+    error: string | null;
+    derivedArtifactFileId: number | null;
+  }>> {
+    await this.workspaceService.ensureMembership(workspaceId, userId);
+    if (!sourceFileIds.length) {
+      return new Map();
+    }
+    const rows = await this.db<DerivedArtifactRecord>('derived_artifacts')
+      .where({ workspaceId, pipelineStage: PART_BASE_STAGE })
+      .whereIn('sourceFileId', sourceFileIds)
+      .whereNot({ status: 'superseded' })
+      .orderBy([{ column: 'updatedAt', order: 'desc' }, { column: 'createdAt', order: 'desc' }]);
+    const states = new Map<number, {
+      status: DerivedArtifactStatus;
+      mode: DerivedArtifactMode;
+      error: string | null;
+      derivedArtifactFileId: number | null;
+    }>();
+    for (const row of rows) {
+      const sourceFileId = Number(row.sourceFileId);
+      if (!Number.isFinite(sourceFileId) || states.has(sourceFileId)) {
+        continue;
+      }
+      states.set(sourceFileId, {
+        status: normalizeStatus(row.status),
+        mode: normalizeMode(row.understandingMode),
+        error: row.lastError ?? null,
+        derivedArtifactFileId: row.derivedArtifactFileId ? Number(row.derivedArtifactFileId) : null,
+      });
+    }
+    return states;
+  }
+
+  async purgeSourceArtifacts(workspaceId: string, sourceFileId: number, userId: string): Promise<void> {
+    const rows = await this.db<DerivedArtifactRecord>('derived_artifacts')
+      .where({ workspaceId, sourceFileId });
+    const siblingRows = await this.db<DerivedArtifactRecord>('derived_artifacts')
+      .where({ workspaceId })
+      .whereNot({ sourceFileId });
+    const siblingAssetPaths = new Set(
+      siblingRows.flatMap((row) =>
+        (row.summaryMetadataJson?.extractedAssets || [])
+          .map((asset) => String(asset?.path || '').trim())
+          .filter(Boolean),
+      ),
+    );
+    for (const row of rows) {
+      if (row.derivedArtifactFileId) {
+        const sharedArtifactRef = await this.db<DerivedArtifactRecord>('derived_artifacts')
+          .where({ workspaceId, derivedArtifactFileId: row.derivedArtifactFileId })
+          .whereNot({ id: row.id })
+          .first();
+        if (!sharedArtifactRef) {
+          try {
+            await this.fileService.deleteFile(Number(row.derivedArtifactFileId), userId);
+          } catch (error) {
+            console.error('Failed to delete hidden derived artifact file', { workspaceId, sourceFileId, rowId: row.id, error });
+          }
+        }
+      }
+      const assetPaths = (row.summaryMetadataJson?.extractedAssets || [])
+        .map((asset) => String(asset?.path || '').trim())
+        .filter(Boolean);
+      for (const assetPath of assetPaths) {
+        if (siblingAssetPaths.has(assetPath)) {
+          continue;
+        }
+        const assetFileId = await this.lookupFileIdByName(workspaceId, assetPath);
+        if (!assetFileId) {
+          continue;
+        }
+        try {
+          await this.fileService.deleteFile(Number(assetFileId), userId);
+        } catch (error) {
+          console.error('Failed to delete hidden extracted asset file', {
+            workspaceId,
+            sourceFileId,
+            rowId: row.id,
+            fileId: assetFileId,
+            error,
+          });
+        }
+      }
+    }
+    await this.db('derived_artifacts').where({ workspaceId, sourceFileId }).del();
+  }
+
+  private async ensureFileContextRef(
+    workspaceId: string,
+    userId: string,
+    sourceFileId: number,
+    options?: { forceAsync?: boolean },
+  ): Promise<FileContextRef> {
+    const sourceFile = await this.fileService.getFileRecord(sourceFileId, userId) as SourceFileRecord;
+    const buffer = await this.fileService.readFileBuffer(sourceFile);
+    const fingerprint = buildFingerprint(buffer);
+    const existing = await this.db<DerivedArtifactRecord>('derived_artifacts')
+      .where({
+        workspaceId,
+        sourceFileId,
+        sourceVersionFingerprint: fingerprint,
+        pipelineStage: PART_BASE_STAGE,
+      })
+      .first();
+
+    if (existing) {
+      if (existing.status === 'pending') {
+        this.scheduleArtifactBuild(existing.id, workspaceId, userId, sourceFile, buffer);
+      }
+      return this.toFileContextRef(existing, sourceFile);
+    }
+
+    const reusable = await this.findReusableArtifact(workspaceId, sourceFileId, fingerprint);
+    if (reusable) {
+      const cloned = await this.cloneArtifactForSource(workspaceId, userId, sourceFile, reusable);
+      return this.toFileContextRef(cloned, sourceFile);
+    }
+
+    const artifactId = randomUUID();
+    const shouldProcessSync = !options?.forceAsync && buffer.byteLength <= this.syncMaxBytes;
+    const initialStatus: DerivedArtifactStatus = 'pending';
+    const initialRecord: DerivedArtifactRecord = {
+      id: artifactId,
+      workspaceId,
+      sourceFileId,
+      sourceVersionFingerprint: fingerprint,
+      pipelineStage: PART_BASE_STAGE,
+      artifactVersion: 1,
+      understandingMode: 'part',
+      status: initialStatus,
+      summaryMetadataJson: null,
+      lastError: null,
+      createdBy: userId,
+      updatedBy: userId,
+    };
+
+    await this.db('derived_artifacts').insert({
+      ...initialRecord,
+      createdAt: this.db.fn.now(),
+      updatedAt: this.db.fn.now(),
+    });
+    await this.db('derived_artifacts')
+      .where({ workspaceId, sourceFileId, pipelineStage: PART_BASE_STAGE })
+      .whereNot({ id: artifactId })
+      .whereNot({ status: 'superseded' })
+      .update({ status: 'superseded', updatedBy: userId, updatedAt: this.db.fn.now() });
+
+    if (!shouldProcessSync) {
+      this.scheduleArtifactBuild(artifactId, workspaceId, userId, sourceFile, buffer);
+      return this.toFileContextRef(initialRecord, sourceFile);
+    }
+
+    try {
+      const built = await this.buildAndPersistArtifact(initialRecord, userId, sourceFile, buffer);
+      return this.toFileContextRef(built, sourceFile);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to build derived artifact';
+      await this.db('derived_artifacts')
+        .where({ id: artifactId })
+        .update({
+          status: 'failed',
+          lastError: message,
+          updatedBy: userId,
+          updatedAt: this.db.fn.now(),
+        });
+      const failed = await this.db<DerivedArtifactRecord>('derived_artifacts').where({ id: artifactId }).first();
+      return this.toFileContextRef(
+        failed || { ...initialRecord, status: 'failed', lastError: message },
+        sourceFile,
+      );
+    }
+  }
+
+  private async findReusableArtifact(
+    workspaceId: string,
+    sourceFileId: number,
+    fingerprint: string,
+  ): Promise<DerivedArtifactRecord | null> {
+    const row = await this.db<DerivedArtifactRecord>('derived_artifacts')
+      .where({
+        workspaceId,
+        sourceVersionFingerprint: fingerprint,
+        pipelineStage: PART_BASE_STAGE,
+      })
+      .whereNotNull('derivedArtifactFileId')
+      .whereIn('status', ['ready', 'partial'])
+      .whereNot({ sourceFileId })
+      .orderBy([{ column: 'updatedAt', order: 'desc' }, { column: 'createdAt', order: 'desc' }])
+      .first();
+    return row || null;
+  }
+
+  private async cloneArtifactForSource(
+    workspaceId: string,
+    userId: string,
+    sourceFile: SourceFileRecord,
+    reusable: DerivedArtifactRecord,
+  ): Promise<DerivedArtifactRecord> {
+    const artifactId = randomUUID();
+    const summaryMetadata = reusable.summaryMetadataJson || {};
+    const clonedRecord: DerivedArtifactRecord = {
+      id: artifactId,
+      workspaceId,
+      sourceFileId: Number(sourceFile.id),
+      sourceVersionFingerprint: reusable.sourceVersionFingerprint,
+      pipelineStage: PART_BASE_STAGE,
+      artifactVersion: 1,
+      understandingMode: normalizeMode(reusable.understandingMode),
+      status: normalizeStatus(reusable.status),
+      derivedArtifactFileId: reusable.derivedArtifactFileId ? Number(reusable.derivedArtifactFileId) : null,
+      summaryMetadataJson: {
+        ...summaryMetadata,
+        title: summaryMetadata.title ?? path.basename(sourceFile.name),
+      },
+      lastError: reusable.lastError ?? null,
+      createdBy: userId,
+      updatedBy: userId,
+    };
+
+    await this.db('derived_artifacts').insert({
+      ...clonedRecord,
+      createdAt: this.db.fn.now(),
+      updatedAt: this.db.fn.now(),
+    });
+    return (await this.db<DerivedArtifactRecord>('derived_artifacts').where({ id: artifactId }).first()) || clonedRecord;
+  }
+
+  private async lookupFileIdByName(workspaceId: string, name: string): Promise<number | null> {
+    const row = await this.db('files').where({ workspaceId, name }).first();
+    return row?.id ? Number(row.id) : null;
+  }
+
+  private scheduleArtifactBuild(
+    artifactId: string,
+    workspaceId: string,
+    userId: string,
+    sourceFile: SourceFileRecord,
+    buffer: Buffer,
+  ) {
+    if (this.inFlightJobs.has(artifactId)) {
+      return;
+    }
+    const promise = this.buildArtifactInBackground(artifactId, workspaceId, userId, sourceFile, buffer)
+      .finally(() => {
+        this.inFlightJobs.delete(artifactId);
+      });
+    this.inFlightJobs.set(artifactId, promise);
+  }
+
+  private async waitForFileContextRef(
+    workspaceId: string,
+    userId: string,
+    sourceFileId: number,
+    artifactId: string,
+    timeoutMs = 120000,
+  ): Promise<FileContextRef> {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < timeoutMs) {
+      const row = await this.db<DerivedArtifactRecord>('derived_artifacts').where({ id: artifactId, workspaceId }).first();
+      if (!row) {
+        throw new Error(`Derived artifact ${artifactId} not found`);
+      }
+      if (row.status !== 'pending') {
+        const sourceFile = await this.fileService.getFileRecord(sourceFileId, userId);
+        return this.toFileContextRef(row, sourceFile as SourceFileRecord);
+      }
+      const inFlight = this.inFlightJobs.get(artifactId);
+      if (inFlight) {
+        try {
+          await Promise.race([
+            inFlight,
+            new Promise((resolve) => setTimeout(resolve, 1000)),
+          ]);
+        } catch {
+          // Ignore here and let the DB row state determine the final result.
+        }
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    }
+    const sourceFile = await this.fileService.getFileRecord(sourceFileId, userId);
+    const fallback = await this.db<DerivedArtifactRecord>('derived_artifacts').where({ id: artifactId, workspaceId }).first();
+    if (!fallback) {
+      throw new Error(`Derived artifact ${artifactId} not found`);
+    }
+    return this.toFileContextRef(fallback, sourceFile as SourceFileRecord);
+  }
+
+  private async buildArtifactInBackground(
+    artifactId: string,
+    workspaceId: string,
+    userId: string,
+    sourceFile: SourceFileRecord,
+    buffer: Buffer,
+  ) {
+    try {
+      const row = await this.db<DerivedArtifactRecord>('derived_artifacts').where({ id: artifactId, workspaceId }).first();
+      if (!row || row.status !== 'pending') {
+        return;
+      }
+      await this.buildAndPersistArtifact(row, userId, sourceFile, buffer);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to build derived artifact';
+      console.error('Derived artifact build failed', { artifactId, workspaceId, sourceFileId: sourceFile.id, error });
+      await this.db('derived_artifacts')
+        .where({ id: artifactId })
+        .update({
+          status: 'failed',
+          lastError: message,
+          updatedBy: userId,
+          updatedAt: this.db.fn.now(),
+        });
+    }
+  }
+
+  private async buildAndPersistArtifact(
+    row: DerivedArtifactRecord,
+    userId: string,
+    sourceFile: SourceFileRecord,
+    buffer: Buffer,
+  ): Promise<DerivedArtifactRecord> {
+    const built = await this.buildArtifactContent(sourceFile, buffer);
+    const existingAssetFiles = await this.db('files')
+      .where({ workspaceId: row.workspaceId })
+      .whereLike('name', `${buildHiddenExtractedAssetPath(row.id, '')}%`);
+    for (const assetFile of existingAssetFiles) {
+      await this.fileService.deleteFile(Number(assetFile.id), userId);
+    }
+    const persistedAssets: Array<{
+      path: string;
+      name: string;
+      mimeType: string;
+      caption?: string | null;
+      footnote?: string | null;
+    }> = [];
+    for (const [index, asset] of (built.extractedAssets || []).entries()) {
+      const fileName = sanitizeAssetFileName(index, asset.name, asset.mimeType);
+      const assetPath = buildHiddenExtractedAssetPath(row.id, fileName);
+      const created = await this.fileService.createFile(
+        row.workspaceId,
+        assetPath,
+        Buffer.from(asset.contentB64, 'base64'),
+        asset.mimeType,
+        userId,
+        { forceLocal: true },
+      );
+      persistedAssets.push({
+        path: String(created.name || assetPath).replace(/\\/g, '/'),
+        name: fileName,
+        mimeType: asset.mimeType,
+        caption: asset.caption || null,
+        footnote: asset.footnote || null,
+      });
+    }
+    const markdownWithExtractedAssets = rewriteMarkdownAssetLinks(
+      built.markdown,
+      persistedAssets.map((asset, index) => ({
+        sourcePath: (built.extractedAssets || [])[index]?.sourcePath || null,
+        workspacePath: asset.path,
+        caption: asset.caption || null,
+      })),
+    );
+    const artifactPath = buildHiddenArtifactPath(row.id, row.artifactVersion);
+    let derivedFileId = row.derivedArtifactFileId ?? null;
+
+    if (derivedFileId) {
+      await this.fileService.updateFile(derivedFileId, markdownWithExtractedAssets, userId);
+    } else {
+      const hiddenFile = await this.fileService.createTextFile(
+        row.workspaceId,
+        artifactPath,
+        markdownWithExtractedAssets,
+        userId,
+        'text/markdown',
+      );
+      derivedFileId = Number(hiddenFile.id);
+    }
+
+    await this.db('derived_artifacts')
+      .where({ id: row.id })
+      .update({
+        status: built.status,
+        understandingMode: built.effectiveMode,
+        derivedArtifactFileId: derivedFileId,
+        summaryMetadataJson: {
+          summary: built.summary ?? null,
+          outline: built.outline ?? null,
+          sections: built.sections ?? null,
+          title: built.title ?? path.basename(sourceFile.name),
+          extractedAssets: persistedAssets,
+        },
+        lastError: null,
+        updatedBy: userId,
+        updatedAt: this.db.fn.now(),
+      });
+
+    const updated = await this.db<DerivedArtifactRecord>('derived_artifacts').where({ id: row.id }).first();
+    if (!updated) {
+      throw new Error('Derived artifact disappeared after update');
+    }
+    return updated;
+  }
+
+  private async buildArtifactContent(sourceFile: SourceFileRecord, buffer: Buffer): Promise<ArtifactBuildResult> {
+    if (isMarkdownLike(sourceFile.name, sourceFile.mimeType)) {
+      const rawText = buffer.toString('utf-8');
+      const title = path.basename(sourceFile.name);
+      const summary = rawText.split(/\r?\n/).map((line) => line.trim()).find(Boolean) || title;
+      const markdown = `# ${title}\n\n## Summary\n\n${summary}\n\n## Source Content\n\n${rawText}`;
+      return {
+        markdown,
+        summary,
+        outline: splitMarkdownSections(markdown).map((section) => section.heading),
+        sections: splitMarkdownSections(markdown),
+        title,
+        effectiveMode: 'part',
+        status: 'ready',
+      };
+    }
+
+    const response = await understandAttachment({
+      fileName: sourceFile.name,
+      mimeType: sourceFile.mimeType || 'application/octet-stream',
+      contentB64: buffer.toString('base64'),
+    });
+    const title = response.title || path.basename(sourceFile.name);
+    const sections = Array.isArray(response.sections) && response.sections.length
+      ? response.sections
+      : splitMarkdownSections(response.markdown || '');
+    return {
+      markdown: response.markdown,
+      summary: response.summary || null,
+      outline: Array.isArray(response.outline) ? response.outline : sections.map((section) => section.heading),
+      sections,
+      title,
+      extractedAssets: Array.isArray(response.extractedAssets)
+        ? response.extractedAssets
+            .filter((asset) =>
+              Boolean(
+                asset
+                && typeof asset === 'object'
+                && typeof asset.contentB64 === 'string'
+                && asset.contentB64.trim(),
+              ),
+            )
+            .map((asset) => ({
+              name: String(asset.name || 'image.png'),
+              mimeType: String(asset.mimeType || 'image/png'),
+              contentB64: String(asset.contentB64 || ''),
+              sourcePath: typeof asset.sourcePath === 'string' ? asset.sourcePath : null,
+              caption: typeof asset.caption === 'string' ? asset.caption : null,
+              footnote: typeof asset.footnote === 'string' ? asset.footnote : null,
+            }))
+        : [],
+      effectiveMode: normalizeMode(response.effectiveMode || 'part'),
+      status: response.status === 'partial' ? 'partial' : 'ready',
+    };
+  }
+
+  private toFileContextRef(row: DerivedArtifactRecord, sourceFile: SourceFileRecord): FileContextRef {
+    const summaryMetadata = row.summaryMetadataJson || {};
+    return {
+      sourceFileId: Number(row.sourceFileId),
+      sourceName: sourceFile.name,
+      sourceMimeType: sourceFile.mimeType ?? null,
+      sourceVersionFingerprint: row.sourceVersionFingerprint,
+      artifactId: row.id,
+      artifactVersion: Number(row.artifactVersion || 1),
+      derivedArtifactFileId: row.derivedArtifactFileId ? Number(row.derivedArtifactFileId) : null,
+      derivedArtifactPath: row.derivedArtifactFileId ? buildHiddenArtifactPath(row.id, Number(row.artifactVersion || 1)) : null,
+      effectiveMode: normalizeMode(row.understandingMode),
+      status: normalizeStatus(row.status),
+      summary: typeof summaryMetadata.summary === 'string' ? summaryMetadata.summary : null,
+      lastError: row.lastError ?? null,
+    };
+  }
+}

--- a/backend/src/services/fileService.ts
+++ b/backend/src/services/fileService.ts
@@ -6,10 +6,9 @@ import { Knex } from 'knex';
 import { WorkspaceService } from './workspaceService';
 import { ConflictError, NotFoundError } from '../errors';
 import { RagQueueService } from './ragQueueService';
+import { resolveWorkspaceRoot } from '../config/workspaceRoot';
 
-const WORKSPACE_DIR = process.env.WORKSPACE_ROOT
-  ? path.resolve(process.env.WORKSPACE_ROOT)
-  : path.join(process.cwd(), 'workspaces');
+const WORKSPACE_DIR = resolveWorkspaceRoot();
 const TEXT_MIME_TYPES = [
   'text/plain',
   'text/markdown',
@@ -20,7 +19,8 @@ const TEXT_MIME_TYPES = [
 ];
 
 const TEXT_FILE_EXTENSIONS = ['.md', '.mermaid', '.txt', '.json', '.html', '.css', '.js', '.ts', '.tsx', '.jsx', '.svg', '.csv'];
-const RAG_INDEXABLE_EXTENSIONS = new Set(['.pdf', '.doc', '.docx', '.md']);
+const DIRECT_RAG_INDEXABLE_EXTENSIONS = new Set(['.doc', '.md']);
+const ARTIFACT_MANAGED_RAG_EXTENSIONS = new Set(['.pdf', '.docx', '.pptx']);
 const BINARY_MIME_TYPES_BY_EXTENSION: Record<string, string> = {
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
@@ -43,12 +43,23 @@ export class FileService {
   private db: Knex;
   private workspaceService: WorkspaceService;
   private ragQueueService?: RagQueueService;
+  private derivedArtifactCleanup?: {
+    purgeSourceArtifacts: (workspaceId: string, sourceFileId: number, userId: string) => Promise<void>;
+  };
 
   constructor(databaseService: DatabaseService, workspaceService: WorkspaceService, ragQueueService?: RagQueueService) {
     this.s3Service = new S3Service();
     this.db = databaseService.getDb();
     this.workspaceService = workspaceService;
     this.ragQueueService = ragQueueService;
+  }
+
+  setDerivedArtifactCleanup(
+    derivedArtifactCleanup: {
+      purgeSourceArtifacts: (workspaceId: string, sourceFileId: number, userId: string) => Promise<void>;
+    },
+  ) {
+    this.derivedArtifactCleanup = derivedArtifactCleanup;
   }
 
   async getFiles(workspaceId: string, userId: string) {
@@ -84,9 +95,18 @@ export class FileService {
     return BINARY_MIME_TYPES_BY_EXTENSION[ext] || null;
   }
 
-  private isRagIndexable(fileName: string): boolean {
+  private usesArtifactManagedRag(fileName: string): boolean {
     const ext = path.extname(fileName).toLowerCase();
-    return RAG_INDEXABLE_EXTENSIONS.has(ext);
+    return ARTIFACT_MANAGED_RAG_EXTENSIONS.has(ext);
+  }
+
+  private isDirectRagIndexable(fileName: string): boolean {
+    const ext = path.extname(fileName).toLowerCase();
+    return DIRECT_RAG_INDEXABLE_EXTENSIONS.has(ext);
+  }
+
+  private shouldEnqueueDirectRagIndex(fileName: string): boolean {
+    return !this.usesArtifactManagedRag(fileName) && this.isDirectRagIndexable(fileName);
   }
 
   private normalizeRelativePath(fileName: string): string {
@@ -199,7 +219,13 @@ export class FileService {
     fileBuffer: Buffer,
     mimeType: string,
     userId: string,
-    options?: { forceLocal?: boolean },
+    options?: {
+      forceLocal?: boolean;
+      sourceProvider?: string | null;
+      sourceExternalId?: string | null;
+      sourceVersionFingerprint?: string | null;
+      sourceUrl?: string | null;
+    },
   ) {
     await this.workspaceService.ensureMembership(workspaceId, userId, { requireEdit: true });
     const relativePath = this.normalizeRelativePath(fileName);
@@ -236,14 +262,18 @@ export class FileService {
       path: filePath,
       mimeType,
       publicUrl,
+      sourceProvider: options?.sourceProvider || null,
+      sourceExternalId: options?.sourceExternalId || null,
+      sourceVersionFingerprint: options?.sourceVersionFingerprint || null,
+      sourceUrl: options?.sourceUrl || null,
       createdBy: userId,
       updatedBy: userId,
     }).returning('*');
 
     await this.workspaceService.touchWorkspace(workspaceId, userId);
 
-    if (this.isRagIndexable(relativePath)) {
-      // Enqueue for RAG indexing (best-effort). The agent service will consume this job.
+    if (this.shouldEnqueueDirectRagIndex(relativePath)) {
+      // Enqueue direct file indexing only for files whose source content remains the canonical RAG input.
       try {
         await this.ragQueueService?.enqueueFileUpsert({
           workspaceId,
@@ -301,6 +331,48 @@ export class FileService {
     }
   }
 
+  async getFileRecord(fileId: number, userId: string, options?: { requireEdit?: boolean }) {
+    const file = await this.db('files').where({ id: fileId }).first();
+    if (!file) {
+      throw new NotFoundError('File not found');
+    }
+    await this.workspaceService.ensureMembership(file.workspaceId, userId, options);
+    await this.ensurePublicUrl(file);
+    return file;
+  }
+
+  async findImportedExternalFile(
+    workspaceId: string,
+    userId: string,
+    params: {
+      sourceProvider: string;
+      sourceExternalId: string;
+      sourceVersionFingerprint: string;
+    },
+  ) {
+    await this.workspaceService.ensureMembership(workspaceId, userId);
+    const file = await this.db('files')
+      .where({
+        workspaceId,
+        sourceProvider: params.sourceProvider,
+        sourceExternalId: params.sourceExternalId,
+        sourceVersionFingerprint: params.sourceVersionFingerprint,
+      })
+      .first();
+    if (!file) {
+      return null;
+    }
+    await this.ensurePublicUrl(file);
+    return file;
+  }
+
+  async readFileBuffer(file: any): Promise<Buffer> {
+    if (file.storageType === 'local') {
+      return fs.readFile(file.path);
+    }
+    return this.s3Service.getFile(file.path);
+  }
+
   async updateFile(fileId: number, content: string, userId: string, expectedVersion?: number) {
     const file = await this.db('files').where({ id: fileId }).first();
     if (!file) {
@@ -328,8 +400,8 @@ export class FileService {
 
     await this.workspaceService.touchWorkspace(file.workspaceId, userId);
 
-    if (this.isRagIndexable(file.name)) {
-      // Re-enqueue for RAG indexing (best-effort).
+    if (this.shouldEnqueueDirectRagIndex(file.name)) {
+      // Re-enqueue direct file indexing only when the source file itself is the canonical RAG document.
       try {
         await this.ragQueueService?.enqueueFileUpsert({
           workspaceId: file.workspaceId,
@@ -387,6 +459,10 @@ export class FileService {
 
     await this.workspaceService.ensureMembership(file.workspaceId, userId, { requireEdit: true });
 
+    if (this.derivedArtifactCleanup) {
+      await this.derivedArtifactCleanup.purgeSourceArtifacts(file.workspaceId, fileId, userId);
+    }
+
     const localPath = this.getLocalPath(file.workspaceId, file.name);
     if (file.storageType === 'local') {
       try {
@@ -412,14 +488,16 @@ export class FileService {
     await this.db('files').where({ id: fileId }).del();
     await this.workspaceService.touchWorkspace(file.workspaceId, userId);
 
-    // Best-effort: remove from RAG index.
-    try {
-      await this.ragQueueService?.enqueueFileDelete({
-        workspaceId: file.workspaceId,
-        relativePath: file.name,
-      });
-    } catch (error) {
-      console.error('Failed to enqueue RAG delete job', error);
+    if (this.shouldEnqueueDirectRagIndex(file.name)) {
+      // Best-effort: remove direct-indexed source files from the RAG index.
+      try {
+        await this.ragQueueService?.enqueueFileDelete({
+          workspaceId: file.workspaceId,
+          relativePath: file.name,
+        });
+      } catch (error) {
+        console.error('Failed to enqueue RAG delete job', error);
+      }
     }
   }
 
@@ -443,6 +521,12 @@ export class FileService {
       .andWhere((query) => {
         query.where('name', normalizedFolder).orWhere('name', 'like', `${prefix}%`);
       });
+
+    if (this.derivedArtifactCleanup) {
+      for (const file of filesInFolder) {
+        await this.derivedArtifactCleanup.purgeSourceArtifacts(workspaceId, Number(file.id), userId);
+      }
+    }
 
     for (const file of filesInFolder) {
       const localPath = this.getLocalPath(workspaceId, file.name);
@@ -483,6 +567,9 @@ export class FileService {
     await this.workspaceService.touchWorkspace(workspaceId, userId);
 
     for (const file of filesInFolder) {
+      if (!this.shouldEnqueueDirectRagIndex(file.name)) {
+        continue;
+      }
       try {
         await this.ragQueueService?.enqueueFileDelete({
           workspaceId,
@@ -509,7 +596,7 @@ export class FileService {
     const currentVersion = this.assertVersion(file.version, expectedVersion);
     const nextVersion = currentVersion + 1;
     const currentRelativePath = this.normalizeRelativePath(file.name);
-    const wasRagIndexable = this.isRagIndexable(currentRelativePath);
+    const wasDirectRagIndexable = this.shouldEnqueueDirectRagIndex(currentRelativePath);
     const destinationRelativePath = target.path !== undefined
       ? (() => {
           const destinationFolder = this.normalizeRelativeFolderPath(target.path || '');
@@ -526,7 +613,7 @@ export class FileService {
             ? normalizedNewName
             : path.posix.join(currentDir, normalizedNewName);
         })();
-    const isDestinationRagIndexable = this.isRagIndexable(destinationRelativePath);
+    const isDestinationDirectRagIndexable = this.shouldEnqueueDirectRagIndex(destinationRelativePath);
 
     if (destinationRelativePath === currentRelativePath) {
       return file;
@@ -578,7 +665,7 @@ export class FileService {
 
     await this.workspaceService.touchWorkspace(file.workspaceId, userId);
 
-    if (wasRagIndexable) {
+    if (wasDirectRagIndexable) {
       try {
         await this.ragQueueService?.enqueueFileDelete({
           workspaceId: file.workspaceId,
@@ -589,7 +676,7 @@ export class FileService {
       }
     }
 
-    if (isDestinationRagIndexable) {
+    if (isDestinationDirectRagIndexable) {
       try {
         await this.ragQueueService?.enqueueFileUpsert({
           workspaceId: file.workspaceId,

--- a/backend/src/services/googleDriveService.ts
+++ b/backend/src/services/googleDriveService.ts
@@ -1,0 +1,690 @@
+import { createHash } from 'crypto';
+import path from 'path';
+import { HttpError } from '../errors';
+import { FileService } from './fileService';
+import { GoogleOAuthService } from './googleOAuthService';
+
+const DRIVE_API_BASE = 'https://www.googleapis.com/drive/v3';
+const DOCS_API_BASE = 'https://docs.googleapis.com/v1/documents';
+const SHEETS_API_BASE = 'https://sheets.googleapis.com/v4/spreadsheets';
+const GOOGLE_DOC_MIME = 'application/vnd.google-apps.document';
+const GOOGLE_SHEET_MIME = 'application/vnd.google-apps.spreadsheet';
+const GOOGLE_SLIDE_MIME = 'application/vnd.google-apps.presentation';
+const GOOGLE_FOLDER_MIME = 'application/vnd.google-apps.folder';
+const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+const PDF_MIME = 'application/pdf';
+const PPTX_MIME = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+
+type WorkspaceFile = {
+  id: string | number;
+  name: string;
+  workspaceId?: string;
+  storageType?: 'local' | 's3';
+  path?: string;
+  mimeType?: string | null;
+  publicUrl?: string | null;
+  content?: string;
+};
+
+type GoogleDrivePickerScope = 'recent' | 'my-drive' | 'shared';
+
+type GoogleDrivePickerItem = {
+  id: string;
+  name: string;
+  mimeType: string;
+  webViewUrl?: string | null;
+  modifiedTime?: string | null;
+  ownerNames?: string[];
+  size?: string | null;
+  iconHint: 'docs' | 'sheets' | 'slides' | 'pdf' | 'image' | 'file';
+  scope?: GoogleDrivePickerScope;
+};
+
+type GoogleDriveSearchResult = {
+  files: GoogleDrivePickerItem[];
+  nextPageToken?: string | null;
+};
+
+type DriveOwner = {
+  displayName?: string;
+};
+
+type DriveFileMetadata = {
+  id: string;
+  name: string;
+  mimeType: string;
+  webViewLink?: string;
+  modifiedTime?: string;
+  size?: string;
+  owners?: DriveOwner[];
+};
+
+type GoogleDocsDocument = {
+  title?: string;
+  body?: {
+    content?: GoogleDocsStructuralElement[];
+  };
+};
+
+type GoogleDocsStructuralElement = {
+  paragraph?: {
+    elements?: Array<{
+      textRun?: {
+        content?: string;
+      };
+    }>;
+    paragraphStyle?: {
+      namedStyleType?: string;
+    };
+  };
+  table?: {
+    tableRows?: Array<{
+      tableCells?: Array<{
+        content?: GoogleDocsStructuralElement[];
+      }>;
+    }>;
+  };
+  tableOfContents?: {
+    content?: GoogleDocsStructuralElement[];
+  };
+};
+
+type ImportPayload = {
+  fileName: string;
+  mimeType: string;
+  buffer: Buffer;
+  forceLocal?: boolean;
+};
+
+type PreparedImport = {
+  fileId: string;
+  resolvedName: string;
+  payload: ImportPayload;
+  fingerprint: string;
+  sourceUrl?: string | null;
+  existingFile?: WorkspaceFile | null;
+};
+
+const escapeDriveQuery = (value: string) =>
+  value
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'");
+
+const sanitizeImportedName = (value: string, fallback: string) => {
+  const normalized = String(value || '')
+    .replace(/[\\/]+/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return normalized || fallback;
+};
+
+const appendExtension = (name: string, extension: string) => {
+  if (name.toLowerCase().endsWith(extension.toLowerCase())) {
+    return name;
+  }
+  return `${name}${extension}`;
+};
+
+const collapseWhitespace = (value: string) =>
+  value
+    .replace(/\u000b/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+const markdownHeadingForNamedStyle = (namedStyleType?: string): string | null => {
+  switch (String(namedStyleType || '').trim()) {
+    case 'TITLE':
+      return '#';
+    case 'SUBTITLE':
+      return '##';
+    case 'HEADING_1':
+      return '##';
+    case 'HEADING_2':
+      return '###';
+    case 'HEADING_3':
+      return '####';
+    case 'HEADING_4':
+      return '#####';
+    default:
+      return null;
+  }
+};
+
+const renderGoogleDocsParagraph = (
+  paragraph: NonNullable<GoogleDocsStructuralElement['paragraph']>,
+): string => {
+  const rawText = (paragraph.elements || [])
+    .map((element) => String(element.textRun?.content || ''))
+    .join('');
+  const text = collapseWhitespace(rawText);
+  if (!text) {
+    return '';
+  }
+  const headingPrefix = markdownHeadingForNamedStyle(paragraph.paragraphStyle?.namedStyleType);
+  return headingPrefix ? `${headingPrefix} ${text}` : text;
+};
+
+const renderGoogleDocsTable = (
+  table: NonNullable<GoogleDocsStructuralElement['table']>,
+): string => {
+  const rows = (table.tableRows || [])
+    .map((row) =>
+      (row.tableCells || [])
+        .map((cell) =>
+          collapseWhitespace(renderGoogleDocsStructuralContent(cell.content || [])) || ' '
+        ),
+    )
+    .filter((row) => row.length);
+  if (!rows.length) {
+    return '';
+  }
+  const columnCount = Math.max(...rows.map((row) => row.length));
+  const normalizedRows = rows.map((row) => {
+    const next = row.slice();
+    while (next.length < columnCount) {
+      next.push(' ');
+    }
+    return next;
+  });
+  const [header, ...rest] = normalizedRows;
+  const separator = new Array(columnCount).fill('---');
+  const lines = [
+    `| ${header.join(' | ')} |`,
+    `| ${separator.join(' | ')} |`,
+    ...rest.map((row) => `| ${row.join(' | ')} |`),
+  ];
+  return lines.join('\n');
+};
+
+const renderGoogleDocsStructuralContent = (
+  content: GoogleDocsStructuralElement[],
+): string => {
+  const sections: string[] = [];
+  for (const element of content) {
+    if (element.paragraph) {
+      const paragraph = renderGoogleDocsParagraph(element.paragraph);
+      if (paragraph) {
+        sections.push(paragraph);
+      }
+      continue;
+    }
+    if (element.table) {
+      const table = renderGoogleDocsTable(element.table);
+      if (table) {
+        sections.push(table);
+      }
+      continue;
+    }
+    if (element.tableOfContents?.content?.length) {
+      const toc = renderGoogleDocsStructuralContent(element.tableOfContents.content);
+      if (toc) {
+        sections.push(toc);
+      }
+    }
+  }
+  return sections.join('\n\n').trim();
+};
+
+const toCsvCell = (value: unknown) => {
+  const text = String(value ?? '');
+  if (/[",\n]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+  return text;
+};
+
+const toCsvText = (rows: string[][]) =>
+  rows.map((row) => row.map((cell) => toCsvCell(cell)).join(',')).join('\n');
+
+const extractDriveFileId = (value?: string): string | null => {
+  const raw = String(value || '').trim();
+  if (!raw) {
+    return null;
+  }
+
+  if (/^[a-zA-Z0-9_-]{20,}$/.test(raw)) {
+    return raw;
+  }
+
+  try {
+    const url = new URL(raw);
+    const directId = url.searchParams.get('id');
+    if (directId && /^[a-zA-Z0-9_-]{20,}$/.test(directId)) {
+      return directId;
+    }
+    const match = url.pathname.match(/\/d\/([a-zA-Z0-9_-]{20,})/);
+    if (match?.[1]) {
+      return match[1];
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+};
+
+const rangeForSheet = (title: string) => `'${title.replace(/'/g, "''")}'`;
+
+const toIconHint = (mimeType: string): GoogleDrivePickerItem['iconHint'] => {
+  if (mimeType === GOOGLE_DOC_MIME) return 'docs';
+  if (mimeType === GOOGLE_SHEET_MIME) return 'sheets';
+  if (mimeType === GOOGLE_SLIDE_MIME) return 'slides';
+  if (mimeType === 'application/pdf') return 'pdf';
+  if (mimeType.startsWith('image/')) return 'image';
+  return 'file';
+};
+
+export class GoogleDriveService {
+  constructor(
+    private readonly googleOAuthService: GoogleOAuthService,
+    private readonly fileService: FileService,
+  ) {}
+
+  async searchFiles(
+    userId: string,
+    options: {
+      query?: string;
+      scope?: GoogleDrivePickerScope;
+      pageSize?: number;
+      pageToken?: string;
+    } = {},
+  ): Promise<GoogleDriveSearchResult> {
+    const scope = options.scope || 'recent';
+    const query = String(options.query || '').trim();
+    const pageSize = Math.min(Math.max(options.pageSize || 24, 1), 50);
+    const pageToken = String(options.pageToken || '').trim();
+    const { accessToken } = await this.googleOAuthService.getDelegatedAccessToken(userId);
+
+    const directId = extractDriveFileId(query);
+    if (directId) {
+      const file = await this.getFileMetadata(accessToken, directId);
+      if (file.mimeType === GOOGLE_FOLDER_MIME) {
+        return { files: [], nextPageToken: null };
+      }
+      return {
+        files: [this.toPickerItem(file, scope)],
+        nextPageToken: null,
+      };
+    }
+
+    const url = new URL(`${DRIVE_API_BASE}/files`);
+    const clauses = [
+      'trashed = false',
+      `mimeType != '${GOOGLE_FOLDER_MIME}'`,
+    ];
+
+    if (scope === 'my-drive') {
+      clauses.push(`'me' in owners`);
+    } else if (scope === 'shared') {
+      clauses.push('sharedWithMe = true');
+    }
+
+    if (query) {
+      clauses.push(`name contains '${escapeDriveQuery(query)}'`);
+    }
+
+    url.searchParams.set('q', clauses.join(' and '));
+    url.searchParams.set('pageSize', String(pageSize));
+    if (pageToken) {
+      url.searchParams.set('pageToken', pageToken);
+    }
+    url.searchParams.set('supportsAllDrives', 'true');
+    url.searchParams.set('includeItemsFromAllDrives', 'true');
+    url.searchParams.set('spaces', 'drive');
+    url.searchParams.set(
+      'fields',
+      'nextPageToken,files(id,name,mimeType,webViewLink,modifiedTime,size,owners(displayName))',
+    );
+    url.searchParams.set(
+      'orderBy',
+      scope === 'recent'
+        ? 'viewedByMeTime desc, modifiedTime desc'
+        : 'modifiedTime desc',
+    );
+
+    const payload = await this.fetchJson<{ files?: DriveFileMetadata[]; nextPageToken?: string }>(
+      accessToken,
+      url.toString(),
+      'Failed to search Google Drive',
+    );
+    return {
+      files: (payload.files || []).map((file) => this.toPickerItem(file, scope)),
+      nextPageToken: payload.nextPageToken || null,
+    };
+  }
+
+  async importFiles(
+    workspaceId: string,
+    userId: string,
+    fileIds: string[],
+  ): Promise<WorkspaceFile[]> {
+    const uniqueFileIds = Array.from(new Set(fileIds.map((value) => value.trim()).filter(Boolean)));
+    if (!uniqueFileIds.length) {
+      return [];
+    }
+
+    const { accessToken } = await this.googleOAuthService.getDelegatedAccessToken(userId);
+    const reservedNames = new Set<string>();
+    const prepared: PreparedImport[] = [];
+
+    for (const fileId of uniqueFileIds) {
+      const metadata = await this.getFileMetadata(accessToken, fileId);
+      if (metadata.mimeType === GOOGLE_FOLDER_MIME) {
+        throw new HttpError(400, `Google Drive folder "${metadata.name}" cannot be attached here.`);
+      }
+      const payload = await this.buildImportPayload(accessToken, metadata);
+      const fingerprint = createHash('sha256').update(payload.buffer).digest('hex');
+      const existingFile = await this.fileService.findImportedExternalFile(workspaceId, userId, {
+        sourceProvider: 'google_drive',
+        sourceExternalId: metadata.id,
+        sourceVersionFingerprint: fingerprint,
+      });
+      if (existingFile) {
+        prepared.push({
+          fileId,
+          resolvedName: String(existingFile.name || metadata.name),
+          payload,
+          fingerprint,
+          sourceUrl: metadata.webViewLink || null,
+          existingFile: existingFile as WorkspaceFile,
+        });
+        reservedNames.add(String(existingFile.name || metadata.name));
+        continue;
+      }
+      const resolvedName = await this.resolveUniqueFileName(workspaceId, userId, payload.fileName, reservedNames);
+      reservedNames.add(resolvedName);
+      prepared.push({
+        fileId,
+        resolvedName,
+        payload,
+        fingerprint,
+        sourceUrl: metadata.webViewLink || null,
+        existingFile: null,
+      });
+    }
+
+    const imported: WorkspaceFile[] = [];
+    const createdIds: number[] = [];
+
+    try {
+      for (const entry of prepared) {
+        if (entry.existingFile) {
+          imported.push(entry.existingFile);
+          continue;
+        }
+        const created = await this.fileService.createFile(
+          workspaceId,
+          entry.resolvedName,
+          entry.payload.buffer,
+          entry.payload.mimeType,
+          userId,
+          {
+            forceLocal: entry.payload.forceLocal,
+            sourceProvider: 'google_drive',
+            sourceExternalId: entry.fileId,
+            sourceVersionFingerprint: entry.fingerprint,
+            sourceUrl: entry.sourceUrl || null,
+          },
+        );
+        imported.push(created as WorkspaceFile);
+        createdIds.push(Number(created.id));
+      }
+      return imported;
+    } catch (error) {
+      await Promise.all(
+        createdIds.map(async (numericId) => {
+          if (!Number.isFinite(numericId)) {
+            return;
+          }
+          try {
+            await this.fileService.deleteFile(numericId, userId);
+          } catch (rollbackError) {
+            console.error('Failed to roll back Google Drive import file', {
+              workspaceId,
+              userId,
+              fileId: numericId,
+              rollbackError,
+            });
+          }
+        }),
+      );
+      throw error;
+    }
+  }
+
+  private toPickerItem(file: DriveFileMetadata, scope: GoogleDrivePickerScope): GoogleDrivePickerItem {
+    return {
+      id: file.id,
+      name: file.name,
+      mimeType: file.mimeType,
+      webViewUrl: file.webViewLink || null,
+      modifiedTime: file.modifiedTime || null,
+      ownerNames: (file.owners || [])
+        .map((owner) => String(owner.displayName || '').trim())
+        .filter(Boolean),
+      size: file.size || null,
+      iconHint: toIconHint(file.mimeType),
+      scope,
+    };
+  }
+
+  private async buildImportPayload(accessToken: string, metadata: DriveFileMetadata): Promise<ImportPayload> {
+    const safeName = sanitizeImportedName(metadata.name, 'google-drive-import');
+
+    if (metadata.mimeType === GOOGLE_DOC_MIME) {
+      try {
+        const buffer = await this.exportGoogleWorkspaceFile(accessToken, metadata.id, PDF_MIME);
+        return {
+          fileName: appendExtension(safeName, '.pdf'),
+          mimeType: PDF_MIME,
+          buffer,
+        };
+      } catch (error) {
+        if (!this.isGoogleExportSizeLimitError(error)) {
+          throw error;
+        }
+        const markdown = await this.renderGoogleDocumentMarkdown(accessToken, metadata);
+        return {
+          fileName: appendExtension(safeName, '.md'),
+          mimeType: 'text/markdown',
+          buffer: Buffer.from(markdown, 'utf-8'),
+          forceLocal: true,
+        };
+      }
+    }
+
+    if (metadata.mimeType === GOOGLE_SHEET_MIME) {
+      const markdown = await this.renderSpreadsheetMarkdown(accessToken, metadata);
+      return {
+        fileName: appendExtension(safeName, '.md'),
+        mimeType: 'text/markdown',
+        buffer: Buffer.from(markdown, 'utf-8'),
+        forceLocal: true,
+      };
+    }
+
+    if (metadata.mimeType === GOOGLE_SLIDE_MIME) {
+      try {
+        const buffer = await this.exportGoogleWorkspaceFile(accessToken, metadata.id, PDF_MIME);
+        return {
+          fileName: appendExtension(safeName, '.pdf'),
+          mimeType: PDF_MIME,
+          buffer,
+        };
+      } catch {
+        const buffer = await this.exportGoogleWorkspaceFile(accessToken, metadata.id, PPTX_MIME);
+        return {
+          fileName: appendExtension(safeName, '.pptx'),
+          mimeType: PPTX_MIME,
+          buffer,
+        };
+      }
+    }
+
+    if (metadata.mimeType.startsWith('application/vnd.google-apps.')) {
+      throw new HttpError(400, `Google Drive item "${metadata.name}" is not supported in the chat attachment flow yet.`);
+    }
+
+    const buffer = await this.downloadDriveBinary(accessToken, metadata.id);
+    return {
+      fileName: safeName,
+      mimeType: metadata.mimeType || 'application/octet-stream',
+      buffer,
+    };
+  }
+
+  private async renderSpreadsheetMarkdown(accessToken: string, metadata: DriveFileMetadata): Promise<string> {
+    const infoUrl = new URL(`${SHEETS_API_BASE}/${metadata.id}`);
+    infoUrl.searchParams.set('fields', 'properties.title,sheets.properties.title');
+    const info = await this.fetchJson<{
+      properties?: { title?: string };
+      sheets?: Array<{ properties?: { title?: string } }>;
+    }>(accessToken, infoUrl.toString(), `Failed to inspect Google Sheet "${metadata.name}"`);
+
+    const sheetTitles = (info.sheets || [])
+      .map((sheet) => String(sheet.properties?.title || '').trim())
+      .filter(Boolean);
+
+    if (!sheetTitles.length) {
+      return `# ${metadata.name}\n\nThis spreadsheet did not contain any readable sheets.`;
+    }
+
+    const valuesUrl = new URL(`${SHEETS_API_BASE}/${metadata.id}/values:batchGet`);
+    valuesUrl.searchParams.set('majorDimension', 'ROWS');
+    valuesUrl.searchParams.set('valueRenderOption', 'FORMATTED_VALUE');
+    valuesUrl.searchParams.set('dateTimeRenderOption', 'FORMATTED_STRING');
+    sheetTitles.forEach((title) => valuesUrl.searchParams.append('ranges', rangeForSheet(title)));
+
+    const valuesPayload = await this.fetchJson<{
+      valueRanges?: Array<{ range?: string; values?: string[][] }>;
+    }>(accessToken, valuesUrl.toString(), `Failed to read Google Sheet "${metadata.name}"`);
+
+    const valuesByTitle = new Map<string, string[][]>();
+    for (const valueRange of valuesPayload.valueRanges || []) {
+      const range = String(valueRange.range || '');
+      const title = range.replace(/^'(.+)'!?$/, '$1').replace(/!.*$/, '');
+      valuesByTitle.set(title, Array.isArray(valueRange.values) ? valueRange.values : []);
+    }
+
+    const sections = sheetTitles.map((title) => {
+      const rows = valuesByTitle.get(title) || [];
+      const csvText = rows.length ? toCsvText(rows) : '(No data)';
+      return `## ${title}\n\n\`\`\`csv\n${csvText}\n\`\`\``;
+    });
+
+    return [
+      `# ${info.properties?.title || metadata.name}`,
+      '',
+      `Imported from Google Drive: ${metadata.webViewLink || ''}`.trim(),
+      '',
+      ...sections,
+      '',
+    ].join('\n');
+  }
+
+  private async getFileMetadata(accessToken: string, fileId: string): Promise<DriveFileMetadata> {
+    const url = new URL(`${DRIVE_API_BASE}/files/${encodeURIComponent(fileId)}`);
+    url.searchParams.set('supportsAllDrives', 'true');
+    url.searchParams.set('fields', 'id,name,mimeType,webViewLink,modifiedTime,size,owners(displayName)');
+    return this.fetchJson<DriveFileMetadata>(accessToken, url.toString(), 'Failed to load Google Drive file');
+  }
+
+  private async exportGoogleWorkspaceFile(accessToken: string, fileId: string, mimeType: string): Promise<Buffer> {
+    const url = new URL(`${DRIVE_API_BASE}/files/${encodeURIComponent(fileId)}/export`);
+    url.searchParams.set('mimeType', mimeType);
+    return this.fetchBuffer(accessToken, url.toString(), 'Failed to export Google Workspace file');
+  }
+
+  private isGoogleExportSizeLimitError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error || '');
+    return message.includes('exportSizeLimitExceeded');
+  }
+
+  private async renderGoogleDocumentMarkdown(accessToken: string, metadata: DriveFileMetadata): Promise<string> {
+    const url = new URL(`${DOCS_API_BASE}/${encodeURIComponent(metadata.id)}`);
+    url.searchParams.set('fields', 'title,body(content(paragraph(elements(textRun/content),paragraphStyle/namedStyleType),table(tableRows(tableCells(content(paragraph(elements(textRun/content),paragraphStyle/namedStyleType),table))))))');
+    const document = await this.fetchJson<GoogleDocsDocument>(
+      accessToken,
+      url.toString(),
+      `Failed to read Google Doc "${metadata.name}"`,
+    );
+    const title = collapseWhitespace(String(document.title || metadata.name || 'Google Doc')) || metadata.name;
+    const body = renderGoogleDocsStructuralContent(document.body?.content || []);
+    return [
+      `# ${title}`,
+      '',
+      `Imported from Google Drive: ${metadata.webViewLink || ''}`.trim(),
+      '',
+      body || '(No readable text content was returned by the Google Docs API.)',
+      '',
+    ].join('\n');
+  }
+
+  private async downloadDriveBinary(accessToken: string, fileId: string): Promise<Buffer> {
+    const url = new URL(`${DRIVE_API_BASE}/files/${encodeURIComponent(fileId)}`);
+    url.searchParams.set('alt', 'media');
+    url.searchParams.set('supportsAllDrives', 'true');
+    return this.fetchBuffer(accessToken, url.toString(), 'Failed to download Google Drive file');
+  }
+
+  private async fetchJson<T>(accessToken: string, url: string, fallbackMessage: string): Promise<T> {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new HttpError(response.status, `${fallbackMessage} (${response.status}): ${text.slice(0, 300)}`);
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  private async fetchBuffer(accessToken: string, url: string, fallbackMessage: string): Promise<Buffer> {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new HttpError(response.status, `${fallbackMessage} (${response.status}): ${text.slice(0, 300)}`);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+  }
+
+  private async resolveUniqueFileName(
+    workspaceId: string,
+    userId: string,
+    fileName: string,
+    reservedNames?: Set<string>,
+  ): Promise<string> {
+    const parsed = path.posix.parse(fileName.replace(/\\/g, '/'));
+    const safeBaseName = sanitizeImportedName(parsed.name, 'google-drive-import');
+    const safeExt = parsed.ext || '';
+    const baseCandidate = `${safeBaseName}${safeExt}`;
+
+    if (!reservedNames?.has(baseCandidate) && !await this.fileService.hasFileName(workspaceId, baseCandidate, userId)) {
+      return baseCandidate;
+    }
+
+    for (let index = 2; index <= 99; index += 1) {
+      const candidate = `${safeBaseName} (${index})${safeExt}`;
+      if (!reservedNames?.has(candidate) && !await this.fileService.hasFileName(workspaceId, candidate, userId)) {
+        return candidate;
+      }
+    }
+
+    let attempt = `${safeBaseName}-${Date.now()}${safeExt}`;
+    while (reservedNames?.has(attempt) || await this.fileService.hasFileName(workspaceId, attempt, userId)) {
+      attempt = `${safeBaseName}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}${safeExt}`;
+    }
+    return attempt;
+  }
+}

--- a/backend/src/services/s3Service.ts
+++ b/backend/src/services/s3Service.ts
@@ -1,7 +1,9 @@
 import {
+  CreateBucketCommand,
   DeleteObjectCommand,
   DeleteObjectsCommand,
   GetObjectCommand,
+  HeadBucketCommand,
   ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
@@ -30,6 +32,30 @@ const s3 = new S3Client({
 });
 
 export class S3Service {
+  private bucketReadyPromise: Promise<void> | null = null;
+
+  private async ensureBucketExists(): Promise<void> {
+    if (!this.bucketReadyPromise) {
+      this.bucketReadyPromise = (async () => {
+        try {
+          await s3.send(new HeadBucketCommand({ Bucket: S3_BUCKET_NAME }));
+        } catch (error: any) {
+          const code = String(error?.Code || error?.name || '');
+          const status = Number(error?.$metadata?.httpStatusCode || 0);
+          const shouldCreate = code === 'NotFound' || code === 'NoSuchBucket' || status === 404;
+          if (!shouldCreate) {
+            throw error;
+          }
+          await s3.send(new CreateBucketCommand({ Bucket: S3_BUCKET_NAME }));
+        }
+      })().catch((error) => {
+        this.bucketReadyPromise = null;
+        throw error;
+      });
+    }
+    await this.bucketReadyPromise;
+  }
+
   async uploadFile(
     workspaceName: string,
     fileName: string,
@@ -37,6 +63,7 @@ export class S3Service {
     mimeType?: string,
     keyOverride?: string,
   ) {
+    await this.ensureBucketExists();
     const key = keyOverride || `${workspaceName}/${fileName.replace(/\\/g, '/')}`;
     const params = {
       Bucket: S3_BUCKET_NAME,
@@ -84,6 +111,7 @@ export class S3Service {
   }
 
   async copyFile(oldKey: string, newKey: string): Promise<void> {
+    await this.ensureBucketExists();
     const encodedSource = encodeURIComponent(oldKey).replace(/%2F/g, '/');
     const command = new CopyObjectCommand({
       Bucket: S3_BUCKET_NAME,

--- a/backend/src/services/workspaceService.ts
+++ b/backend/src/services/workspaceService.ts
@@ -7,10 +7,9 @@ import { RagQueueService } from './ragQueueService';
 import { S3Service } from './s3Service';
 import { UserContext } from '../types/user';
 import { AccessDeniedError, NotFoundError } from '../errors';
+import { resolveWorkspaceRoot } from '../config/workspaceRoot';
 
-const WORKSPACE_DIR = process.env.WORKSPACE_ROOT
-  ? path.resolve(process.env.WORKSPACE_ROOT)
-  : path.join(process.cwd(), 'workspaces');
+const WORKSPACE_DIR = resolveWorkspaceRoot();
 
 export type WorkspaceRole = 'owner' | 'editor' | 'viewer';
 

--- a/frontend/src/components/FileRenderer.tsx
+++ b/frontend/src/components/FileRenderer.tsx
@@ -397,7 +397,7 @@ const FileRenderer: React.FC<FileRendererProps> = ({
     }
     if (isImageFile) {
       const dataSrc = fileContent ? `data:${file.mimeType || 'image/*'};base64,${fileContent}` : undefined;
-      const imageSrc = file.publicUrl || dataSrc;
+      const imageSrc = dataSrc || file.publicUrl;
       if (!imageSrc) {
         return (
           <div className="flex h-full items-center justify-center text-sm text-gray-500">
@@ -435,7 +435,7 @@ const FileRenderer: React.FC<FileRendererProps> = ({
       );
     }
     if (isPdfFile) {
-      const pdfSrc = file.publicUrl || (fileContent ? `data:application/pdf;base64,${fileContent}` : undefined);
+      const pdfSrc = fileContent ? `data:application/pdf;base64,${fileContent}` : file.publicUrl || undefined;
       if (!pdfSrc) {
         return (
           <div className="flex h-full items-center justify-center text-sm text-gray-500">

--- a/frontend/src/components/WorkspaceFileTree.tsx
+++ b/frontend/src/components/WorkspaceFileTree.tsx
@@ -40,6 +40,15 @@ const getFolderLabel = (node: WorkspaceFileTreeFolderNode) => {
   if (!node.path) {
     return node.name;
   }
+  if (node.path === '.system') {
+    return 'System';
+  }
+  if (node.path === '.system/extracted-assets') {
+    return 'Extracted assets';
+  }
+  if (node.path === '.system/derived-artifacts') {
+    return 'Derived artifacts';
+  }
   return node.name;
 };
 
@@ -126,7 +135,11 @@ const TreeFileRow: React.FC<{
   const isPendingJob = file.mimeType === 'application/vnd.helpudoc.paper2slides-job';
   const ragStatus = getRagStatus(ragStatuses, file);
   const ragState = ragStatus?.status ? String(ragStatus.status).toLowerCase() : '';
+  const understandingState = file.understandingStatus ? String(file.understandingStatus).toLowerCase() : '';
   const isIndexing = !isPendingJob && ['pending', 'processing', 'preprocessed'].includes(ragState);
+  const isUnderstandingPending = !isPendingJob && understandingState === 'pending';
+  const understandingFailed = !isPendingJob && understandingState === 'failed';
+  const understandingPartial = !isPendingJob && understandingState === 'partial';
   const displayName = getFileDisplayName(file.name || '');
   const fileIcon = getFileTypeIcon(file.name || '');
   const isDraft = isDraftWorkspaceFile(file);
@@ -184,16 +197,43 @@ const TreeFileRow: React.FC<{
         }}
         className="flex min-w-0 flex-1 items-start gap-2 text-left"
       >
-        <div className="flex min-w-0 items-center gap-2">
-          {(isPendingJob || isIndexing) && (
-            <span className="inline-flex h-4 w-4 items-center justify-center text-blue-500">
-              <span className="h-2 w-2 animate-pulse rounded-full bg-current" />
+        <div className="flex min-w-0 flex-col gap-1">
+          <div className="flex min-w-0 items-center gap-2">
+            {(isPendingJob || isIndexing || isUnderstandingPending) && (
+              <span className="inline-flex h-4 w-4 items-center justify-center text-blue-500">
+                <span className="h-2 w-2 animate-pulse rounded-full bg-current" />
+              </span>
+            )}
+            {understandingFailed && (
+              <span className="inline-flex h-4 w-4 items-center justify-center text-rose-500">
+                <span className="h-2 w-2 rounded-full bg-current" />
+              </span>
+            )}
+            {understandingPartial && (
+              <span className="inline-flex h-4 w-4 items-center justify-center text-amber-500">
+                <span className="h-2 w-2 rounded-full bg-current" />
+              </span>
+            )}
+            <span className="shrink-0" aria-hidden="true">
+              {fileIcon}
+            </span>
+            <SlidingFileName name={displayName} colorMode={colorMode} />
+          </div>
+          {(isUnderstandingPending || understandingFailed || understandingPartial) && (
+            <span className={`pl-6 text-[11px] leading-none ${
+              understandingFailed
+                ? isDarkMode ? 'text-rose-400' : 'text-rose-600'
+                : understandingPartial
+                  ? isDarkMode ? 'text-amber-400' : 'text-amber-600'
+                  : isDarkMode ? 'text-sky-400' : 'text-sky-600'
+            }`}>
+              {understandingFailed
+                ? (file.understandingError?.trim() || 'Artifact processing failed')
+                : understandingPartial
+                  ? 'Artifact ready with partial extraction'
+                  : 'Processing document artifacts...'}
             </span>
           )}
-          <span className="shrink-0" aria-hidden="true">
-            {fileIcon}
-          </span>
-          <SlidingFileName name={displayName} colorMode={colorMode} />
         </div>
       </button>
       {!isPendingJob && (

--- a/frontend/src/components/chat/AgentChatPane.tsx
+++ b/frontend/src/components/chat/AgentChatPane.tsx
@@ -20,6 +20,7 @@ import ChatHistoryPanel from './ChatHistoryPanel';
 import ChatInputArea from './ChatInputArea';
 import ChatMessageList from './ChatMessageList';
 import type { RenderableInterruptAction } from './interruptActions';
+import type { ChatComposerAttachment } from './chatTypes';
 
 type CommandSuggestion = {
   id: string;
@@ -54,6 +55,7 @@ export default function AgentChatPane({
   conversationStreaming,
   messages,
   isStreaming,
+  isPreparingAttachments,
   personaDisplayName,
   messageBubbleMaxWidth,
   markdownComponents,
@@ -112,7 +114,8 @@ export default function AgentChatPane({
   onChatInputKeyDown,
   onChatInputKeyUp,
   onChatInputSelectionChange,
-  onChatAttachmentButtonClick,
+  onOpenLocalAttachmentPicker,
+  onOpenDrivePicker,
   onInsertSlashTrigger,
   onOpenPresentationModal,
   onStopStreaming,
@@ -136,6 +139,7 @@ export default function AgentChatPane({
   conversationStreaming: ConversationStreamingMap;
   messages: ConversationMessage[];
   isStreaming: boolean;
+  isPreparingAttachments: boolean;
   personaDisplayName: string;
   messageBubbleMaxWidth: string;
   markdownComponents: Record<string, any>;
@@ -148,7 +152,7 @@ export default function AgentChatPane({
   interruptSubmittingByMessageId: Record<string, boolean>;
   interruptErrorByMessageId: Record<string, string>;
   chatMessage: string;
-  chatAttachments: File[];
+  chatAttachments: ChatComposerAttachment[];
   showPaper2SlidesControls: boolean;
   presentationStatus: 'idle' | 'running' | 'success' | 'error';
   presentationOptionSummary: string;
@@ -211,7 +215,8 @@ export default function AgentChatPane({
   onChatInputKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
   onChatInputKeyUp: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
   onChatInputSelectionChange: (event: SyntheticEvent<HTMLTextAreaElement>) => void;
-  onChatAttachmentButtonClick: () => void;
+  onOpenLocalAttachmentPicker: () => void;
+  onOpenDrivePicker: () => void;
   onInsertSlashTrigger: () => void;
   onOpenPresentationModal: () => void;
   onStopStreaming: () => void;
@@ -306,6 +311,7 @@ export default function AgentChatPane({
           chatInputRef={chatInputRef}
           attachmentInputRef={attachmentInputRef}
           isStreaming={isStreaming}
+          isPreparingAttachments={isPreparingAttachments}
           showPaper2SlidesControls={showPaper2SlidesControls}
           presentationStatus={presentationStatus}
           presentationOptionSummary={presentationOptionSummary}
@@ -320,7 +326,8 @@ export default function AgentChatPane({
           onChatInputKeyDown={onChatInputKeyDown}
           onChatInputKeyUp={onChatInputKeyUp}
           onChatInputSelectionChange={onChatInputSelectionChange}
-          onChatAttachmentButtonClick={onChatAttachmentButtonClick}
+          onOpenLocalAttachmentPicker={onOpenLocalAttachmentPicker}
+          onOpenDrivePicker={onOpenDrivePicker}
           onInsertSlashTrigger={onInsertSlashTrigger}
           onOpenPresentationModal={onOpenPresentationModal}
           onStopStreaming={onStopStreaming}

--- a/frontend/src/components/chat/ChatInputArea.tsx
+++ b/frontend/src/components/chat/ChatInputArea.tsx
@@ -1,7 +1,9 @@
-import { FileIcon, MonitorPlay, Plus, Send, StopCircle, X } from 'lucide-react';
-import { type ChangeEvent, type KeyboardEvent, type RefObject, type SyntheticEvent } from 'react';
+import { FileIcon, MonitorPlay, Paperclip, Plus, Send, StopCircle, X } from 'lucide-react';
+import { type ChangeEvent, type KeyboardEvent, type RefObject, type SyntheticEvent, useEffect, useRef, useState } from 'react';
 
 import type { File as WorkspaceFile } from '../../types';
+import type { ChatComposerAttachment } from './chatTypes';
+import GoogleDriveIcon from './GoogleDriveIcon';
 
 type CommandSuggestion = {
   id: string;
@@ -21,6 +23,7 @@ export default function ChatInputArea({
   chatInputRef,
   attachmentInputRef,
   isStreaming,
+  isPreparingAttachments,
   showPaper2SlidesControls,
   presentationStatus,
   presentationOptionSummary,
@@ -35,7 +38,8 @@ export default function ChatInputArea({
   onChatInputKeyDown,
   onChatInputKeyUp,
   onChatInputSelectionChange,
-  onChatAttachmentButtonClick,
+  onOpenLocalAttachmentPicker,
+  onOpenDrivePicker,
   onInsertSlashTrigger,
   onOpenPresentationModal,
   onStopStreaming,
@@ -48,10 +52,11 @@ export default function ChatInputArea({
 }: {
   colorMode: 'light' | 'dark';
   chatMessage: string;
-  chatAttachments: File[];
+  chatAttachments: ChatComposerAttachment[];
   chatInputRef: RefObject<HTMLTextAreaElement | null>;
   attachmentInputRef: RefObject<HTMLInputElement | null>;
   isStreaming: boolean;
+  isPreparingAttachments: boolean;
   showPaper2SlidesControls: boolean;
   presentationStatus: 'idle' | 'running' | 'success' | 'error';
   presentationOptionSummary: string;
@@ -66,7 +71,8 @@ export default function ChatInputArea({
   onChatInputKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
   onChatInputKeyUp: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
   onChatInputSelectionChange: (event: SyntheticEvent<HTMLTextAreaElement>) => void;
-  onChatAttachmentButtonClick: () => void;
+  onOpenLocalAttachmentPicker: () => void;
+  onOpenDrivePicker: () => void;
   onInsertSlashTrigger: () => void;
   onOpenPresentationModal: () => void;
   onStopStreaming: () => void;
@@ -78,6 +84,24 @@ export default function ChatInputArea({
   onSelectCommand: (command: CommandSuggestion) => void;
 }) {
   const isDarkMode = colorMode === 'dark';
+  const [isAttachmentMenuOpen, setIsAttachmentMenuOpen] = useState(false);
+  const attachmentMenuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isAttachmentMenuOpen) {
+      return undefined;
+    }
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (attachmentMenuRef.current?.contains(event.target as Node)) {
+        return;
+      }
+      setIsAttachmentMenuOpen(false);
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => document.removeEventListener('mousedown', handlePointerDown);
+  }, [isAttachmentMenuOpen]);
 
   return (
     <div className={`sticky bottom-0 border-t p-3 backdrop-blur-md ${
@@ -92,11 +116,16 @@ export default function ChatInputArea({
           <div className="flex flex-wrap gap-2 px-3 pt-2.5">
             {chatAttachments.map((file, index) => (
               <div
-                key={`${file.name}-${index}`}
-                className={`group flex items-center gap-2 rounded-lg border px-2 py-1 text-[11px] font-medium transition-all duration-200 ${
+                key={file.id}
+                className={`group flex items-center gap-2 rounded-lg border px-2 py-1 text-xs font-medium transition-all duration-200 ${
                   isDarkMode ? 'border-slate-700/70 bg-slate-950/70 text-slate-200' : 'border-slate-200 bg-slate-50 text-slate-700'
                 }`}
               >
+                {file.source === 'drive' ? (
+                  <GoogleDriveIcon className="h-3.5 w-3.5 shrink-0" />
+                ) : (
+                  <Paperclip size={12} className={isDarkMode ? 'text-slate-400' : 'text-slate-500'} />
+                )}
                 <span className="max-w-[120px] truncate">{file.name}</span>
                 <button
                   type="button"
@@ -154,21 +183,75 @@ export default function ChatInputArea({
         />
         <div className="flex items-center justify-between px-2 pb-1.5">
           <div className="flex items-center gap-1">
-            <button
-              type="button"
-              onClick={onChatAttachmentButtonClick}
-              className={`rounded-lg p-1.5 transition-all duration-200 ${
-                isDarkMode ? 'text-slate-400 hover:bg-slate-800 hover:text-slate-100' : 'text-slate-500 hover:bg-slate-100 hover:text-slate-800'
-              }`}
-              title="Attach files"
-            >
-              <Plus size={16} />
-            </button>
+            <div className="relative" ref={attachmentMenuRef}>
+              <button
+                type="button"
+                disabled={isPreparingAttachments}
+                onClick={() => setIsAttachmentMenuOpen((prev) => !prev)}
+                className={`rounded-lg p-2 transition-all duration-200 ${
+                  isPreparingAttachments
+                    ? isDarkMode
+                      ? 'cursor-not-allowed text-slate-600'
+                      : 'cursor-not-allowed text-slate-300'
+                    : isDarkMode ? 'text-slate-400 hover:bg-slate-800 hover:text-slate-100' : 'text-slate-500 hover:bg-slate-100 hover:text-slate-800'
+                }`}
+                title="Attach files"
+              >
+                <Plus size={18} />
+              </button>
+              {isAttachmentMenuOpen && (
+                <div className={`absolute bottom-full left-0 z-30 mb-2 w-64 rounded-2xl border p-2 shadow-2xl backdrop-blur-md ${
+                  isDarkMode ? 'border-slate-700/80 bg-slate-900/95' : 'border-slate-200 bg-white/95'
+                }`}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setIsAttachmentMenuOpen(false);
+                      onOpenLocalAttachmentPicker();
+                    }}
+                    className={`flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left text-sm font-medium transition ${
+                      isDarkMode ? 'text-slate-100 hover:bg-slate-800' : 'text-slate-800 hover:bg-slate-50'
+                    }`}
+                  >
+                    <Paperclip size={18} />
+                    <div className="flex flex-col">
+                      <span>Upload files</span>
+                      <span className={`text-[11px] font-normal ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+                        Add files from this device
+                      </span>
+                    </div>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setIsAttachmentMenuOpen(false);
+                      onOpenDrivePicker();
+                    }}
+                    className={`mt-1 flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left text-sm font-medium transition ${
+                      isDarkMode ? 'text-slate-100 hover:bg-slate-800' : 'text-slate-800 hover:bg-slate-50'
+                    }`}
+                  >
+                    <GoogleDriveIcon className="h-[18px] w-[18px]" />
+                    <div className="flex flex-col">
+                      <span>Add from Google Drive</span>
+                      <span className={`text-[11px] font-normal ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+                        Search Drive or paste a file URL
+                      </span>
+                    </div>
+                  </button>
+                </div>
+              )}
+            </div>
             <button
               type="button"
               onClick={onInsertSlashTrigger}
-              className={`rounded-lg p-1.5 transition-all duration-200 ${
-                isDarkMode ? 'text-slate-400 hover:bg-slate-800 hover:text-slate-100' : 'text-slate-500 hover:bg-slate-100 hover:text-slate-800'
+              disabled={isPreparingAttachments}
+              className={`rounded-lg p-2 transition-all duration-200 ${
+                isPreparingAttachments
+                  ? isDarkMode
+                    ? 'cursor-not-allowed text-slate-600'
+                    : 'cursor-not-allowed text-slate-300'
+                  : isDarkMode ? 'text-slate-400 hover:bg-slate-800 hover:text-slate-100' : 'text-slate-500 hover:bg-slate-100 hover:text-slate-800'
               }`}
               title="Commands"
               aria-label="Insert command"
@@ -200,13 +283,13 @@ export default function ChatInputArea({
           </div>
           <div className="flex items-center gap-2">
             <span className={`mr-2 hidden text-[10px] sm:inline-block ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
-              {isStreaming ? 'Generating...' : 'Enter to send'}
+              {isStreaming ? 'Generating...' : isPreparingAttachments ? 'Preparing attachments...' : 'Enter to send'}
             </span>
             <button
               onClick={isStreaming ? onStopStreaming : onSendMessage}
-              disabled={!chatMessage.trim() && !chatAttachments.length && !isStreaming}
-              className={`rounded-xl p-1.5 transition-all duration-200 ${
-                !chatMessage.trim() && !chatAttachments.length && !isStreaming
+              disabled={isPreparingAttachments || (!chatMessage.trim() && !chatAttachments.length && !isStreaming)}
+              className={`rounded-xl p-2 transition-all duration-200 ${
+                isPreparingAttachments || (!chatMessage.trim() && !chatAttachments.length && !isStreaming)
                   ? isDarkMode
                     ? 'cursor-not-allowed bg-slate-800 text-slate-600'
                     : 'cursor-not-allowed bg-slate-100 text-slate-300'

--- a/frontend/src/components/chat/DrivePickerModal.tsx
+++ b/frontend/src/components/chat/DrivePickerModal.tsx
@@ -1,0 +1,378 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Check, Loader2, Search, X } from 'lucide-react';
+
+import { searchGoogleDriveFiles } from '../../services/fileApi';
+import type {
+  GoogleDrivePickerItem,
+  GoogleDrivePickerScope,
+} from '../../types';
+import GoogleDriveIcon from './GoogleDriveIcon';
+
+type Props = {
+  isOpen: boolean;
+  workspaceId?: string;
+  colorMode: 'light' | 'dark';
+  onClose: () => void;
+  onConfirm: (items: GoogleDrivePickerItem[]) => void;
+};
+
+const DRIVE_SCOPE_TABS: Array<{ id: GoogleDrivePickerScope; label: string }> = [
+  { id: 'recent', label: 'Recent' },
+  { id: 'my-drive', label: 'My Drive' },
+  { id: 'shared', label: 'Shared with me' },
+];
+
+const badgeClassByHint: Record<string, string> = {
+  docs: 'bg-blue-50 text-blue-700 border-blue-200',
+  sheets: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  slides: 'bg-amber-50 text-amber-700 border-amber-200',
+  pdf: 'bg-rose-50 text-rose-700 border-rose-200',
+  image: 'bg-violet-50 text-violet-700 border-violet-200',
+  file: 'bg-slate-100 text-slate-700 border-slate-200',
+};
+
+const badgeLabelByHint: Record<string, string> = {
+  docs: 'Doc',
+  sheets: 'Sheet',
+  slides: 'Slide',
+  pdf: 'PDF',
+  image: 'Image',
+  file: 'File',
+};
+
+export default function DrivePickerModal({
+  isOpen,
+  workspaceId,
+  colorMode,
+  onClose,
+  onConfirm,
+}: Props) {
+  const isDarkMode = colorMode === 'dark';
+  const [scope, setScope] = useState<GoogleDrivePickerScope>('recent');
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<GoogleDrivePickerItem[]>([]);
+  const [selectedById, setSelectedById] = useState<Record<string, GoogleDrivePickerItem>>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [nextPageToken, setNextPageToken] = useState<string | null>(null);
+  const resultsPaneRef = useRef<HTMLDivElement | null>(null);
+  const requestKeyRef = useRef('');
+
+  useEffect(() => {
+    if (!isOpen) {
+      setScope('recent');
+      setQuery('');
+      setResults([]);
+      setSelectedById({});
+      setIsLoading(false);
+      setIsLoadingMore(false);
+      setError(null);
+      setNextPageToken(null);
+      requestKeyRef.current = '';
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || !workspaceId) {
+      return;
+    }
+
+    const timer = window.setTimeout(async () => {
+      const requestKey = `${scope}::${query.trim()}`;
+      requestKeyRef.current = requestKey;
+      setIsLoading(true);
+      setError(null);
+      try {
+        const payload = await searchGoogleDriveFiles(workspaceId, { query, scope });
+        if (requestKeyRef.current !== requestKey) {
+          return;
+        }
+        setResults(payload.files);
+        setNextPageToken(payload.nextPageToken ?? null);
+        resultsPaneRef.current?.scrollTo({ top: 0 });
+      } catch (fetchError) {
+        const message = fetchError instanceof Error ? fetchError.message : 'Failed to search Google Drive.';
+        setError(message);
+        setResults([]);
+        setNextPageToken(null);
+      } finally {
+        if (requestKeyRef.current === requestKey) {
+          setIsLoading(false);
+        }
+      }
+    }, query.trim() ? 250 : 0);
+
+    return () => window.clearTimeout(timer);
+  }, [isOpen, query, scope, workspaceId]);
+
+  const selectedItems = useMemo(
+    () => Object.values(selectedById).sort((a, b) => a.name.localeCompare(b.name)),
+    [selectedById],
+  );
+
+  const toggleItem = (item: GoogleDrivePickerItem) => {
+    setSelectedById((prev) => {
+      if (prev[item.id]) {
+        const next = { ...prev };
+        delete next[item.id];
+        return next;
+      }
+      return { ...prev, [item.id]: item };
+    });
+  };
+
+  const loadMore = useCallback(async () => {
+    if (!workspaceId || !nextPageToken || isLoading || isLoadingMore) {
+      return;
+    }
+
+    const requestKey = `${scope}::${query.trim()}`;
+    setIsLoadingMore(true);
+    try {
+      const payload = await searchGoogleDriveFiles(workspaceId, {
+        query,
+        scope,
+        pageToken: nextPageToken,
+      });
+      if (requestKeyRef.current !== requestKey) {
+        return;
+      }
+      setResults((prev) => {
+        const seen = new Set(prev.map((item) => item.id));
+        const nextItems = payload.files.filter((item) => !seen.has(item.id));
+        return [...prev, ...nextItems];
+      });
+      setNextPageToken(payload.nextPageToken ?? null);
+    } catch (fetchError) {
+      const message = fetchError instanceof Error ? fetchError.message : 'Failed to load more Google Drive files.';
+      setError(message);
+    } finally {
+      if (requestKeyRef.current === requestKey) {
+        setIsLoadingMore(false);
+      }
+    }
+  }, [workspaceId, nextPageToken, isLoading, isLoadingMore, scope, query]);
+
+  const handleResultsScroll = useCallback(() => {
+    const container = resultsPaneRef.current;
+    if (!container || !nextPageToken || isLoading || isLoadingMore) {
+      return;
+    }
+    const remaining = container.scrollHeight - container.scrollTop - container.clientHeight;
+    if (remaining < 280) {
+      void loadMore();
+    }
+  }, [nextPageToken, isLoading, isLoadingMore, loadMore]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60 p-4">
+      <div className={`flex max-h-[min(92vh,860px)] w-full max-w-5xl flex-col overflow-hidden rounded-3xl border shadow-2xl ${
+        isDarkMode ? 'border-slate-700 bg-slate-900 text-slate-100' : 'border-slate-200 bg-white text-slate-900'
+      }`}>
+        <div className={`flex items-center justify-between border-b px-5 py-4 ${
+          isDarkMode ? 'border-slate-800' : 'border-slate-200'
+        }`}>
+          <div className="flex items-center gap-3">
+            <div className={`flex h-11 w-11 items-center justify-center rounded-2xl ${
+              isDarkMode ? 'bg-slate-800' : 'bg-slate-100'
+            }`}>
+              <GoogleDriveIcon className="h-6 w-6" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold">Select files from Google Drive</p>
+              <p className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+                Search Drive or paste a file URL, then add the selections to this message.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className={`rounded-full p-2 transition ${
+              isDarkMode ? 'text-slate-400 hover:bg-slate-800 hover:text-slate-100' : 'text-slate-500 hover:bg-slate-100 hover:text-slate-900'
+            }`}
+            aria-label="Close Google Drive picker"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className={`border-b px-5 py-4 ${isDarkMode ? 'border-slate-800' : 'border-slate-200'}`}>
+          <div className={`flex items-center gap-3 rounded-2xl border px-4 py-3 ${
+            isDarkMode ? 'border-slate-700 bg-slate-950' : 'border-slate-200 bg-slate-50'
+          }`}>
+            <Search size={18} className={isDarkMode ? 'text-slate-500' : 'text-slate-400'} />
+            <input
+              type="text"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search in Drive or paste URL"
+              className={`w-full bg-transparent text-sm outline-none ${
+                isDarkMode ? 'placeholder:text-slate-500' : 'placeholder:text-slate-400'
+              }`}
+            />
+          </div>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {DRIVE_SCOPE_TABS.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setScope(tab.id)}
+                className={`rounded-full px-3 py-1.5 text-xs font-semibold transition ${
+                  scope === tab.id
+                    ? isDarkMode
+                      ? 'bg-sky-400/15 text-sky-100 ring-1 ring-sky-400/25'
+                      : 'bg-sky-50 text-sky-700 ring-1 ring-sky-200'
+                    : isDarkMode
+                      ? 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                      : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_280px]">
+          <div
+            ref={resultsPaneRef}
+            onScroll={handleResultsScroll}
+            className="min-h-0 overflow-y-auto p-5"
+          >
+            {isLoading ? (
+              <div className={`flex min-h-[320px] items-center justify-center gap-3 text-sm ${
+                isDarkMode ? 'text-slate-400' : 'text-slate-500'
+              }`}>
+                <Loader2 size={18} className="animate-spin" />
+                <span>Loading Drive files…</span>
+              </div>
+            ) : error ? (
+              <div className={`rounded-2xl border px-4 py-3 text-sm ${
+                isDarkMode ? 'border-rose-500/20 bg-rose-500/10 text-rose-200' : 'border-rose-200 bg-rose-50 text-rose-700'
+              }`}>
+                {error}
+              </div>
+            ) : !results.length ? (
+              <div className={`flex min-h-[320px] items-center justify-center rounded-2xl border border-dashed text-sm ${
+                isDarkMode ? 'border-slate-800 text-slate-400' : 'border-slate-200 text-slate-500'
+              }`}>
+                No matching Google Drive files
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                  {results.map((item) => {
+                    const isSelected = Boolean(selectedById[item.id]);
+                    return (
+                      <button
+                        key={item.id}
+                        type="button"
+                        onClick={() => toggleItem(item)}
+                        className={`rounded-2xl border p-4 text-left transition ${
+                          isSelected
+                            ? isDarkMode
+                              ? 'border-sky-400/40 bg-sky-400/10'
+                              : 'border-sky-300 bg-sky-50'
+                            : isDarkMode
+                              ? 'border-slate-800 bg-slate-950 hover:border-slate-700'
+                              : 'border-slate-200 bg-white hover:border-slate-300'
+                        }`}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <span className={`inline-flex rounded-full border px-2 py-1 text-[11px] font-semibold ${
+                            badgeClassByHint[item.iconHint]
+                          }`}>
+                            {badgeLabelByHint[item.iconHint]}
+                          </span>
+                          {isSelected && (
+                            <span className={`inline-flex h-6 w-6 items-center justify-center rounded-full ${
+                              isDarkMode ? 'bg-sky-400/15 text-sky-100' : 'bg-sky-100 text-sky-700'
+                            }`}>
+                              <Check size={14} />
+                            </span>
+                          )}
+                        </div>
+                        <p className="mt-4 line-clamp-2 text-sm font-semibold">{item.name}</p>
+                        <div className={`mt-3 space-y-1 text-xs ${
+                          isDarkMode ? 'text-slate-400' : 'text-slate-500'
+                        }`}>
+                          {item.ownerNames?.length ? <p>{item.ownerNames.join(', ')}</p> : null}
+                          {item.modifiedTime ? <p>Updated {new Date(item.modifiedTime).toLocaleString()}</p> : null}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+                {(isLoadingMore || nextPageToken) ? (
+                  <div className={`flex items-center justify-center gap-2 rounded-2xl border border-dashed px-4 py-3 text-sm ${
+                    isDarkMode ? 'border-slate-800 text-slate-400' : 'border-slate-200 text-slate-500'
+                  }`}>
+                    {isLoadingMore ? <Loader2 size={16} className="animate-spin" /> : null}
+                    <span>{isLoadingMore ? 'Loading more files…' : 'Scroll down to load more Drive files'}</span>
+                  </div>
+                ) : null}
+              </div>
+            )}
+          </div>
+
+          <aside className={`flex min-h-0 flex-col border-l p-5 ${isDarkMode ? 'border-slate-800 bg-slate-950/60' : 'border-slate-200 bg-slate-50/80'}`}>
+            <p className="text-sm font-semibold">Selected</p>
+            <p className={`mt-1 text-xs ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+              {selectedItems.length ? `${selectedItems.length} file${selectedItems.length === 1 ? '' : 's'} ready to attach` : 'Pick one or more Drive files'}
+            </p>
+            <div className="mt-4 min-h-0 flex-1 space-y-2 overflow-y-auto pr-1">
+              {selectedItems.length ? selectedItems.map((item) => (
+                <div
+                  key={item.id}
+                  className={`rounded-2xl border px-3 py-2 text-sm ${
+                    isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-slate-200 bg-white'
+                  }`}
+                >
+                  <p className="truncate font-medium">{item.name}</p>
+                  <p className={`mt-1 text-[11px] ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+                    {badgeLabelByHint[item.iconHint]}
+                  </p>
+                </div>
+              )) : (
+                <div className={`rounded-2xl border border-dashed px-3 py-4 text-xs ${
+                  isDarkMode ? 'border-slate-800 text-slate-500' : 'border-slate-200 text-slate-500'
+                }`}>
+                  Your selections will appear here.
+                </div>
+              )}
+            </div>
+            <div className="mt-5 flex gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className={`flex-1 rounded-xl border px-3 py-2 text-sm font-semibold transition ${
+                  isDarkMode ? 'border-slate-700 bg-slate-900 text-slate-200 hover:bg-slate-800' : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
+                }`}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => onConfirm(selectedItems)}
+                disabled={!selectedItems.length}
+                className={`flex-1 rounded-xl px-3 py-2 text-sm font-semibold text-white transition ${
+                  selectedItems.length
+                    ? 'bg-[linear-gradient(135deg,rgba(66,133,244,0.95),rgba(15,157,88,0.92))] shadow-[0_12px_30px_-18px_rgba(66,133,244,0.85)]'
+                    : 'cursor-not-allowed bg-slate-300 text-slate-100 shadow-none'
+                }`}
+              >
+                Add to message
+              </button>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/GoogleDriveIcon.tsx
+++ b/frontend/src/components/chat/GoogleDriveIcon.tsx
@@ -1,0 +1,15 @@
+export default function GoogleDriveIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 87.3 78"
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M6.6 65.5 0 54.1 21.9 16h13.2L6.6 65.5Z" fill="#0F9D58" />
+      <path d="M48.8 65.5H6.6L13.2 54.1h42.2l-6.6 11.4Z" fill="#4285F4" />
+      <path d="m35.1 16 6.6-11.4h13.2L87.3 60.7l-6.6 11.4L35.1 16Z" fill="#F4B400" />
+    </svg>
+  );
+}

--- a/frontend/src/components/chat/chatTypes.ts
+++ b/frontend/src/components/chat/chatTypes.ts
@@ -1,0 +1,15 @@
+import type { GoogleDrivePickerItem } from '../../types';
+
+export type ChatComposerAttachment =
+  | {
+      id: string;
+      name: string;
+      source: 'local';
+      file: File;
+    }
+  | {
+      id: string;
+      name: string;
+      source: 'drive';
+      driveItem: GoogleDrivePickerItem;
+    };

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -22,7 +22,13 @@ import {
   getFileContent,
   renameFile,
   getRagStatuses,
+  resolveFileContextRefs,
 } from '../services/fileApi';
+import {
+  createAttachmentPrepJob,
+  getAttachmentPrepJob,
+  type AttachmentPrepJob,
+} from '../services/attachmentPrepApi';
 import { startPaper2SlidesJob, getPaper2SlidesJob, exportPaper2SlidesPptx } from '../services/paper2SlidesJobApi';
 import {
   cancelRun,
@@ -56,6 +62,8 @@ import type {
   InterruptAction,
   InterruptAnswersByQuestionId,
   InterruptQuestion,
+  GoogleDrivePickerItem,
+  FileContextRef,
   SkillDefinition,
 } from '../types';
 import CollapsibleDrawer from '../components/CollapsibleDrawer';
@@ -65,6 +73,8 @@ import WorkspaceFileTree from '../components/WorkspaceFileTree';
 import AgentChatPane from '../components/chat/AgentChatPane';
 import { buildApprovalDraftContent, buildApprovalReview } from '../components/chat/approvalReview';
 import type { RenderableInterruptAction } from '../components/chat/interruptActions';
+import DrivePickerModal from '../components/chat/DrivePickerModal';
+import type { ChatComposerAttachment } from '../components/chat/chatTypes';
 import { useAuth } from '../auth/AuthProvider';
 import {
   CANVAS_ZOOM_STEP,
@@ -104,6 +114,50 @@ const sanitizePresentationLabel = (value: string, fallback: string) => {
 };
 
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const summarizeComposerAttachments = (attachments: ChatComposerAttachment[]): string => {
+  if (!attachments.length) {
+    return '';
+  }
+  return attachments
+    .map((attachment) => (attachment.source === 'drive' ? `${attachment.name} (Drive)` : attachment.name))
+    .join(', ');
+};
+
+const findLatestFileContextRefs = (messages: ConversationMessage[]): FileContextRef[] | undefined => {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const metadata = messages[index]?.metadata as ConversationMessageMetadata | undefined;
+    if (metadata?.fileContextRefs?.length) {
+      return metadata.fileContextRefs;
+    }
+  }
+  return undefined;
+};
+
+const mergeFileContextRefs = (
+  ...groups: Array<FileContextRef[] | undefined>
+): FileContextRef[] | undefined => {
+  const merged: FileContextRef[] = [];
+  const seen = new Set<string>();
+
+  groups.forEach((group) => {
+    group?.forEach((ref) => {
+      const sourceFileId = String(ref.sourceFileId || '').trim();
+      const artifactId = typeof ref.artifactId === 'string' ? ref.artifactId.trim() : '';
+      const derivedArtifactFileId = String(ref.derivedArtifactFileId || '').trim();
+      const dedupeKey = sourceFileId || artifactId || derivedArtifactFileId;
+      if (!dedupeKey || seen.has(dedupeKey)) {
+        return;
+      }
+      seen.add(dedupeKey);
+      merged.push(ref);
+    });
+  });
+
+  return merged.length ? merged : undefined;
+};
+
+const delay = (ms: number) => new Promise((resolve) => window.setTimeout(resolve, ms));
 
 const DEFAULT_PERSONA_NAME = 'fast';
 const DEFAULT_PERSONAS: AgentPersona[] = [
@@ -411,6 +465,7 @@ export default function WorkspacePage() {
   const [colorMode, setColorMode] = useState<PaletteMode>(resolveInitialColorMode);
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [selectedWorkspace, setSelectedWorkspace] = useState<Workspace | null>(null);
+  const selectedWorkspaceIdRef = useRef<string | null>(null);
   const [workspaceSettingsBusy, setWorkspaceSettingsBusy] = useState(false);
   const [workspaceSearchQuery, setWorkspaceSearchQuery] = useState('');
   const [isWorkspaceRenameActive, setIsWorkspaceRenameActive] = useState(false);
@@ -423,7 +478,7 @@ export default function WorkspacePage() {
   const [fileContent, setFileContent] = useState('');
   const [conversationMessages, setConversationMessages] = useState<Record<string, ConversationMessage[]>>({});
   const [chatMessage, setChatMessage] = useState('');
-  const [chatAttachments, setChatAttachments] = useState<File[]>([]);
+  const [chatAttachments, setChatAttachments] = useState<ChatComposerAttachment[]>([]);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const personas = DEFAULT_PERSONAS;
   const [selectedPersona, setSelectedPersona] = useState(DEFAULT_PERSONA_NAME);
@@ -450,6 +505,8 @@ export default function WorkspacePage() {
   });
   const [presentationStatus, setPresentationStatus] = useState<'idle' | 'running' | 'success' | 'error'>('idle');
   const [isPresentationModalOpen, setIsPresentationModalOpen] = useState(false);
+  const [isDrivePickerOpen, setIsDrivePickerOpen] = useState(false);
+  const [isDriveImporting, setIsDriveImporting] = useState(false);
   const [draftPresentationOptions, setDraftPresentationOptions] = useState<PresentationOptionsState | null>(null);
   const [isPptxExporting, setIsPptxExporting] = useState(false);
   const streamAbortMapRef = useRef<Map<string, AbortController>>(new Map());
@@ -467,6 +524,9 @@ export default function WorkspacePage() {
   const persistInFlightRef = useRef<Set<string>>(new Set());
   const pendingPersistRef = useRef<Record<string, PersistProgressRequest>>({});
   const stopRequestedRef = useRef(false);
+  const sendLockRef = useRef(false);
+  const attachmentPrepPromiseRef = useRef<Map<string, Promise<AttachmentPrepJob>>>(new Map());
+  const attachmentPrepResumeRef = useRef<Set<string>>(new Set());
   const chatInputRef = useRef<HTMLTextAreaElement | null>(null);
   const attachmentInputRef = useRef<HTMLInputElement | null>(null);
   const workspaceNameInputRef = useRef<HTMLInputElement | null>(null);
@@ -511,6 +571,11 @@ export default function WorkspacePage() {
   const resumeInFlightRef = useRef<Set<string>>(new Set());
   const resumeAttemptedRef = useRef<Set<string>>(new Set());
   const theme = useMemo(() => buildAppTheme(colorMode), [colorMode]);
+
+  useEffect(() => {
+    selectedWorkspaceIdRef.current = selectedWorkspace?.id ?? null;
+  }, [selectedWorkspace]);
+
   const messages = useMemo(
     () => (activeConversationId ? conversationMessages[activeConversationId] || [] : []),
     [activeConversationId, conversationMessages],
@@ -1610,6 +1675,22 @@ export default function WorkspacePage() {
     if (!selectedWorkspace) {
       return;
     }
+    const hasPendingUnderstanding = files.some((file) =>
+      String(file.understandingStatus || '').toLowerCase() === 'pending',
+    );
+    if (!hasPendingUnderstanding) {
+      return;
+    }
+    const interval = window.setInterval(() => {
+      void loadFilesForWorkspace(selectedWorkspace.id);
+    }, 5000);
+    return () => window.clearInterval(interval);
+  }, [files, loadFilesForWorkspace, selectedWorkspace]);
+
+  useEffect(() => {
+    if (!selectedWorkspace) {
+      return;
+    }
     const workspaceId = selectedWorkspace.id;
     const hasPendingStatus = Object.values(ragStatuses).some((status) => {
       const normalized = String(status?.status || '').toLowerCase();
@@ -2194,6 +2275,155 @@ export default function WorkspacePage() {
     }
   }, [activeConversationId, selectedWorkspace, selectedPersona, refreshConversationHistory, setStreamingForConversation]);
 
+  const upsertConversationMessage = useCallback(
+    (conversationId: string, nextMessage: ConversationMessage) => {
+      updateMessagesForConversation(conversationId, (prev) => {
+        const next = [...prev];
+        const existingIndex = next.findIndex((message) => {
+          if (nextMessage.id !== undefined && message.id === nextMessage.id) {
+            return true;
+          }
+          return Boolean(nextMessage.turnId) && message.sender === nextMessage.sender && message.turnId === nextMessage.turnId;
+        });
+        if (existingIndex >= 0) {
+          next[existingIndex] = nextMessage;
+          return next;
+        }
+        return [...next, nextMessage];
+      });
+    },
+    [updateMessagesForConversation],
+  );
+
+  const persistUserMessageMetadata = useCallback(
+    async (
+      conversationId: string,
+      message: ConversationMessage,
+      metadata: ConversationMessageMetadata,
+    ): Promise<ConversationMessage> => {
+      const persisted = await appendConversationMessage(conversationId, 'user', message.text, {
+        turnId: message.turnId,
+        replaceExisting: true,
+        metadata,
+      });
+      const normalized = mergeMessageMetadata(persisted);
+      upsertConversationMessage(conversationId, normalized);
+      return normalized;
+    },
+    [upsertConversationMessage],
+  );
+
+  const waitForAttachmentPrepJob = useCallback(
+    (workspaceId: string, jobId: string): Promise<AttachmentPrepJob> => {
+      const existing = attachmentPrepPromiseRef.current.get(jobId);
+      if (existing) {
+        return existing;
+      }
+      const promise = (async () => {
+        while (true) {
+          const job = await getAttachmentPrepJob(workspaceId, jobId);
+          if (job.status === 'ready' || job.status === 'failed') {
+            return job;
+          }
+          await delay(1500);
+        }
+      })().finally(() => {
+        attachmentPrepPromiseRef.current.delete(jobId);
+      });
+      attachmentPrepPromiseRef.current.set(jobId, promise);
+      return promise;
+    },
+    [],
+  );
+
+  async function launchPreparedAgentRun(params: {
+    workspaceId: string;
+    persona: string;
+    conversationId: string;
+    turnId: string;
+    prompt: string;
+    historyPayload: Array<{ role: string; content: string }>;
+    fileContextRefs?: FileContextRef[];
+    currentTurnFileIds?: number[];
+    taggedFiles?: string[];
+  }) {
+    const {
+      workspaceId,
+      persona,
+      conversationId,
+      turnId,
+      prompt,
+      historyPayload,
+      fileContextRefs,
+      currentTurnFileIds,
+      taggedFiles,
+    } = params;
+    const { runId } = await startAgentRun(
+      workspaceId,
+      persona,
+      prompt,
+      historyPayload.length ? historyPayload : undefined,
+      turnId,
+      {
+        forceReset: true,
+        taggedFiles,
+        fileContextRefs,
+        currentTurnFileIds,
+      },
+    );
+    if (STREAM_DEBUG_ENABLED) {
+      console.debug('[WorkspacePage] run started', { runId, conversationId });
+    }
+    const placeholderId = `agent-${runId}`;
+    ensureAgentPlaceholder(conversationId, placeholderId, turnId, true);
+    agentMessageBufferRef.current.set(placeholderId, '');
+    const runInfo: ActiveRunInfo = {
+      runId,
+      conversationId,
+      workspaceId,
+      persona,
+      turnId,
+      placeholderId,
+      status: 'running',
+    };
+    markRunStreamLaunching(runId);
+    registerActiveRun(runInfo);
+    setConversationAttention(conversationId, 'running', 'Queued the latest run...');
+    await streamRunForConversation(runInfo, true);
+
+    const messagesSnapshot = getConversationMessagesSnapshot(conversationId);
+    const targetIndex = messagesSnapshot.findIndex((message) => message.id === placeholderId);
+    const agentMessage = targetIndex >= 0 ? messagesSnapshot[targetIndex] : null;
+    const metadata = buildMessageMetadata(agentMessage) || {};
+    const bufferedText =
+      placeholderId !== null && placeholderId !== undefined
+        ? agentMessageBufferRef.current.get(placeholderId) ?? agentMessage?.text
+        : agentMessage?.text;
+    const placeholderTurnId = agentMessage?.turnId || turnId;
+    if (bufferedText) {
+      try {
+        const persisted = await appendConversationMessage(conversationId, 'agent', bufferedText, {
+          turnId: placeholderTurnId,
+          metadata: { ...metadata, runId },
+          replaceExisting: true,
+        });
+        upsertPersistedAgentMessage(conversationId, persisted, {
+          placeholderId,
+          existing: agentMessage,
+        });
+        if (placeholderId !== null && placeholderId !== undefined) {
+          agentMessageBufferRef.current.delete(placeholderId);
+        }
+        agentMessageBufferRef.current.set(persisted.id, persisted.text || '');
+        await refreshConversationHistory(workspaceId);
+      } catch (error) {
+        console.error('Failed to store agent message', error);
+      }
+    } else if (placeholderId !== null && placeholderId !== undefined) {
+      agentMessageBufferRef.current.delete(placeholderId);
+    }
+  }
+
   useEffect(() => {
     const loadConversations = async () => {
       if (!selectedWorkspace) {
@@ -2227,6 +2457,103 @@ export default function WorkspacePage() {
     };
     fetchWorkspaces();
   }, []);
+
+  useEffect(() => {
+    if (!selectedWorkspace?.id || !activeConversationId) {
+      return;
+    }
+    const workspaceId = selectedWorkspace.id;
+    const conversationId = activeConversationId;
+    const messagesForConversation = conversationMessages[conversationId] || [];
+    const pendingMessages = messagesForConversation.filter((message) => {
+      if (message.sender !== 'user' || !message.turnId) {
+        return false;
+      }
+      const metadata = message.metadata as ConversationMessageMetadata | undefined;
+      return Boolean(
+        metadata?.attachmentJobId
+        && (metadata.attachmentPrepStatus === 'pending' || metadata.attachmentPrepStatus === 'running'),
+      );
+    });
+    pendingMessages.forEach((message) => {
+      const metadata = message.metadata as ConversationMessageMetadata | undefined;
+      const jobId = metadata?.attachmentJobId;
+      if (!jobId || attachmentPrepResumeRef.current.has(jobId)) {
+        return;
+      }
+      attachmentPrepResumeRef.current.add(jobId);
+      void (async () => {
+        try {
+          const turnId = message.turnId;
+          if (!turnId) {
+            return;
+          }
+          setIsDriveImporting(true);
+          const settledJob = await waitForAttachmentPrepJob(workspaceId, jobId);
+          if (settledJob.status === 'failed') {
+            await persistUserMessageMetadata(conversationId, message, {
+              ...(metadata || {}),
+              attachmentJobId: jobId,
+              attachmentPrepStatus: 'failed',
+              attachmentPrepError: settledJob.error || 'Failed to prepare attachments.',
+            });
+            return;
+          }
+          const readyRefs = settledJob.result?.fileContextRefs?.length
+            ? settledJob.result.fileContextRefs
+            : undefined;
+          await persistUserMessageMetadata(conversationId, message, {
+            ...(metadata || {}),
+            attachmentJobId: jobId,
+            attachmentPrepStatus: 'ready',
+            attachmentPrepError: undefined,
+            fileContextRefs: readyRefs,
+          });
+          const agentExistsForTurn = getConversationMessagesSnapshot(conversationId).some(
+            (candidate) => candidate.sender === 'agent' && candidate.turnId === message.turnId,
+          );
+          if (agentExistsForTurn) {
+            return;
+          }
+          const updatedMessages = getConversationMessagesSnapshot(conversationId);
+          const historyPayload = mapMessagesToAgentHistory(updatedMessages);
+          const directive = parseSlashDirective(message.text.trim());
+          const agentPromptBase = buildAgentPromptFromDirective(directive) || message.text;
+          const attachmentPrompt = readyRefs?.length
+            ? `Use these attached files as primary context: ${readyRefs.map((ref) => ref.sourceName).join(', ')}`
+            : '';
+          await launchPreparedAgentRun({
+            workspaceId,
+            persona: normalizePersonaName(activeConversationPersona || selectedPersona || DEFAULT_PERSONA_NAME),
+            conversationId,
+            turnId,
+            prompt: attachmentPrompt
+              ? `${agentPromptBase}${agentPromptBase ? '\n\n' : ''}${attachmentPrompt}`
+              : agentPromptBase,
+            historyPayload,
+            fileContextRefs: readyRefs,
+            currentTurnFileIds: settledJob.result?.multimodalFileIds,
+            taggedFiles: readyRefs?.map((ref) => ref.sourceName).filter(Boolean),
+          });
+        } catch (error) {
+          console.error('Failed to resume attachment prep job', error);
+        } finally {
+          attachmentPrepResumeRef.current.delete(jobId);
+          setIsDriveImporting(false);
+        }
+      })();
+    });
+  }, [
+    activeConversationId,
+    activeConversationPersona,
+    conversationMessages,
+    getConversationMessagesSnapshot,
+    launchPreparedAgentRun,
+    persistUserMessageMetadata,
+    selectedPersona,
+    selectedWorkspace?.id,
+    waitForAttachmentPrepJob,
+  ]);
 
   useEffect(() => {
     if (!selectedWorkspace) {
@@ -4826,7 +5153,7 @@ export default function WorkspacePage() {
               await finalizeMessage('completed', status.result, status.updatedAt);
               stopPresentationProgress('success');
               removePendingPresentationPlaceholder(startResponse.jobId);
-              if (selectedWorkspace?.id === workspaceId) {
+              if (selectedWorkspaceIdRef.current === workspaceId) {
                 await loadFilesForWorkspace(workspaceId);
                 await refreshConversationHistory(workspaceId);
               }
@@ -4908,192 +5235,299 @@ export default function WorkspacePage() {
   );
 
   const handleSendMessage = async () => {
+    if (sendLockRef.current || isDriveImporting) {
+      return;
+    }
     const trimmed = chatMessage.trim();
+    const localAttachments = chatAttachments.filter(
+      (attachment): attachment is Extract<ChatComposerAttachment, { source: 'local' }> => attachment.source === 'local',
+    );
+    const driveAttachments = chatAttachments.filter(
+      (attachment): attachment is Extract<ChatComposerAttachment, { source: 'drive' }> => attachment.source === 'drive',
+    );
     const hasAttachments = chatAttachments.length > 0;
+    const hasLocalAttachments = localAttachments.length > 0;
     if (!trimmed && !hasAttachments) return;
+    sendLockRef.current = true;
 
-    stopRequestedRef.current = false;
-    const directive = parseSlashDirective(trimmed);
-    const isPresentationCommand = directive.kind === 'presentation';
-    const mentionedFiles = isPresentationCommand ? findMentionedFiles(trimmed) : [];
-    const presentationFileIds = isPresentationCommand
-      ? Array.from(
+    try {
+      stopRequestedRef.current = false;
+      const directive = parseSlashDirective(trimmed);
+      const isPresentationCommand = directive.kind === 'presentation';
+      const mentionedFiles = findMentionedFiles(trimmed);
+      const mentionedFileIds = Array.from(
         new Set(
           mentionedFiles
             .map((file) => toNumericFileId(file.id))
             .filter((id): id is number => typeof id === 'number' && Number.isFinite(id)),
         ),
-      )
-      : [];
-    const presentationBrief = isPresentationCommand ? stripMentionedFilesFromPrompt(directive.prompt) : '';
-
-    if (isPresentationCommand && hasAttachments) {
-      addLocalSystemMessage('Attachments are not supported for /presentation. Please tag files using @filename instead.');
-      return;
-    }
-    if (directive.kind === 'skill') {
-      if (hasAttachments) {
-        addLocalSystemMessage('Attachments are not supported with /skill yet. Please upload files to the workspace first and reference them in your request.');
-        return;
-      }
-      if (!directive.skillId || !directive.prompt) {
-        addLocalSystemMessage('Use /skill <skill-id> <task>. Example: /skill sales draft follow-up from today\'s call.');
-        return;
-      }
-      if (!availableSkillMap.has(directive.skillId.toLowerCase())) {
-        addLocalSystemMessage(`Skill "${directive.skillId}" is not available.`);
-        return;
-      }
-    }
-    if (directive.kind === 'mcp') {
-      if (hasAttachments) {
-        addLocalSystemMessage('Attachments are not supported with /mcp yet. Please upload files to the workspace first if needed.');
-        return;
-      }
-      if (!directive.serverId || !directive.prompt) {
-        addLocalSystemMessage('Use /mcp <server-id> <task>. Example: /mcp google-workspace search my inbox for BMMB.');
-        return;
-      }
-      if (!availableMcpServerMap.has(directive.serverId.toLowerCase())) {
-        addLocalSystemMessage(`MCP server "${directive.serverId}" is not configured.`);
-        return;
-      }
-    }
-    if (isPresentationCommand && !presentationFileIds.length) {
-      addLocalSystemMessage('Tag at least one file using @filename before requesting a presentation.');
-      return;
-    }
-    const attachmentSummary = hasAttachments
-      ? `Attachments: ${chatAttachments.map((file) => file.name).join(', ')}`
-      : '';
-    const messageContent = hasAttachments
-      ? `${trimmed}${trimmed ? '\n\n' : ''}[${attachmentSummary}]`
-      : trimmed;
-    const agentPrompt = buildAgentPromptFromDirective(directive);
-
-    if (!selectedWorkspace) {
-      addLocalSystemMessage('Please select a workspace before chatting with an agent.');
-      return;
-    }
-
-    const workspaceId = selectedWorkspace.id;
-    const persona = normalizePersonaName(activeConversationPersona || selectedPersona || DEFAULT_PERSONA_NAME);
-
-    const conversationId = await ensureConversation();
-    if (!conversationId) {
-      addLocalSystemMessage('Unable to start a conversation right now.');
-      return;
-    }
-
-    cancelStreamForConversation(conversationId);
-    lastUserMessageMapRef.current[conversationId] = messageContent;
-    setChatMessage('');
-    setChatAttachments([]);
-    closeMention();
-    closeCommand();
-
-    const pendingTurnId = generateTurnId();
-    let resolvedTurnId = pendingTurnId;
-    let userMessageRecord: ConversationMessage | null = null;
-    let historyPayload: Array<{ role: string; content: string }> = [];
-    const existingMessages = getConversationMessagesSnapshot(conversationId);
-    try {
-      const createdMessage = await appendConversationMessage(conversationId, 'user', messageContent, {
-        turnId: pendingTurnId,
-      });
-      const normalizedMessage = mergeMessageMetadata(createdMessage);
-      userMessageRecord = normalizedMessage;
-      resolvedTurnId = normalizedMessage.turnId || pendingTurnId;
-      updateMessagesForConversation(conversationId, (prev) => [...prev, normalizedMessage]);
-      await refreshConversationHistory(workspaceId);
-      const pendingMessages = [...existingMessages, normalizedMessage];
-      historyPayload = mapMessagesToAgentHistory(pendingMessages);
-    } catch (error) {
-      console.error('Failed to send user message', error);
-      addLocalSystemMessage('Failed to send your message. Please try again.');
-      return;
-    }
-    if (!userMessageRecord) {
-      addLocalSystemMessage('Failed to record your message. Please try again.');
-      return;
-    }
-
-    if (isPresentationCommand) {
-      await runPresentationCommand({
-        workspaceId,
-        conversationId,
-        turnId: resolvedTurnId,
-        brief: presentationBrief,
-        fileIds: presentationFileIds,
-        fileNames: mentionedFiles.map((file) => file.name),
-        persona,
-      });
-      return;
-    }
-
-    try {
-      const { runId } = await startAgentRun(
-        workspaceId,
-        persona,
-        agentPrompt,
-        historyPayload.length ? historyPayload : undefined,
-        resolvedTurnId,
-        { forceReset: true }
       );
-      if (STREAM_DEBUG_ENABLED) {
-        console.debug('[WorkspacePage] run started', { runId, conversationId });
-      }
-      const placeholderId = `agent-${runId}`;
-      ensureAgentPlaceholder(conversationId, placeholderId, resolvedTurnId, true);
-      agentMessageBufferRef.current.set(placeholderId, '');
-      const runInfo: ActiveRunInfo = {
-        runId,
-        conversationId,
-        workspaceId,
-        persona,
-        turnId: resolvedTurnId,
-        placeholderId,
-        status: 'running',
-      };
-      markRunStreamLaunching(runId);
-      registerActiveRun(runInfo);
-      setConversationAttention(conversationId, 'running', 'Queued the latest run...');
-      await streamRunForConversation(runInfo, true);
+      const presentationFileIds = isPresentationCommand
+        ? Array.from(
+          new Set(mentionedFileIds),
+        )
+        : [];
+      const presentationBrief = isPresentationCommand ? stripMentionedFilesFromPrompt(directive.prompt) : '';
 
-      const messagesSnapshot = getConversationMessagesSnapshot(conversationId);
-      const targetIndex = messagesSnapshot.findIndex((message) => message.id === placeholderId);
-      const agentMessage = targetIndex >= 0 ? messagesSnapshot[targetIndex] : null;
-      const metadata = buildMessageMetadata(agentMessage) || {};
-      const bufferedText =
-        placeholderId !== null && placeholderId !== undefined
-          ? agentMessageBufferRef.current.get(placeholderId) ?? agentMessage?.text
-          : agentMessage?.text;
-      const placeholderTurnId = agentMessage?.turnId || resolvedTurnId;
-      if (bufferedText) {
-        try {
-          const persisted = await appendConversationMessage(conversationId, 'agent', bufferedText, {
-            turnId: placeholderTurnId,
-            metadata: { ...metadata, runId },
-            replaceExisting: true,
-          });
-          upsertPersistedAgentMessage(conversationId, persisted, {
-            placeholderId,
-            existing: agentMessage,
-          });
-          if (placeholderId !== null && placeholderId !== undefined) {
-            agentMessageBufferRef.current.delete(placeholderId);
-          }
-          agentMessageBufferRef.current.set(persisted.id, persisted.text || '');
-          await refreshConversationHistory(workspaceId);
-        } catch (error) {
-          console.error('Failed to store agent message', error);
-        }
-      } else if (placeholderId !== null && placeholderId !== undefined) {
-        agentMessageBufferRef.current.delete(placeholderId);
+      if (isPresentationCommand && hasAttachments) {
+        addLocalSystemMessage('Attachments are not supported for /presentation. Please tag files using @filename instead.');
+        return;
       }
-    } catch (error) {
-      console.error('Failed to start agent run', error);
-      addLocalSystemMessage('Failed to start agent run. Please try again.');
+      if (directive.kind === 'skill') {
+        if (hasLocalAttachments) {
+          addLocalSystemMessage('Attachments are not supported with /skill yet. Please upload files to the workspace first and reference them in your request.');
+          return;
+        }
+        if (!directive.skillId || !directive.prompt) {
+          addLocalSystemMessage('Use /skill <skill-id> <task>. Example: /skill sales draft follow-up from today\'s call.');
+          return;
+        }
+        if (!availableSkillMap.has(directive.skillId.toLowerCase())) {
+          addLocalSystemMessage(`Skill "${directive.skillId}" is not available.`);
+          return;
+        }
+      }
+      if (directive.kind === 'mcp') {
+        if (hasLocalAttachments) {
+          addLocalSystemMessage('Attachments are not supported with /mcp yet. Please upload files to the workspace first if needed.');
+          return;
+        }
+        if (!directive.serverId || !directive.prompt) {
+          addLocalSystemMessage('Use /mcp <server-id> <task>. Example: /mcp google-workspace search my inbox for BMMB.');
+          return;
+        }
+        if (!availableMcpServerMap.has(directive.serverId.toLowerCase())) {
+          addLocalSystemMessage(`MCP server "${directive.serverId}" is not configured.`);
+          return;
+        }
+      }
+      if (isPresentationCommand && !presentationFileIds.length) {
+        addLocalSystemMessage('Tag at least one file using @filename before requesting a presentation.');
+        return;
+      }
+
+      if (!selectedWorkspace) {
+        addLocalSystemMessage('Please select a workspace before chatting with an agent.');
+        return;
+      }
+
+      const workspaceId = selectedWorkspace.id;
+      const persona = normalizePersonaName(activeConversationPersona || selectedPersona || DEFAULT_PERSONA_NAME);
+      const attachmentSummary = hasAttachments ? `Attachments: ${summarizeComposerAttachments(chatAttachments)}` : '';
+      const messageContent = hasAttachments
+        ? `${trimmed}${trimmed ? '\n\n' : ''}[${attachmentSummary}]`
+        : trimmed;
+      const agentPromptBase = buildAgentPromptFromDirective(directive) || messageContent;
+      const conversationId = await ensureConversation();
+      if (!conversationId) {
+        addLocalSystemMessage('Unable to start a conversation right now.');
+        return;
+      }
+
+      cancelStreamForConversation(conversationId);
+      lastUserMessageMapRef.current[conversationId] = messageContent;
+      setChatMessage('');
+      setChatAttachments([]);
+      setIsDrivePickerOpen(false);
+      closeMention();
+      closeCommand();
+
+      const pendingTurnId = generateTurnId();
+      let resolvedTurnId = pendingTurnId;
+      let userMessageRecord: ConversationMessage | null = null;
+      const existingMessages = getConversationMessagesSnapshot(conversationId);
+
+      try {
+        const createdMessage = await appendConversationMessage(conversationId, 'user', messageContent, {
+          turnId: pendingTurnId,
+          metadata: hasAttachments ? { attachmentPrepStatus: 'pending' } : undefined,
+        });
+        const normalizedMessage = mergeMessageMetadata(createdMessage);
+        userMessageRecord = normalizedMessage;
+        resolvedTurnId = normalizedMessage.turnId || pendingTurnId;
+        upsertConversationMessage(conversationId, normalizedMessage);
+        await refreshConversationHistory(workspaceId);
+      } catch (error) {
+        console.error('Failed to send user message', error);
+        addLocalSystemMessage('Failed to send your message. Please try again.');
+        return;
+      }
+      if (!userMessageRecord) {
+        addLocalSystemMessage('Failed to record your message. Please try again.');
+        return;
+      }
+
+      if (isPresentationCommand) {
+        await runPresentationCommand({
+          workspaceId,
+          conversationId,
+          turnId: resolvedTurnId,
+          brief: presentationBrief,
+          fileIds: presentationFileIds,
+          fileNames: mentionedFiles.map((file) => file.name),
+          persona,
+        });
+        return;
+      }
+
+      let resolvedFileContextRefs: FileContextRef[] | undefined;
+      let currentTurnFileIds: number[] | undefined;
+      let taggedFiles: string[] | undefined;
+
+      if (hasAttachments) {
+        setIsDriveImporting(true);
+        try {
+          const sourceFileIds: number[] = [];
+          for (const attachment of localAttachments) {
+            const uploaded = await createFile(workspaceId, attachment.file);
+            const uploadedId = toNumericFileId(uploaded.id);
+            if (uploadedId) {
+              sourceFileIds.push(uploadedId);
+            }
+          }
+          if (sourceFileIds.length && selectedWorkspaceIdRef.current === workspaceId) {
+            await loadFilesForWorkspace(workspaceId);
+          }
+          const prepJob = await createAttachmentPrepJob(workspaceId, {
+            conversationId,
+            turnId: resolvedTurnId,
+            driveFileIds: driveAttachments.map((attachment) => attachment.driveItem.id),
+            sourceFileIds,
+          });
+          attachmentPrepResumeRef.current.add(prepJob.id);
+          userMessageRecord = await persistUserMessageMetadata(conversationId, userMessageRecord, {
+            ...((userMessageRecord.metadata as ConversationMessageMetadata | undefined) || {}),
+            attachmentJobId: prepJob.id,
+            attachmentPrepStatus: prepJob.status,
+            attachmentPrepError: undefined,
+          });
+          const settledJob = prepJob.status === 'ready' || prepJob.status === 'failed'
+            ? prepJob
+            : await waitForAttachmentPrepJob(workspaceId, prepJob.id);
+          if (settledJob.status === 'failed') {
+            await persistUserMessageMetadata(conversationId, userMessageRecord, {
+              ...((userMessageRecord.metadata as ConversationMessageMetadata | undefined) || {}),
+              attachmentJobId: settledJob.id,
+              attachmentPrepStatus: 'failed',
+              attachmentPrepError: settledJob.error || 'Failed to prepare attachments.',
+            });
+            addLocalSystemMessage(settledJob.error || 'Failed to prepare attachments.');
+            return;
+          }
+          const preparedFiles = Array.isArray(settledJob.result?.files) ? settledJob.result?.files : [];
+          if (preparedFiles?.length && selectedWorkspaceIdRef.current === workspaceId) {
+            await loadFilesForWorkspace(workspaceId);
+          }
+          resolvedFileContextRefs = settledJob.result?.fileContextRefs?.length
+            ? settledJob.result.fileContextRefs
+            : undefined;
+          currentTurnFileIds = settledJob.result?.multimodalFileIds?.length
+            ? settledJob.result.multimodalFileIds
+            : undefined;
+          taggedFiles = resolvedFileContextRefs?.map((ref) => ref.sourceName).filter(Boolean);
+          userMessageRecord = await persistUserMessageMetadata(conversationId, userMessageRecord, {
+            ...((userMessageRecord.metadata as ConversationMessageMetadata | undefined) || {}),
+            attachmentJobId: settledJob.id,
+            attachmentPrepStatus: 'ready',
+            attachmentPrepError: undefined,
+            fileContextRefs: resolvedFileContextRefs,
+          });
+        } catch (error) {
+          console.error('Failed to prepare attachments', error);
+          const message = error instanceof Error ? error.message : 'Failed to prepare attachments.';
+          await persistUserMessageMetadata(conversationId, userMessageRecord, {
+            ...((userMessageRecord.metadata as ConversationMessageMetadata | undefined) || {}),
+            attachmentPrepStatus: 'failed',
+            attachmentPrepError: message,
+          }).catch((persistError) => {
+            console.error('Failed to persist attachment prep failure', persistError);
+          });
+          addLocalSystemMessage(message);
+          return;
+        } finally {
+          const jobId = (userMessageRecord?.metadata as ConversationMessageMetadata | undefined)?.attachmentJobId;
+          if (jobId) {
+            attachmentPrepResumeRef.current.delete(jobId);
+          }
+          setIsDriveImporting(false);
+        }
+      } else {
+        const previousFileContextRefs = findLatestFileContextRefs(existingMessages);
+        if (previousFileContextRefs?.length) {
+          try {
+            const refreshed = await resolveFileContextRefs(
+              workspaceId,
+              previousFileContextRefs
+                .map((ref) => Number(ref.sourceFileId))
+                .filter((value) => Number.isFinite(value) && value > 0),
+            );
+            resolvedFileContextRefs = Array.isArray(refreshed.fileContextRefs) && refreshed.fileContextRefs.length
+              ? refreshed.fileContextRefs
+              : previousFileContextRefs;
+          } catch (error) {
+            console.error('Failed to refresh file context refs', error);
+            resolvedFileContextRefs = previousFileContextRefs;
+          }
+        }
+      }
+
+      if (mentionedFileIds.length) {
+        try {
+          const resolvedMentions = await resolveFileContextRefs(workspaceId, mentionedFileIds);
+          resolvedFileContextRefs = hasAttachments
+            ? mergeFileContextRefs(resolvedFileContextRefs, resolvedMentions.fileContextRefs)
+            : mergeFileContextRefs(resolvedMentions.fileContextRefs, resolvedFileContextRefs);
+        } catch (error) {
+          console.error('Failed to resolve mentioned file context refs', error);
+          resolvedFileContextRefs = mergeFileContextRefs(resolvedFileContextRefs);
+        }
+      }
+
+      if (resolvedFileContextRefs?.length) {
+        taggedFiles = resolvedFileContextRefs.map((ref) => ref.sourceName).filter(Boolean);
+      } else if (mentionedFiles.length) {
+        taggedFiles = mentionedFiles.map((file) => file.name).filter(Boolean);
+      }
+
+      if (mentionedFileIds.length && resolvedFileContextRefs?.length) {
+        try {
+          userMessageRecord = await persistUserMessageMetadata(conversationId, userMessageRecord, {
+            ...((userMessageRecord.metadata as ConversationMessageMetadata | undefined) || {}),
+            fileContextRefs: resolvedFileContextRefs,
+          });
+        } catch (error) {
+          console.error('Failed to persist mentioned file context refs', error);
+        }
+      }
+
+      const preparedMessages = getConversationMessagesSnapshot(conversationId);
+      const historyPayload = mapMessagesToAgentHistory(preparedMessages);
+      const attachmentPrompt = resolvedFileContextRefs?.length
+        ? `Use these attached files as primary context: ${resolvedFileContextRefs.map((ref) => ref.sourceName).join(', ')}`
+        : '';
+      const agentPrompt = attachmentPrompt
+        ? `${agentPromptBase}${agentPromptBase ? '\n\n' : ''}${attachmentPrompt}`
+        : agentPromptBase;
+
+      try {
+        await launchPreparedAgentRun({
+          workspaceId,
+          persona,
+          conversationId,
+          turnId: resolvedTurnId,
+          prompt: agentPrompt,
+          historyPayload,
+          fileContextRefs: resolvedFileContextRefs,
+          currentTurnFileIds,
+          taggedFiles,
+        });
+      } catch (error) {
+        console.error('Failed to start agent run', error);
+        addLocalSystemMessage('Failed to start agent run. Please try again.');
+      }
+    } finally {
+      setIsDriveImporting(false);
+      sendLockRef.current = false;
     }
   };
 
@@ -5342,27 +5776,66 @@ export default function WorkspacePage() {
       for (const file of filesToUpload) {
         const newFileData = (await createFile(selectedWorkspace.id, file)) as WorkspaceFile;
         setFiles((prevFiles) => [...prevFiles, newFileData]);
-        if (newFileData?.name) {
-          setRagStatuses((prev) => ({
-            ...prev,
-            [newFileData.name]: { status: 'pending' },
-          }));
-        }
       }
     } catch (error) {
       console.error('Failed to upload file:', error);
     }
   };
 
-  const handleChatAttachmentButtonClick = () => {
+  const handleOpenLocalAttachmentPicker = () => {
     attachmentInputRef.current?.click();
   };
 
   const handleChatAttachmentChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (!event.target.files) return;
     const selected = Array.from(event.target.files);
-    setChatAttachments((prev) => [...prev, ...selected]);
+    setChatAttachments((prev) => [
+      ...prev,
+      ...selected.map((file) => ({
+        id: `local:${file.name}:${file.size}:${file.lastModified}:${Math.random().toString(16).slice(2)}`,
+        name: file.name,
+        source: 'local' as const,
+        file,
+      })),
+    ]);
     event.target.value = '';
+  };
+
+  const handleOpenDrivePicker = () => {
+    if (!selectedWorkspace) {
+      addLocalSystemMessage('Please select a workspace before attaching Google Drive files.');
+      return;
+    }
+    setIsDrivePickerOpen(true);
+  };
+
+  const handleDrivePickerConfirm = (items: GoogleDrivePickerItem[]) => {
+    if (!items.length) {
+      setIsDrivePickerOpen(false);
+      return;
+    }
+    setChatAttachments((prev) => {
+      const existingDriveIds = new Set(
+        prev
+          .filter((attachment): attachment is Extract<ChatComposerAttachment, { source: 'drive' }> => attachment.source === 'drive')
+          .map((attachment) => attachment.driveItem.id),
+      );
+      const next = [...prev];
+      items.forEach((item) => {
+        if (existingDriveIds.has(item.id)) {
+          return;
+        }
+        existingDriveIds.add(item.id);
+        next.push({
+          id: `drive:${item.id}`,
+          name: item.name,
+          source: 'drive',
+          driveItem: item,
+        });
+      });
+      return next;
+    });
+    setIsDrivePickerOpen(false);
   };
 
   const handleRemoveChatAttachment = (index: number) => {
@@ -5838,6 +6311,7 @@ export default function WorkspacePage() {
               conversationStreaming={conversationStreaming}
               messages={messages}
               isStreaming={isStreaming}
+              isPreparingAttachments={isDriveImporting}
               personaDisplayName={personaDisplayName}
               messageBubbleMaxWidth={messageBubbleMaxWidth}
               markdownComponents={markdownComponents}
@@ -5896,7 +6370,8 @@ export default function WorkspacePage() {
               onChatInputKeyDown={handleChatInputKeyDown}
               onChatInputKeyUp={handleChatInputKeyUp}
               onChatInputSelectionChange={handleChatInputSelectionChange}
-              onChatAttachmentButtonClick={handleChatAttachmentButtonClick}
+              onOpenLocalAttachmentPicker={handleOpenLocalAttachmentPicker}
+              onOpenDrivePicker={handleOpenDrivePicker}
               onInsertSlashTrigger={handleInsertSlashTrigger}
               onOpenPresentationModal={handleOpenPresentationModal}
               onStopStreaming={handleStopStreaming}
@@ -5916,6 +6391,13 @@ export default function WorkspacePage() {
         onChange={handleDraftPresentationOptionChange}
         onClose={handleClosePresentationModal}
         onSave={handleSavePresentationOptions}
+      />
+      <DrivePickerModal
+        isOpen={isDrivePickerOpen}
+        workspaceId={selectedWorkspace?.id}
+        colorMode={colorMode}
+        onClose={() => setIsDrivePickerOpen(false)}
+        onConfirm={handleDrivePickerConfirm}
       />
     </ThemeProvider>
   );

--- a/frontend/src/services/agentApi.ts
+++ b/frontend/src/services/agentApi.ts
@@ -1,7 +1,7 @@
 import { streamAgentRunWithReconnect, type AgentStreamChunk } from '../../../packages/shared/src/services/agentStream';
 export type { AgentStreamChunk };
 import { API_URL, apiFetch } from './apiClient';
-import type { ConversationMessageMetadata, InterruptAnswersByQuestionId } from '../types';
+import type { ConversationMessageMetadata, FileContextRef, InterruptAnswersByQuestionId } from '../types';
 import type { SkillDefinition } from '../types';
 
 const STREAM_DEBUG_ENABLED =
@@ -43,7 +43,11 @@ export const startAgentRun = async (
   prompt: string,
   history: Array<{ role: string; content: string }> | undefined,
   turnId?: string,
-  options?: AgentStreamOptions,
+  options?: AgentStreamOptions & {
+    taggedFiles?: string[];
+    fileContextRefs?: FileContextRef[];
+    currentTurnFileIds?: number[];
+  },
 ): Promise<AgentRunStartResponse> => {
   const response = await apiFetch(`${API_URL}/agent/runs`, {
     method: 'POST',
@@ -57,6 +61,9 @@ export const startAgentRun = async (
       history,
       forceReset: options?.forceReset,
       turnId,
+      taggedFiles: options?.taggedFiles,
+      fileContextRefs: options?.fileContextRefs,
+      currentTurnFileIds: options?.currentTurnFileIds,
     }),
   });
   if (!response.ok) {

--- a/frontend/src/services/attachmentPrepApi.ts
+++ b/frontend/src/services/attachmentPrepApi.ts
@@ -1,0 +1,63 @@
+import { API_URL, apiFetch } from './apiClient';
+import type { File as WorkspaceFile, FileContextRef, AttachmentPrepStatus } from '../types';
+
+export type AttachmentPrepJob = {
+  id: string;
+  workspaceId: string;
+  conversationId: string;
+  turnId: string;
+  status: AttachmentPrepStatus;
+  createdAt: string;
+  updatedAt: string;
+  error?: string;
+  result?: {
+    files: WorkspaceFile[];
+    fileContextRefs: FileContextRef[];
+    multimodalFileIds: number[];
+  };
+};
+
+const readAttachmentPrepError = async (response: Response, fallback: string): Promise<string> => {
+  try {
+    const payload = await response.json();
+    if (payload && typeof payload === 'object' && typeof payload.error === 'string' && payload.error.trim()) {
+      return payload.error;
+    }
+  } catch {
+    // Ignore non-JSON responses.
+  }
+  return fallback;
+};
+
+export const createAttachmentPrepJob = async (
+  workspaceId: string,
+  payload: {
+    conversationId: string;
+    turnId: string;
+    driveFileIds?: string[];
+    sourceFileIds?: number[];
+  },
+): Promise<AttachmentPrepJob> => {
+  const response = await apiFetch(`${API_URL}/workspaces/${workspaceId}/attachments/jobs`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error(await readAttachmentPrepError(response, 'Failed to prepare attachments'));
+  }
+  return response.json();
+};
+
+export const getAttachmentPrepJob = async (
+  workspaceId: string,
+  jobId: string,
+): Promise<AttachmentPrepJob> => {
+  const response = await apiFetch(`${API_URL}/workspaces/${workspaceId}/attachments/jobs/${jobId}`);
+  if (!response.ok) {
+    throw new Error(await readAttachmentPrepError(response, 'Failed to load attachment prep status'));
+  }
+  return response.json();
+};

--- a/frontend/src/services/fileApi.ts
+++ b/frontend/src/services/fileApi.ts
@@ -1,4 +1,9 @@
 import { API_URL, apiFetch } from './apiClient';
+import type {
+  FileContextRef,
+  GoogleDrivePickerScope,
+  GoogleDriveSearchResult,
+} from '../types';
 
 export const getFiles = async (workspaceId: string) => {
   const response = await apiFetch(`${API_URL}/workspaces/${workspaceId}/files`);
@@ -132,6 +137,76 @@ export const getRagStatuses = async (workspaceId: string, files: string[]) => {
   });
   if (!response.ok) {
     throw new Error('Failed to fetch RAG status');
+  }
+  return response.json();
+};
+
+export const searchGoogleDriveFiles = async (
+  workspaceId: string,
+  params: { query?: string; scope?: GoogleDrivePickerScope; pageToken?: string },
+): Promise<GoogleDriveSearchResult> => {
+  const url = new URL(`${API_URL}/workspaces/${workspaceId}/files/drive/search`);
+  if (params.query?.trim()) {
+    url.searchParams.set('query', params.query.trim());
+  }
+  if (params.scope) {
+    url.searchParams.set('scope', params.scope);
+  }
+  if (params.pageToken?.trim()) {
+    url.searchParams.set('pageToken', params.pageToken.trim());
+  }
+  const response = await apiFetch(url.toString());
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null);
+    throw new Error(
+      payload && typeof payload === 'object' && typeof payload.error === 'string'
+        ? payload.error
+        : 'Failed to search Google Drive',
+    );
+  }
+  return response.json();
+};
+
+export const importGoogleDriveFiles = async (
+  workspaceId: string,
+  fileIds: string[],
+) => {
+  const response = await apiFetch(`${API_URL}/workspaces/${workspaceId}/files/drive/import`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ fileIds }),
+  });
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null);
+    throw new Error(
+      payload && typeof payload === 'object' && typeof payload.error === 'string'
+        ? payload.error
+        : 'Failed to import Google Drive files',
+    );
+  }
+  return response.json();
+};
+
+export const resolveFileContextRefs = async (
+  workspaceId: string,
+  fileIds: number[],
+): Promise<{ fileContextRefs: FileContextRef[] }> => {
+  const response = await apiFetch(`${API_URL}/workspaces/${workspaceId}/files/context`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ fileIds }),
+  });
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null);
+    throw new Error(
+      payload && typeof payload === 'object' && typeof payload.error === 'string'
+        ? payload.error
+        : 'Failed to prepare attached files',
+    );
   }
   return response.json();
 };

--- a/frontend/src/utils/files.tsx
+++ b/frontend/src/utils/files.tsx
@@ -27,6 +27,11 @@ const TEXT_PREVIEW_EXTENSIONS = new Set([
 
 export const normalizeFilePath = (value: string) => value.replace(/\\/g, '/');
 
+export const isExtractedAssetFilePath = (value: string): boolean => {
+  const normalized = normalizeFilePath(value || '').replace(/^\/+/, '').toLowerCase();
+  return normalized.startsWith('.system/extracted-assets/');
+};
+
 export const getFileDisplayName = (value: string) => {
   if (!value) {
     return '';
@@ -60,6 +65,9 @@ export const getFileTypeIcon = (value: string) => {
 export const isSystemFile = (file: WorkspaceFile): boolean => {
   const name = normalizeFilePath(file.name || '');
   if (!name) {
+    return false;
+  }
+  if (isExtractedAssetFilePath(name)) {
     return false;
   }
   const lowerName = name.toLowerCase();

--- a/frontend/src/utils/messages.ts
+++ b/frontend/src/utils/messages.ts
@@ -88,6 +88,18 @@ export const buildMessageMetadata = (
   if (existingMetadata?.pendingInterrupt) {
     metadata.pendingInterrupt = existingMetadata.pendingInterrupt;
   }
+  if (existingMetadata?.attachmentJobId) {
+    metadata.attachmentJobId = existingMetadata.attachmentJobId;
+  }
+  if (existingMetadata?.attachmentPrepStatus) {
+    metadata.attachmentPrepStatus = existingMetadata.attachmentPrepStatus;
+  }
+  if (existingMetadata?.attachmentPrepError) {
+    metadata.attachmentPrepError = existingMetadata.attachmentPrepError;
+  }
+  if (existingMetadata?.fileContextRefs?.length) {
+    metadata.fileContextRefs = existingMetadata.fileContextRefs;
+  }
   return Object.keys(metadata).length ? metadata : undefined;
 };
 

--- a/infra/gke/k8s/50-app.yaml
+++ b/infra/gke/k8s/50-app.yaml
@@ -190,8 +190,10 @@ spec:
             - name: AGENT_CONFIG_PATH
               value: /agent/config/runtime.yaml
             - name: RAG_PARSER_PIPELINE
-              value: basic
-            - name: PARSER
+              value: raganything
+            - name: RAGANYTHING_PARSER
+              value: docling
+            - name: PARSER_ENRICHMENT_MODE
               value: docling
             - name: POSTGRES_HOST
               value: postgres

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -19,6 +19,50 @@ export interface File {
   mimeType?: string | null;
   publicUrl?: string | null;
   content?: string;
+  understandingStatus?: DerivedArtifactStatus | null;
+  understandingMode?: DerivedArtifactMode | null;
+  understandingError?: string | null;
+  derivedArtifactFileId?: number | null;
+}
+
+export type GoogleDrivePickerScope = 'recent' | 'my-drive' | 'shared';
+
+export type GoogleDriveIconHint = 'docs' | 'sheets' | 'slides' | 'pdf' | 'image' | 'file';
+
+export interface GoogleDrivePickerItem {
+  id: string;
+  name: string;
+  mimeType: string;
+  webViewUrl?: string | null;
+  modifiedTime?: string | null;
+  ownerNames?: string[];
+  size?: string | null;
+  iconHint: GoogleDriveIconHint;
+  scope?: GoogleDrivePickerScope;
+}
+
+export interface GoogleDriveSearchResult {
+  files: GoogleDrivePickerItem[];
+  nextPageToken?: string | null;
+}
+
+export type DerivedArtifactStatus = 'pending' | 'partial' | 'ready' | 'failed' | 'superseded';
+export type DerivedArtifactMode = 'part' | 'parser' | 'hybrid';
+export type AttachmentPrepStatus = 'pending' | 'running' | 'ready' | 'failed';
+
+export interface FileContextRef {
+  sourceFileId: number;
+  sourceName: string;
+  sourceMimeType?: string | null;
+  sourceVersionFingerprint: string;
+  artifactId: string;
+  artifactVersion: number;
+  derivedArtifactFileId?: number | null;
+  derivedArtifactPath?: string | null;
+  effectiveMode: DerivedArtifactMode;
+  status: DerivedArtifactStatus;
+  summary?: string | null;
+  lastError?: string | null;
 }
 
 export interface AgentPersona {
@@ -119,6 +163,9 @@ export interface ConversationMessageMetadata {
   bodySource?: 'assistant' | 'summary';
   runId?: string;
   status?: 'queued' | 'running' | 'awaiting_approval' | 'completed' | 'failed' | 'cancelled';
+  attachmentJobId?: string;
+  attachmentPrepStatus?: AttachmentPrepStatus;
+  attachmentPrepError?: string;
   pendingInterrupt?: PendingInterrupt;
   runPolicy?: {
     skill?: string;
@@ -128,6 +175,7 @@ export interface ConversationMessageMetadata {
     prePlanSearchLimit?: number;
     prePlanSearchUsed?: number;
   };
+  fileContextRefs?: FileContextRef[];
 }
 
 export interface ConversationMessage {

--- a/tests/test_agent_configuration.py
+++ b/tests/test_agent_configuration.py
@@ -9,15 +9,26 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "agent"))
 from helpudoc_agent.configuration import load_settings  # noqa: E402
 
 
-def test_env_override_paths_resolve_from_agent_root(monkeypatch) -> None:
+def test_workspace_root_env_override_resolves_from_repo_root(monkeypatch) -> None:
     repo_root = Path(__file__).resolve().parents[1]
-    agent_root = repo_root / "agent"
 
     monkeypatch.chdir(repo_root)
-    monkeypatch.setenv("WORKSPACE_ROOT", "../backend/workspaces")
-    monkeypatch.setenv("SKILLS_ROOT", "../skills")
+    monkeypatch.setenv("WORKSPACE_ROOT", "backend/workspaces")
+    monkeypatch.setenv("SKILLS_ROOT", "skills")
 
     settings = load_settings()
 
     assert settings.backend.workspace_root == (repo_root / "backend" / "workspaces").resolve()
     assert settings.backend.skills_root == (repo_root / "skills").resolve()
+
+
+def test_workspace_root_defaults_to_runtime_yaml_repo_relative_path(monkeypatch) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+
+    monkeypatch.chdir(repo_root)
+    monkeypatch.delenv("WORKSPACE_ROOT", raising=False)
+    monkeypatch.delenv("SKILLS_ROOT", raising=False)
+
+    settings = load_settings()
+
+    assert settings.backend.workspace_root == (repo_root / "backend" / "workspaces").resolve()

--- a/tests/test_mcp_binding.py
+++ b/tests/test_mcp_binding.py
@@ -21,13 +21,18 @@ if str(AGENT_DIR) not in sys.path:
 from langchain_core.tools import StructuredTool, tool  # noqa: E402
 
 from helpudoc_agent.configuration import Settings  # noqa: E402
-from helpudoc_agent.graph import AgentRegistry  # noqa: E402
+from helpudoc_agent.graph import AgentRegistry, _clone_preservable_context  # noqa: E402
 from helpudoc_agent.mcp_manager import (  # noqa: E402
     MCPServerManager,
     _preflight_gemini_tools,
     _wrap_tool_for_gemini,
 )
-from helpudoc_agent.skills_registry import get_candidate_mcp_servers  # noqa: E402
+from helpudoc_agent.skills_registry import (  # noqa: E402
+    SkillMetadata,
+    SkillPolicy,
+    activate_skill_context,
+    get_candidate_mcp_servers,
+)
 from helpudoc_agent.state import WorkspaceState  # noqa: E402
 
 
@@ -108,6 +113,11 @@ def _build_settings(tmp_path: Path) -> Settings:
                 "transport": "http",
                 "url": "https://knowledge.example.com/mcp",
             },
+            "google-workspace": {
+                "name": "google-workspace",
+                "transport": "http",
+                "url": "https://workspace.example.com/mcp",
+            },
         },
     }
     try:
@@ -119,6 +129,11 @@ def _build_settings(tmp_path: Path) -> Settings:
 class ToolFactoryStub:
     def build_tools(self, _tool_names, _workspace_state):
         return []
+
+
+class UncopyableHandle:
+    def __deepcopy__(self, memo):
+        raise TypeError("cannot pickle '_duckdb.DuckDBPyConnection' object")
 
 
 def test_preflight_handles_live_like_pricing_union_schema():
@@ -174,6 +189,7 @@ def test_registry_preserves_runtime_context_when_auth_fingerprint_rotates(tmp_pa
     )
     runtime.workspace_state.context["thread_id"] = "general-assistant:fast:workspace-rotate:user-1:thread"
     runtime.workspace_state.context["custom_resume_marker"] = "keep-me"
+    runtime.workspace_state.context["data_agent_manager"] = UncopyableHandle()
 
     rotated_runtime = asyncio.run(
         registry.get_or_create(
@@ -192,11 +208,26 @@ def test_registry_preserves_runtime_context_when_auth_fingerprint_rotates(tmp_pa
     assert rotated_runtime.workspace_state.context["thread_id"] == "general-assistant:fast:workspace-rotate:user-1:thread"
     assert rotated_runtime.workspace_state.context["active_skill"] == "frontend-slides"
     assert rotated_runtime.workspace_state.context["custom_resume_marker"] == "keep-me"
+    assert "data_agent_manager" not in rotated_runtime.workspace_state.context
     assert rotated_runtime.workspace_state.context["mcp_auth_fingerprint"] == "fingerprint-b"
     assert rotated_runtime.workspace_state.context["mcp_auth"] == {
         "google-workspace": {"Authorization": "Bearer refreshed-token"}
     }
     assert len(created_tools) == 2
+
+
+def test_clone_preservable_context_skips_uncopyable_handles():
+    cloned = _clone_preservable_context(
+        {
+            "thread_id": "thread-123",
+            "tagged_files": ["spec.docx"],
+            "data_agent_manager": UncopyableHandle(),
+        }
+    )
+
+    assert cloned["thread_id"] == "thread-123"
+    assert cloned["tagged_files"] == ["spec.docx"]
+    assert "data_agent_manager" not in cloned
 
 
 def test_aws_pricing_wrapper_sanitizes_schema_and_normalizes_inputs():
@@ -301,15 +332,41 @@ def test_preflight_accepts_simple_gemini_safe_tool():
 
 def test_candidate_servers_only_for_general_and_proposal_skills():
     assert get_candidate_mcp_servers(None) == []
+    assert get_candidate_mcp_servers(None, preferred_server="google-workspace") == ["google-workspace"]
     assert get_candidate_mcp_servers({"skill_id": "research", "tools": [], "mcp_servers": []}) == []
     assert get_candidate_mcp_servers({"skill_id": "general", "tools": [], "mcp_servers": []}) == [
         "aws-pricing",
         "aws-knowledge",
     ]
+    assert get_candidate_mcp_servers(
+        {"skill_id": "general", "tools": [], "mcp_servers": []},
+        preferred_server="google-workspace",
+    ) == [
+        "aws-pricing",
+        "aws-knowledge",
+        "google-workspace",
+    ]
     assert get_candidate_mcp_servers({"skill_id": "proposal-writing", "tools": [], "mcp_servers": []}) == [
         "aws-pricing",
         "aws-knowledge",
     ]
+
+
+def test_activate_skill_context_inherits_preferred_mcp_server():
+    context = {"preferred_mcp_server": "google-workspace"}
+    skill = SkillMetadata(
+        skill_id="research",
+        name="research",
+        description=None,
+        tools=[],
+        mcp_servers=[],
+        policy=SkillPolicy(),
+        path=Path("/tmp/research/SKILL.md"),
+    )
+
+    activate_skill_context(context, skill)
+
+    assert context["active_skill_scope"]["mcp_servers"] == ["google-workspace"]
 
 
 def test_manager_accepts_wrapped_aws_pricing_and_compatible_server(
@@ -423,3 +480,60 @@ def test_agent_registry_builds_runtime_with_wrapped_aws_pricing_candidate(
 
     assert runtime is not None
     assert captured["tool_names"] == ["get_pricing", "aws___search_documentation"]
+
+
+def test_agent_registry_rebuilds_runtime_when_preferred_mcp_server_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    settings = _build_settings(tmp_path)
+    initialize_calls: list[list[str]] = []
+
+    class DummyAgent:
+        def __init__(self, tools):
+            self.tools = tools
+
+        def with_config(self, _config):
+            return self
+
+    def fake_create_agent(*, model, tools, system_prompt, middleware, checkpointer):
+        return DummyAgent(tools)
+
+    async def fake_initialize(self, *, candidate_server_names=None, preflight_gemini=False):
+        initialize_calls.append(list(candidate_server_names or []))
+        self._allowed_servers = {}
+        self._tools_by_server = {}
+        self._clients_by_server = {}
+        self._rejected_servers = {}
+
+    monkeypatch.setattr("helpudoc_agent.graph.create_agent", fake_create_agent)
+    monkeypatch.setattr("helpudoc_agent.graph.init_chat_model", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.FilesystemBackend", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.TodoListMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.FilesystemMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.SummarizationMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.PatchToolCallsMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.HumanInTheLoopMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.mcp_manager.MCPServerManager.initialize", fake_initialize)
+
+    registry = AgentRegistry(settings, ToolFactoryStub())
+
+    runtime = asyncio.run(
+        registry.get_or_create(
+            "fast",
+            "workspace-pref",
+            initial_context={},
+        )
+    )
+    rebound_runtime = asyncio.run(
+        registry.get_or_create(
+            "fast",
+            "workspace-pref",
+            initial_context={"preferred_mcp_server": "google-workspace"},
+        )
+    )
+
+    assert runtime is not rebound_runtime
+    assert initialize_calls == [[], ["google-workspace"]]
+    assert rebound_runtime.workspace_state.context["preferred_mcp_server"] == "google-workspace"
+    assert rebound_runtime.workspace_state.context["_bound_mcp_candidates"] == ["google-workspace"]

--- a/tests/test_tool_factory.py
+++ b/tests/test_tool_factory.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+
+from helpudoc_agent.configuration import ToolConfig
+from helpudoc_agent.tools_and_schemas import ToolFactory
+
+
+class SettingsStub:
+    def __init__(self, tools):
+        self._tools = tools
+
+    def get_tool(self, name: str) -> ToolConfig:
+        return self._tools[name]
+
+
+def test_build_tools_skips_missing_entrypoint(monkeypatch):
+    factory = ToolFactory(
+        SettingsStub(
+            {
+                "missing_tool": ToolConfig(
+                    name="missing_tool",
+                    entrypoint="helpudoc_agent.arxiv_tools:build_arxiv_tools",
+                )
+            }
+        ),
+        source_tracker=SimpleNamespace(),
+        gemini_manager=SimpleNamespace(),
+    )
+
+    def fake_import_module(module_path: str):
+        raise ModuleNotFoundError(f"No module named '{module_path}'", name=module_path)
+
+    monkeypatch.setattr("helpudoc_agent.tools_and_schemas.import_module", fake_import_module)
+
+    built = factory.build_tools(["missing_tool"], workspace_state=SimpleNamespace())
+
+    assert built == []


### PR DESCRIPTION
## Summary
- add queued attachment prep and hidden derived artifacts as the canonical document representation
- standardize docling-backed processing for uploaded and attached pdf/docx/pptx files
- resolve mentioned files into fileContextRefs so exact-file chat turns ground on artifacts instead of raw filenames

## Testing
- backend/node_modules/.bin/tsc -p backend/tsconfig.json --noEmit
- npm --prefix frontend run build