### PR TITLE
Fix intermittent pre-run failure and MCP binding hardening

### DIFF
--- a/agent/helpudoc_agent/graph.py
+++ b/agent/helpudoc_agent/graph.py
@@ -223,6 +223,12 @@ class AgentRegistry:
             candidate_server_names=candidate_mcp_servers,
             preflight_gemini=self.settings.model.provider == "gemini",
         )
+        preferred_server = workspace_state.context.get("preferred_mcp_server")
+        normalized_preferred = str(preferred_server).strip() if isinstance(preferred_server, str) else ""
+        bound_servers = list(mcp_manager.get_tools_by_server().keys())
+        workspace_state.context["preferred_mcp_server_bound"] = bool(
+            normalized_preferred and normalized_preferred in bound_servers
+        )
         mcp_tools = []
         for server_name, server_tools in mcp_manager.get_tools_by_server().items():
             for tool in server_tools:

--- a/agent/helpudoc_agent/graph.py
+++ b/agent/helpudoc_agent/graph.py
@@ -158,9 +158,14 @@ class AgentRegistry:
         context_payload = initial_context or {}
         policy_key = json.dumps(context_payload.get("mcp_policy", {}) or {}, sort_keys=True, default=str)
         mcp_auth_fingerprint = str(context_payload.get("mcp_auth_fingerprint") or "")
+        preferred_mcp_server = str(context_payload.get("preferred_mcp_server") or "").strip()
         user_key = str(context_payload.get("user_id") or "")
         cache_scope_prefix = f"{user_key}:{policy_key}:"
-        key = (resolved_name, workspace_id, f"{user_key}:{policy_key}:{mcp_auth_fingerprint}")
+        key = (
+            resolved_name,
+            workspace_id,
+            f"{user_key}:{policy_key}:{mcp_auth_fingerprint}:{preferred_mcp_server}",
+        )
         if key in self._cache:
             runtime = self._cache[key]
             if context_payload:

--- a/agent/helpudoc_agent/graph.py
+++ b/agent/helpudoc_agent/graph.py
@@ -105,6 +105,47 @@ class AgentRegistry:
         self._models[model_name] = model
         return model
 
+    def _resolve_candidate_mcp_servers(self, workspace_state: WorkspaceState) -> list[str]:
+        """Resolve MCP bind candidates from active skill scope and /mcp preference.
+
+        Order is deterministic:
+        1) skill-derived candidates
+        2) explicit preferred MCP server (if configured and not already present)
+        """
+        active_skill = workspace_state.context.get("active_skill_scope")
+        skill_candidates = list(get_candidate_mcp_servers(active_skill))
+
+        preferred = workspace_state.context.get("preferred_mcp_server")
+        preferred_server = str(preferred).strip() if isinstance(preferred, str) else ""
+        candidates: list[str] = []
+        seen: set[str] = set()
+        for server_name in skill_candidates:
+            normalized = str(server_name).strip()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            candidates.append(normalized)
+
+        if preferred_server:
+            if preferred_server in self.settings.mcp_servers:
+                if preferred_server not in seen:
+                    candidates.append(preferred_server)
+            else:
+                logger.warning(
+                    "Ignoring preferred MCP server not present in runtime config (workspace=%s preferred=%s)",
+                    workspace_state.workspace_id,
+                    preferred_server,
+                )
+
+        logger.info(
+            "MCP bind candidates resolved (workspace=%s preferred=%s allowed_by_skill=%s final_candidates=%s)",
+            workspace_state.workspace_id,
+            preferred_server or None,
+            skill_candidates,
+            candidates,
+        )
+        return candidates
+
     async def get_or_create(
         self,
         agent_name: str,
@@ -176,14 +217,8 @@ class AgentRegistry:
             for tool in self.tool_factory.build_tools(tool_names, workspace_state)
         ]
 
-        active_skill = workspace_state.context.get("active_skill_scope")
-        candidate_mcp_servers = get_candidate_mcp_servers(active_skill)
+        candidate_mcp_servers = self._resolve_candidate_mcp_servers(workspace_state)
         mcp_manager = MCPServerManager(self.settings, workspace_state)
-        logger.info(
-            "MCP bind candidates resolved (workspace=%s allowed_by_skill=%s)",
-            workspace_id,
-            candidate_mcp_servers,
-        )
         await mcp_manager.initialize(
             candidate_server_names=candidate_mcp_servers,
             preflight_gemini=self.settings.model.provider == "gemini",

--- a/agent/helpudoc_agent/graph.py
+++ b/agent/helpudoc_agent/graph.py
@@ -56,6 +56,66 @@ GENERAL_SYSTEM_PROMPT = (
 BASE_AGENT_PROMPT = "In order to complete the objective that the user asks of you, you have access to a number of standard tools."
 
 
+_SKIP_CONTEXT_VALUE = object()
+
+
+def _safe_clone_context_value(value: Any) -> Any:
+    """Best-effort deepcopy that skips non-copyable runtime handles."""
+    try:
+        return deepcopy(value)
+    except Exception:
+        pass
+
+    if isinstance(value, dict):
+        cloned: Dict[Any, Any] = {}
+        for key, child in value.items():
+            cloned_child = _safe_clone_context_value(child)
+            if cloned_child is _SKIP_CONTEXT_VALUE:
+                continue
+            cloned[key] = cloned_child
+        return cloned
+    if isinstance(value, list):
+        cloned_list = []
+        for child in value:
+            cloned_child = _safe_clone_context_value(child)
+            if cloned_child is _SKIP_CONTEXT_VALUE:
+                continue
+            cloned_list.append(cloned_child)
+        return cloned_list
+    if isinstance(value, tuple):
+        cloned_tuple = []
+        for child in value:
+            cloned_child = _safe_clone_context_value(child)
+            if cloned_child is _SKIP_CONTEXT_VALUE:
+                continue
+            cloned_tuple.append(cloned_child)
+        return tuple(cloned_tuple)
+    if isinstance(value, set):
+        cloned_set = set()
+        for child in value:
+            cloned_child = _safe_clone_context_value(child)
+            if cloned_child is _SKIP_CONTEXT_VALUE:
+                continue
+            cloned_set.add(cloned_child)
+        return cloned_set
+
+    return _SKIP_CONTEXT_VALUE
+
+
+def _safe_clone_workspace_context(context: Dict[str, Any]) -> Dict[str, Any]:
+    cloned: Dict[str, Any] = {}
+    dropped_keys: list[str] = []
+    for key, value in context.items():
+        cloned_value = _safe_clone_context_value(value)
+        if cloned_value is _SKIP_CONTEXT_VALUE:
+            dropped_keys.append(str(key))
+            continue
+        cloned[key] = cloned_value
+    if dropped_keys:
+        logger.warning("Skipping non-copyable workspace context keys during runtime rebuild: %s", dropped_keys)
+    return cloned
+
+
 class AgentRegistry:
     """Caches DeepAgents keyed by (agent_name, workspace_id)."""
 
@@ -185,7 +245,7 @@ class AgentRegistry:
             stale_runtime = self._cache.pop(stale_key, None)
             if stale_runtime is not None:
                 # Preserve in-flight thread/skill state when delegated auth refreshes.
-                preserved_context = deepcopy(stale_runtime.workspace_state.context)
+                preserved_context = _safe_clone_workspace_context(stale_runtime.workspace_state.context)
 
         workspace_base = self.settings.backend.workspace_root
         workspace_base.mkdir(parents=True, exist_ok=True)

--- a/agent/helpudoc_agent/tool_guard.py
+++ b/agent/helpudoc_agent/tool_guard.py
@@ -11,6 +11,12 @@ from pydantic import ConfigDict, Field
 from .skills_registry import is_tool_allowed
 from .state import WorkspaceState
 
+_PREFERRED_MCP_ONLY_BUILTINS = {
+    "google_search",
+    "google_grounded_search",
+    "rag_query",
+}
+
 
 def _tool_scope_error(tool_name: str, skill_id: Optional[str], tool_mcp_server: Optional[str]) -> str:
     if skill_id:
@@ -59,6 +65,19 @@ class GuardedTool(BaseTool):
 
     def _guard(self) -> Optional[str]:
         context = self.workspace_state.context if isinstance(self.workspace_state.context, dict) else {}
+        preferred_server = context.get("preferred_mcp_server")
+        preferred_bound = bool(context.get("preferred_mcp_server_bound"))
+        if (
+            isinstance(preferred_server, str)
+            and preferred_server.strip()
+            and preferred_bound
+            and self.tool_mcp_server is None
+            and self.name in _PREFERRED_MCP_ONLY_BUILTINS
+        ):
+            return (
+                f"Tool '{self.name}' is blocked for this turn because '/mcp {preferred_server.strip()}' "
+                "is active and bound. Use tools from the preferred MCP server first."
+            )
         active_scope = context.get("active_skill_scope")
         if is_tool_allowed(self.name, active_scope, tool_mcp_server=self.tool_mcp_server):
             return None

--- a/agent/raganything/__init__.py
+++ b/agent/raganything/__init__.py
@@ -1,0 +1,5 @@
+from paper2slides.raganything import RAGAnything as RAGAnything
+from paper2slides.raganything import RAGAnythingConfig as RAGAnythingConfig
+
+__all__ = ["RAGAnything", "RAGAnythingConfig"]
+

--- a/agent/raganything/__init__.py
+++ b/agent/raganything/__init__.py
@@ -1,5 +1,12 @@
-from paper2slides.raganything import RAGAnything as RAGAnything
-from paper2slides.raganything import RAGAnythingConfig as RAGAnythingConfig
+from pathlib import Path
+
+_vendored_pkg_dir = (
+    Path(__file__).resolve().parent.parent / "paper2slides" / "raganything"
+)
+if _vendored_pkg_dir.exists():
+    __path__.append(str(_vendored_pkg_dir))
+
+from .config import RAGAnythingConfig as RAGAnythingConfig
+from .raganything import RAGAnything as RAGAnything
 
 __all__ = ["RAGAnything", "RAGAnythingConfig"]
-

--- a/agent/raganything/utils.py
+++ b/agent/raganything/utils.py
@@ -1,0 +1,2 @@
+from paper2slides.raganything.utils import *  # noqa: F403
+

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -264,7 +264,16 @@ const summarizeMessageFromToolEvents = (
   const toolEvents = message?.toolEvents || [];
   const latestFinishedEvent = [...toolEvents]
     .reverse()
-    .find((event) => event.status === 'completed' || event.status === 'error');
+    .find((event) => {
+      if (!(event.status === 'completed' || event.status === 'error')) {
+        return false;
+      }
+      const summary = String(event.summary || '').trim();
+      if (!summary || isSummaryLikeAgentText(summary)) {
+        return false;
+      }
+      return true;
+    });
   if (latestFinishedEvent?.summary?.trim()) {
     return latestFinishedEvent.summary.trim();
   }

--- a/infra/cloudbuild.yaml
+++ b/infra/cloudbuild.yaml
@@ -176,6 +176,32 @@ steps:
         tar -C skills -cf - . | kubectl -n helpudoc exec -i "$${APP_POD}" -c backend -- sh -lc "tar -xf - -C /app/skills"
         kubectl -n helpudoc exec "$${APP_POD}" -c backend -- sh -lc "test -f /app/skills/research/SKILL.md"
 
+  # 6b. Sync repo agent/config/runtime.yaml into the agent-config PVC.
+  #
+  # Why:
+  # - The agent process reads /agent/config/runtime.yaml at startup and caches it.
+  # - In GKE, /agent/config is PVC-backed and can drift from the repo defaults.
+  # - If it drifts, prompts like "use aws-knowledge / aws pricing" may be ignored because the MCP
+  #   servers were never registered in the runtime.
+  - id: sync-agent-config-pvc
+    name: 'gcr.io/cloud-builders/kubectl'
+    waitFor: ['deploy']
+    env:
+      - 'CLOUDSDK_COMPUTE_ZONE=$_GKE_LOCATION'
+      - 'CLOUDSDK_CONTAINER_CLUSTER=$_GKE_CLUSTER'
+    entrypoint: 'sh'
+    args:
+      - '-c'
+      - |
+        set -eu
+        APP_POD="$$(kubectl -n helpudoc get pods -l app=helpudoc-app -o jsonpath='{.items[0].metadata.name}')"
+        test -n "$${APP_POD}"
+        echo "Syncing repo agent/config/runtime.yaml to /agent/config in pod: $${APP_POD}"
+
+        kubectl -n helpudoc exec "$${APP_POD}" -c backend -- sh -lc "set -eu; mkdir -p /agent/config; rm -f /agent/config/runtime.yaml"
+        tar -C agent/config -cf - runtime.yaml | kubectl -n helpudoc exec -i "$${APP_POD}" -c backend -- sh -lc "tar -xf - -C /agent/config"
+        kubectl -n helpudoc exec "$${APP_POD}" -c backend -- sh -lc "test -f /agent/config/runtime.yaml"
+
   # 7. Bootstrap default admin (optional, idempotent).
   - id: bootstrap-admin
     name: 'gcr.io/cloud-builders/kubectl'
@@ -229,7 +255,7 @@ steps:
   # 8. Post-deploy drift guard (fails if PVC-backed runtime/skills are stale)
   - id: post-deploy-drift-guard
     name: 'gcr.io/cloud-builders/kubectl'
-    waitFor: ['sync-skills-pvc', 'bootstrap-admin']
+    waitFor: ['sync-skills-pvc', 'sync-agent-config-pvc', 'bootstrap-admin']
     env:
       - 'CLOUDSDK_COMPUTE_ZONE=$_GKE_LOCATION'
       - 'CLOUDSDK_CONTAINER_CLUSTER=$_GKE_CLUSTER'
@@ -246,6 +272,8 @@ steps:
         echo "Checking mounted runtime config and skills in pod: $${APP_POD}"
 
         kubectl -n helpudoc exec "$${APP_POD}" -c agent -- sh -lc "grep -q 'request_plan_approval' /agent/config/runtime.yaml"
+        kubectl -n helpudoc exec "$${APP_POD}" -c agent -- sh -lc "grep -q 'name: aws-pricing' /agent/config/runtime.yaml"
+        kubectl -n helpudoc exec "$${APP_POD}" -c agent -- sh -lc "grep -q 'name: aws-knowledge' /agent/config/runtime.yaml"
         kubectl -n helpudoc exec "$${APP_POD}" -c agent -- sh -lc "grep -q 'request_plan_approval' /app/skills/research/SKILL.md"
         kubectl -n helpudoc exec "$${APP_POD}" -c agent -- python -c "import requests; data=requests.get('http://localhost:8001/agents', timeout=10).json(); tools=data['agents'][0]['tools']; assert 'request_plan_approval' in tools, tools; print('request_plan_approval available in /agents')"
 

--- a/infra/cloudbuild.yaml
+++ b/infra/cloudbuild.yaml
@@ -202,6 +202,20 @@ steps:
         tar -C agent/config -cf - runtime.yaml | kubectl -n helpudoc exec -i "$${APP_POD}" -c backend -- sh -lc "tar -xf - -C /agent/config"
         kubectl -n helpudoc exec "$${APP_POD}" -c backend -- sh -lc "test -f /agent/config/runtime.yaml"
 
+  - id: restart-app-after-runtime-sync
+    name: 'gcr.io/cloud-builders/kubectl'
+    waitFor: ['sync-agent-config-pvc']
+    env:
+      - 'CLOUDSDK_COMPUTE_ZONE=$_GKE_LOCATION'
+      - 'CLOUDSDK_CONTAINER_CLUSTER=$_GKE_CLUSTER'
+    entrypoint: 'sh'
+    args:
+      - '-c'
+      - |
+        set -eu
+        kubectl -n helpudoc rollout restart deployment/helpudoc-app
+        kubectl -n helpudoc rollout status deployment/helpudoc-app --timeout=180s
+
   # 7. Bootstrap default admin (optional, idempotent).
   - id: bootstrap-admin
     name: 'gcr.io/cloud-builders/kubectl'
@@ -255,7 +269,7 @@ steps:
   # 8. Post-deploy drift guard (fails if PVC-backed runtime/skills are stale)
   - id: post-deploy-drift-guard
     name: 'gcr.io/cloud-builders/kubectl'
-    waitFor: ['sync-skills-pvc', 'sync-agent-config-pvc', 'bootstrap-admin']
+    waitFor: ['sync-skills-pvc', 'restart-app-after-runtime-sync', 'bootstrap-admin']
     env:
       - 'CLOUDSDK_COMPUTE_ZONE=$_GKE_LOCATION'
       - 'CLOUDSDK_CONTAINER_CLUSTER=$_GKE_CLUSTER'

--- a/infra/gke/README.md
+++ b/infra/gke/README.md
@@ -100,6 +100,29 @@ kubectl apply -f infra/gke/k8s/72-backendconfig.yaml
 
 If you are not using Cloud Build's image-tag rewriting, update the deployment image references yourself with `kubectl set image` or by editing the manifests before apply.
 
+## Sync PVC-backed runtime/skills (manual)
+
+In GKE, `skills-pvc` and `agent-config-pvc` are mounted into the running pod. If you change `skills/` or `agent/config/runtime.yaml` in the repo, the cluster can keep using stale PVC contents until you sync them.
+
+After applying manifests (or after a Cloud Build deploy if you're debugging drift), you can sync both:
+
+```bash
+APP_POD="$(kubectl -n helpudoc get pods -l app=helpudoc-app -o jsonpath='{.items[0].metadata.name}')"
+test -n "$APP_POD"
+
+# Sync skills
+kubectl -n helpudoc exec "$APP_POD" -c backend -- sh -lc "set -eu; mkdir -p /app/skills; find /app/skills -mindepth 1 -maxdepth 1 -exec rm -rf {} +"
+tar -C skills -cf - . | kubectl -n helpudoc exec -i "$APP_POD" -c backend -- sh -lc "tar -xf - -C /app/skills"
+
+# Sync agent runtime config
+kubectl -n helpudoc exec "$APP_POD" -c backend -- sh -lc "set -eu; mkdir -p /agent/config; rm -f /agent/config/runtime.yaml"
+tar -C agent/config -cf - runtime.yaml | kubectl -n helpudoc exec -i "$APP_POD" -c backend -- sh -lc "tar -xf - -C /agent/config"
+
+# Agent caches runtime.yaml at startup, so restart to pick up changes
+kubectl -n helpudoc rollout restart deployment/helpudoc-app
+kubectl -n helpudoc rollout status deployment/helpudoc-app
+```
+
 ## Storage and config notes
 
 - `30-storage.yaml` provisions PVCs used by workspaces, agent config, and shared skills.

--- a/tests/test_data_skill_family.py
+++ b/tests/test_data_skill_family.py
@@ -401,6 +401,59 @@ class TestGuardedTool:
         assert runtime_result.status == "success"
         assert "orders in thelook_ecommerce" in str(runtime_result.content)
 
+    def test_guarded_tool_blocks_google_search_when_preferred_mcp_is_bound(self, tmp_path: Path) -> None:
+        from langchain_core.messages import ToolMessage
+        from langchain_core.tools import tool
+
+        from agent.helpudoc_agent.state import WorkspaceState
+        from agent.helpudoc_agent.tool_guard import GuardedTool
+
+        @tool
+        def google_search(query: str) -> str:
+            """Search the web."""
+            return f"results for {query}"
+
+        workspace_state = WorkspaceState(workspace_id="w", root_path=tmp_path)
+        workspace_state.context["preferred_mcp_server"] = "aws-knowledge"
+        workspace_state.context["preferred_mcp_server_bound"] = True
+
+        guarded = GuardedTool.from_tool(google_search, workspace_state=workspace_state)
+        result = guarded.invoke({"query": "latest bedrock models"})
+        assert isinstance(result, str)
+        assert "blocked for this turn" in result.lower()
+
+        runtime_result = guarded.invoke(
+            {
+                "id": "tool-call-4",
+                "name": "google_search",
+                "type": "tool_call",
+                "query": "latest bedrock models",
+            }
+        )
+        assert isinstance(runtime_result, ToolMessage)
+        assert runtime_result.status == "error"
+        assert "preferred mcp server" in str(runtime_result.content).lower()
+
+    def test_guarded_tool_allows_google_search_when_preferred_mcp_is_not_bound(self, tmp_path: Path) -> None:
+        from langchain_core.tools import tool
+
+        from agent.helpudoc_agent.state import WorkspaceState
+        from agent.helpudoc_agent.tool_guard import GuardedTool
+
+        @tool
+        def google_search(query: str) -> str:
+            """Search the web."""
+            return f"results for {query}"
+
+        workspace_state = WorkspaceState(workspace_id="w", root_path=tmp_path)
+        workspace_state.context["preferred_mcp_server"] = "aws-knowledge"
+        workspace_state.context["preferred_mcp_server_bound"] = False
+
+        guarded = GuardedTool.from_tool(google_search, workspace_state=workspace_state)
+        result = guarded.invoke({"query": "latest bedrock models"})
+        assert isinstance(result, str)
+        assert "results for latest bedrock models" == result
+
 
 # ---------------------------------------------------------------------------
 # data_agent_tools tests

--- a/tests/test_mcp_binding.py
+++ b/tests/test_mcp_binding.py
@@ -199,6 +199,67 @@ def test_registry_preserves_runtime_context_when_auth_fingerprint_rotates(tmp_pa
     assert len(created_tools) == 2
 
 
+def test_registry_rebuilds_runtime_when_preferred_mcp_server_changes(tmp_path, monkeypatch):
+    settings = _build_settings(tmp_path)
+    created_tools: list[list[str]] = []
+
+    class DummyAgent:
+        def __init__(self, tools):
+            self.tools = tools
+
+        def with_config(self, _config):
+            return self
+
+    def fake_create_agent(*, model, tools, system_prompt, middleware, checkpointer):
+        created_tools.append([getattr(tool, "name", None) for tool in tools])
+        return DummyAgent(tools)
+
+    async def fake_initialize(self, *, candidate_server_names=None, preflight_gemini=False):
+        self._allowed_servers = {}
+        self._tools_by_server = {}
+        self._clients_by_server = {}
+        self._rejected_servers = {}
+
+    monkeypatch.setattr("helpudoc_agent.graph.create_agent", fake_create_agent)
+    monkeypatch.setattr("helpudoc_agent.graph.init_chat_model", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.FilesystemBackend", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.TodoListMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.FilesystemMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.SummarizationMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.PatchToolCallsMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.HumanInTheLoopMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.mcp_manager.MCPServerManager.initialize", fake_initialize)
+
+    registry = AgentRegistry(settings, ToolFactoryStub())
+
+    runtime_without_mcp = asyncio.run(
+        registry.get_or_create(
+            "lite",
+            "workspace-pref-switch",
+            initial_context={
+                "user_id": "user-1",
+                "mcp_policy": {"allowIds": [], "denyIds": [], "isAdmin": False},
+                "mcp_auth_fingerprint": "fingerprint-a",
+            },
+        )
+    )
+    runtime_with_mcp = asyncio.run(
+        registry.get_or_create(
+            "lite",
+            "workspace-pref-switch",
+            initial_context={
+                "user_id": "user-1",
+                "mcp_policy": {"allowIds": [], "denyIds": [], "isAdmin": False},
+                "mcp_auth_fingerprint": "fingerprint-a",
+                "preferred_mcp_server": "aws-knowledge",
+            },
+        )
+    )
+
+    assert runtime_with_mcp is not runtime_without_mcp
+    assert len(created_tools) == 2
+
+
 def test_aws_pricing_wrapper_sanitizes_schema_and_normalizes_inputs():
     pytest.importorskip("langchain_google_genai")
     captured = {}

--- a/tests/test_mcp_binding.py
+++ b/tests/test_mcp_binding.py
@@ -199,6 +199,69 @@ def test_registry_preserves_runtime_context_when_auth_fingerprint_rotates(tmp_pa
     assert len(created_tools) == 2
 
 
+def test_registry_rotation_skips_non_copyable_context_values(tmp_path, monkeypatch):
+    settings = _build_settings(tmp_path)
+
+    class DummyAgent:
+        def with_config(self, _config):
+            return self
+
+    class NonCopyable:
+        def __deepcopy__(self, _memo):
+            raise TypeError("cannot pickle '_duckdb.DuckDBPyConnection' object")
+
+    def fake_create_agent(*, model, tools, system_prompt, middleware, checkpointer):
+        return DummyAgent()
+
+    async def fake_initialize(self, *, candidate_server_names=None, preflight_gemini=False):
+        self._allowed_servers = {}
+        self._tools_by_server = {}
+        self._clients_by_server = {}
+        self._rejected_servers = {}
+
+    monkeypatch.setattr("helpudoc_agent.graph.create_agent", fake_create_agent)
+    monkeypatch.setattr("helpudoc_agent.graph.init_chat_model", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.FilesystemBackend", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.TodoListMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.FilesystemMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.SummarizationMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.PatchToolCallsMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.HumanInTheLoopMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.mcp_manager.MCPServerManager.initialize", fake_initialize)
+
+    registry = AgentRegistry(settings, ToolFactoryStub())
+    runtime = asyncio.run(
+        registry.get_or_create(
+            "fast",
+            "workspace-rotate-noncopyable",
+            initial_context={
+                "user_id": "user-1",
+                "mcp_policy": {"allowIds": [], "denyIds": [], "isAdmin": False},
+                "mcp_auth_fingerprint": "fingerprint-a",
+            },
+        )
+    )
+    runtime.workspace_state.context["thread_id"] = "general-assistant:fast:workspace-rotate-noncopyable:user-1:thread"
+    runtime.workspace_state.context["data_agent_manager"] = NonCopyable()
+
+    rotated_runtime = asyncio.run(
+        registry.get_or_create(
+            "fast",
+            "workspace-rotate-noncopyable",
+            initial_context={
+                "user_id": "user-1",
+                "mcp_policy": {"allowIds": [], "denyIds": [], "isAdmin": False},
+                "mcp_auth_fingerprint": "fingerprint-b",
+            },
+        )
+    )
+
+    assert rotated_runtime.workspace_state.context["thread_id"] == (
+        "general-assistant:fast:workspace-rotate-noncopyable:user-1:thread"
+    )
+    assert "data_agent_manager" not in rotated_runtime.workspace_state.context
+
+
 def test_registry_rebuilds_runtime_when_preferred_mcp_server_changes(tmp_path, monkeypatch):
     settings = _build_settings(tmp_path)
     created_tools: list[list[str]] = []

--- a/tests/test_mcp_binding.py
+++ b/tests/test_mcp_binding.py
@@ -423,3 +423,144 @@ def test_agent_registry_builds_runtime_with_wrapped_aws_pricing_candidate(
 
     assert runtime is not None
     assert captured["tool_names"] == ["get_pricing", "aws___search_documentation"]
+
+
+def test_registry_includes_preferred_mcp_server_without_active_skill(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    settings = _build_settings(tmp_path)
+    captured: dict[str, object] = {}
+
+    class DummyAgent:
+        def with_config(self, _config):
+            return self
+
+    def fake_create_agent(*, model, tools, system_prompt, middleware, checkpointer):
+        return DummyAgent()
+
+    async def fake_initialize(self, *, candidate_server_names=None, preflight_gemini=False):
+        captured["candidates"] = list(candidate_server_names or [])
+        self._allowed_servers = {}
+        self._tools_by_server = {}
+        self._clients_by_server = {}
+        self._rejected_servers = {}
+
+    monkeypatch.setattr("helpudoc_agent.graph.create_agent", fake_create_agent)
+    monkeypatch.setattr("helpudoc_agent.graph.init_chat_model", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.FilesystemBackend", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.TodoListMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.FilesystemMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.SummarizationMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.PatchToolCallsMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.HumanInTheLoopMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.mcp_manager.MCPServerManager.initialize", fake_initialize)
+
+    registry = AgentRegistry(settings, ToolFactoryStub())
+    asyncio.run(
+        registry.get_or_create(
+            "fast",
+            "workspace-pref",
+            initial_context={
+                "preferred_mcp_server": "aws-knowledge",
+            },
+        )
+    )
+
+    assert captured["candidates"] == ["aws-knowledge"]
+
+
+def test_registry_keeps_skill_candidates_and_appends_preferred_for_lite_persona(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    settings = _build_settings(tmp_path)
+    captured: dict[str, object] = {}
+
+    class DummyAgent:
+        def with_config(self, _config):
+            return self
+
+    def fake_create_agent(*, model, tools, system_prompt, middleware, checkpointer):
+        return DummyAgent()
+
+    async def fake_initialize(self, *, candidate_server_names=None, preflight_gemini=False):
+        captured["candidates"] = list(candidate_server_names or [])
+        self._allowed_servers = {}
+        self._tools_by_server = {}
+        self._clients_by_server = {}
+        self._rejected_servers = {}
+
+    monkeypatch.setattr("helpudoc_agent.graph.create_agent", fake_create_agent)
+    monkeypatch.setattr("helpudoc_agent.graph.init_chat_model", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.FilesystemBackend", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.TodoListMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.FilesystemMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.SummarizationMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.PatchToolCallsMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.HumanInTheLoopMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.mcp_manager.MCPServerManager.initialize", fake_initialize)
+
+    registry = AgentRegistry(settings, ToolFactoryStub())
+    asyncio.run(
+        registry.get_or_create(
+            "lite",
+            "workspace-lite-pref",
+            initial_context={
+                "active_skill_scope": {
+                    "skill_id": "general",
+                    "tools": [],
+                    "mcp_servers": [],
+                },
+                "preferred_mcp_server": "aws-pricing",
+            },
+        )
+    )
+
+    # "general" skill contributes both AWS servers; preferred is deduped.
+    assert captured["candidates"] == ["aws-pricing", "aws-knowledge"]
+
+
+def test_registry_ignores_unknown_preferred_mcp_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    settings = _build_settings(tmp_path)
+    captured: dict[str, object] = {}
+
+    class DummyAgent:
+        def with_config(self, _config):
+            return self
+
+    def fake_create_agent(*, model, tools, system_prompt, middleware, checkpointer):
+        return DummyAgent()
+
+    async def fake_initialize(self, *, candidate_server_names=None, preflight_gemini=False):
+        captured["candidates"] = list(candidate_server_names or [])
+        self._allowed_servers = {}
+        self._tools_by_server = {}
+        self._clients_by_server = {}
+        self._rejected_servers = {}
+
+    monkeypatch.setattr("helpudoc_agent.graph.create_agent", fake_create_agent)
+    monkeypatch.setattr("helpudoc_agent.graph.init_chat_model", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.FilesystemBackend", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.TodoListMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.FilesystemMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.SummarizationMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.PatchToolCallsMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.graph.HumanInTheLoopMiddleware", lambda *args, **kwargs: object())
+    monkeypatch.setattr("helpudoc_agent.mcp_manager.MCPServerManager.initialize", fake_initialize)
+
+    registry = AgentRegistry(settings, ToolFactoryStub())
+    asyncio.run(
+        registry.get_or_create(
+            "fast",
+            "workspace-unknown-pref",
+            initial_context={
+                "preferred_mcp_server": "not-configured",
+            },
+        )
+    )
+
+    assert captured["candidates"] == []


### PR DESCRIPTION
## Summary
- Fix intermittent pre-run failure before streaming by avoiding unsafe `deepcopy` of non-copyable runtime context values during registry rotation.
- Preserve copyable context state while skipping runtime handles (for example DuckDB connections).
- Add regression coverage for non-copyable stale runtime context.
- Include MCP binding and deployment/doc updates that are part of this branch.
- Address Codex review findings:
  - make the top-level `raganything` package resolve vendored submodules like `raganything.config`
  - restart `helpudoc-app` after syncing runtime config PVC so new config is actually loaded

## Validation
- `python3 -m pytest -q tests/test_mcp_binding.py::test_registry_rotation_skips_non_copyable_context_values tests/test_mcp_binding.py::test_registry_includes_preferred_mcp_server_without_active_skill tests/test_mcp_binding.py::test_registry_keeps_skill_candidates_and_appends_preferred_for_lite_persona`
- Deploy workflow: `deploy-agent-gke.yml` succeeded and live stream smoke returned `200` for `lite` persona.
