### PR TITLE
feat(workspace): preview docx/pptx and fix binary file saves

### DIFF
--- a/backend/src/services/fileService.ts
+++ b/backend/src/services/fileService.ts
@@ -31,6 +31,8 @@ const BINARY_MIME_TYPES_BY_EXTENSION: Record<string, string> = {
   '.svg': 'image/svg+xml',
   '.pdf': 'application/pdf',
   '.parquet': 'application/octet-stream',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
 };
 
 const normalizeS3Key = (workspaceId: string, fileName: string) => {
@@ -384,7 +386,11 @@ export class FileService {
     const nextVersion = currentVersion + 1;
 
     if (file.storageType === 'local') {
-      await fs.writeFile(file.path, content);
+      const mimeType = this.resolveMimeType(file.name, file.mimeType) || 'application/octet-stream';
+      const payload = this.isTextFile(file.name, mimeType)
+        ? Buffer.from(content, 'utf-8')
+        : Buffer.from(content, 'base64');
+      await fs.writeFile(file.path, payload);
     } else {
       throw new ConflictError('Updating S3 files is not supported.');
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "hyparquet": "^1.25.1",
         "hyparquet-compressors": "^1.1.1",
         "lucide-react": "^0.546.0",
+        "mammoth": "^1.12.0",
         "mermaid": "^11.12.0",
         "papaparse": "^5.5.3",
         "plotly.js-dist-min": "^3.3.0",
@@ -8202,6 +8203,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -8635,6 +8645,12 @@
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -9346,8 +9362,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -10256,6 +10271,12 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -10344,6 +10365,15 @@
       "peer": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -12605,6 +12635,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -13063,6 +13099,18 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/katex": {
       "version": "0.16.25",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.25.tgz",
@@ -13266,6 +13314,15 @@
       "integrity": "sha512-woWhKMAVx1fzzUnMCyOzglgSgf6/AFHLASdOBcchYCyvWSGWt12imw3iu2hdI5d4dGZRsNWAmWiz37sDKUPaRQ==",
       "license": "MIT"
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -13390,6 +13447,17 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/lowlight": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
@@ -13426,6 +13494,39 @@
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/mammoth": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.0.tgz",
+      "integrity": "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/mammoth/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/map-limit": {
@@ -15537,6 +15638,12 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -15655,6 +15762,12 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.5.0.tgz",
       "integrity": "sha512-uBj69dVlYe/+wxj8JOpr97XfsxH/eumMt6HqjNTmJDf/6NO9s+0uxeOneIz3AsPt2m6y9PqzDzd3ATcU17MNfw==",
       "license": "MIT"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/papaparse": {
       "version": "5.5.3",
@@ -15789,6 +15902,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -16421,8 +16543,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/process-warning": {
       "version": "5.0.0",
@@ -16899,7 +17020,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -16914,15 +17034,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -17610,6 +17728,12 @@
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
       "license": "MIT"
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -17804,6 +17928,12 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stack-trace": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
@@ -17938,7 +18068,6 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -17947,8 +18076,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/string-split-by": {
       "version": "1.0.0",
@@ -18737,6 +18865,12 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
     },
     "node_modules/undici-types": {
@@ -19534,6 +19668,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xtend": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "hyparquet": "^1.25.1",
     "hyparquet-compressors": "^1.1.1",
     "lucide-react": "^0.546.0",
+    "mammoth": "^1.12.0",
     "mermaid": "^11.12.0",
     "papaparse": "^5.5.3",
     "plotly.js-dist-min": "^3.3.0",

--- a/frontend/src/components/FileEditor.tsx
+++ b/frontend/src/components/FileEditor.tsx
@@ -6,7 +6,9 @@ import { getAuthUser } from '../auth/authStore';
 import { createFile } from '../services/fileApi';
 import { createCollabSession } from '../services/collabClient';
 import EditorLoadingState from './EditorLoadingState';
+import FileRenderer from './FileRenderer';
 import type { MarkdownRichEditorHandle } from './MarkdownRichEditor';
+import { isBinaryOfficeDocument } from '../utils/officeFiles';
 
 const MonacoEditor = lazy(() => import('@monaco-editor/react'));
 const MarkdownRichEditor = lazy(() => import('./MarkdownRichEditor'));
@@ -93,7 +95,32 @@ interface FileEditorProps {
   colorMode: 'light' | 'dark';
 }
 
-const FileEditor: React.FC<FileEditorProps> = ({
+const OfficeDocumentReadOnlyPane: React.FC<{
+  file: WorkspaceFile;
+  fileContent: string;
+  workspaceId: string;
+  colorMode: 'light' | 'dark';
+}> = ({ file, fileContent, workspaceId, colorMode }) => {
+  const isDarkMode = colorMode === 'dark';
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div
+        className={`border-b px-3 py-2 text-xs ${
+          isDarkMode
+            ? 'border-slate-700/70 bg-slate-950/70 text-slate-300'
+            : 'border-amber-100 bg-amber-50 text-amber-950'
+        }`}
+      >
+        Read-only preview. Word and PowerPoint files are not editable in the workspace editor.
+      </div>
+      <div className="min-h-0 flex-1">
+        <FileRenderer file={file} fileContent={fileContent} workspaceId={workspaceId} />
+      </div>
+    </div>
+  );
+};
+
+const CollabWorkspaceFileEditor: React.FC<FileEditorProps> = ({
   file,
   fileContent,
   onContentChange,
@@ -631,6 +658,23 @@ const FileEditor: React.FC<FileEditorProps> = ({
       </div>
     </div>
   );
+};
+
+const FileEditor: React.FC<FileEditorProps> = (props) => {
+  if (!props.file) {
+    return null;
+  }
+  if (isBinaryOfficeDocument(props.file.name ?? '')) {
+    return (
+      <OfficeDocumentReadOnlyPane
+        file={props.file}
+        fileContent={props.fileContent}
+        workspaceId={props.workspaceId}
+        colorMode={props.colorMode}
+      />
+    );
+  }
+  return <CollabWorkspaceFileEditor {...props} />;
 };
 
 export default FileEditor;

--- a/frontend/src/components/FileRenderer.tsx
+++ b/frontend/src/components/FileRenderer.tsx
@@ -9,6 +9,11 @@ import {
   createMarkdownComponents,
   useMermaidColorMode,
 } from './markdown/MarkdownShared';
+import {
+  isPowerPointDocument,
+  isWordDocument,
+  officeOnlineEmbedUrl,
+} from '../utils/officeFiles';
 
 const PlotlyChart = lazy(() => import('./PlotlyChart'));
 
@@ -123,9 +128,20 @@ const FileRenderer: React.FC<FileRendererProps> = ({
     lowerName.endsWith('.plot.json') ||
     lowerName.endsWith('.chart.json') ||
     lowerName.endsWith('.plotly');
+  const isDocxFile =
+    isWordDocument(lowerName) ||
+    (file?.mimeType || '').toLowerCase().includes(
+      'wordprocessingml',
+    );
+  const isPptxFile =
+    isPowerPointDocument(lowerName) ||
+    (file?.mimeType || '').toLowerCase().includes('presentationml');
   const [parquetPreview, setParquetPreview] = useState<TabularPreview | null>(null);
   const [parquetError, setParquetError] = useState<string | null>(null);
   const [isParquetLoading, setIsParquetLoading] = useState(false);
+  const [docxHtml, setDocxHtml] = useState<string | null>(null);
+  const [docxError, setDocxError] = useState<string | null>(null);
+  const [isDocxLoading, setIsDocxLoading] = useState(false);
 
   const parsedCsv = useMemo(() => {
     if (!isCsvFile || !fileContent.trim()) return null;
@@ -243,6 +259,54 @@ const FileRenderer: React.FC<FileRendererProps> = ({
       cancelled = true;
     };
   }, [fileContent, isParquetFile]);
+
+  useEffect(() => {
+    if (!isDocxFile) {
+      setDocxHtml(null);
+      setDocxError(null);
+      setIsDocxLoading(false);
+      return;
+    }
+
+    if (!fileContent.trim()) {
+      setDocxHtml(null);
+      setDocxError(null);
+      setIsDocxLoading(true);
+      return;
+    }
+
+    let cancelled = false;
+
+    const run = async () => {
+      setIsDocxLoading(true);
+      setDocxError(null);
+      try {
+        const mammoth = await import('mammoth');
+        const arrayBuffer = decodeBase64ToArrayBuffer(fileContent);
+        const { value } = await mammoth.convertToHtml({ arrayBuffer });
+        if (!cancelled) {
+          setDocxHtml(value);
+        }
+      } catch (error) {
+        console.error('DOCX preview error', error);
+        if (!cancelled) {
+          setDocxHtml(null);
+          setDocxError(
+            error instanceof Error ? error.message : 'Failed to render Word document.',
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsDocxLoading(false);
+        }
+      }
+    };
+
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [fileContent, isDocxFile]);
 
   const markdownComponents = useMemo(
     () => createMarkdownComponents({
@@ -525,6 +589,128 @@ const FileRenderer: React.FC<FileRendererProps> = ({
               ))}
             </tbody>
           </table>
+        </div>
+      );
+    }
+    if (isDocxFile) {
+      if (isDocxLoading) {
+        return (
+          <div className="flex h-full items-center justify-center text-sm text-gray-500">
+            Loading Word preview…
+          </div>
+        );
+      }
+      if (docxError) {
+        return (
+          <div className="flex h-full items-center justify-center px-4 text-sm text-red-600">
+            {docxError}
+          </div>
+        );
+      }
+      if (!docxHtml) {
+        return (
+          <div className="flex h-full items-center justify-center text-sm text-gray-500">
+            Unable to preview this document.
+          </div>
+        );
+      }
+      const docxProse = [
+        colorMode === 'dark' ? 'prose prose-invert' : 'prose prose-slate',
+        'max-w-none break-words p-4 text-sm',
+        disableInternalScroll ? 'h-auto overflow-y-visible' : 'h-full overflow-y-auto',
+      ].join(' ');
+      return (
+        <div className="flex h-full min-h-0 flex-col">
+          <div
+            className={`border-b px-4 py-2 text-xs ${
+              colorMode === 'dark'
+                ? 'border-slate-700 text-slate-400'
+                : 'border-gray-200 text-gray-500'
+            }`}
+          >
+            <span className={`font-medium ${colorMode === 'dark' ? 'text-slate-200' : 'text-gray-700'}`}>
+              Word preview
+            </span>
+            {' · '}
+            Approximate layout (not identical to Microsoft Word).
+          </div>
+          <div
+            className={`helpudoc-docx-preview min-h-0 flex-1 ${docxProse}`}
+            // mammoth emits semantic HTML only; images use data URLs from the file
+            dangerouslySetInnerHTML={{ __html: docxHtml }}
+          />
+        </div>
+      );
+    }
+    if (isPptxFile) {
+      const embedSrc = officeOnlineEmbedUrl(file?.publicUrl ?? null);
+      if (embedSrc) {
+        return (
+          <div className="relative flex h-full min-h-0 flex-col">
+            <div
+              className={`border-b px-4 py-2 text-xs ${
+                colorMode === 'dark'
+                  ? 'border-slate-700 text-slate-400'
+                  : 'border-gray-200 text-gray-500'
+              }`}
+            >
+              <span className={`font-medium ${colorMode === 'dark' ? 'text-slate-200' : 'text-gray-700'}`}>
+                PowerPoint preview
+              </span>
+              {' · '}
+              Via Microsoft Office Online (requires a public HTTPS file URL).
+            </div>
+            <iframe
+              title={file.name}
+              src={embedSrc}
+              className="min-h-0 w-full flex-1 border-none"
+              referrerPolicy="no-referrer"
+              loading="lazy"
+            />
+          </div>
+        );
+      }
+      const downloadBlob = () => {
+        try {
+          const buffer = decodeBase64ToArrayBuffer(fileContent);
+          const blob = new Blob([buffer], {
+            type:
+              file?.mimeType
+              || 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+          });
+          const url = URL.createObjectURL(blob);
+          const anchor = document.createElement('a');
+          anchor.href = url;
+          anchor.download = file.name || 'presentation.pptx';
+          anchor.click();
+          URL.revokeObjectURL(url);
+        } catch (e) {
+          console.error('PPTX download failed', e);
+        }
+      };
+      return (
+        <div
+          className={`flex h-full flex-col items-center justify-center gap-4 px-6 text-center text-sm ${
+            colorMode === 'dark' ? 'text-slate-300' : 'text-gray-600'
+          }`}
+        >
+          <p>
+            Inline PowerPoint preview needs a public <strong className="font-semibold">https</strong> URL to
+            your file. Download the deck and open it locally, or use a workspace with public file URLs.
+          </p>
+          {fileContent.trim() ? (
+            <button
+              type="button"
+              onClick={downloadBlob}
+              className={`rounded-lg px-4 py-2 text-sm font-medium text-white ${
+                colorMode === 'dark'
+                  ? 'bg-slate-600 hover:bg-slate-500'
+                  : 'bg-slate-800 hover:bg-slate-700'
+              }`}
+            >
+              Download .pptx
+            </button>
+          ) : null}
         </div>
       );
     }

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -85,6 +85,7 @@ import {
   SLASH_COMMANDS,
 } from '../constants/workspace';
 import { isSystemFile, normalizeFilePath } from '../utils/files';
+import { isBinaryOfficeDocument } from '../utils/officeFiles';
 import {
   areStructuredClarificationQuestionsComplete,
   buildClarificationDraftStorageKey,
@@ -2747,6 +2748,13 @@ export default function WorkspacePage() {
   useEffect(() => {
     fetchFileContent();
   }, [selectedFile, selectedWorkspace]);
+
+  useEffect(() => {
+    const name = selectedFile?.name ?? '';
+    if (isBinaryOfficeDocument(name)) {
+      setIsEditMode(false);
+    }
+  }, [selectedFile?.id, selectedFile?.name]);
 
   const handleCreateWorkspace = async () => {
     try {

--- a/frontend/src/utils/officeFiles.ts
+++ b/frontend/src/utils/officeFiles.ts
@@ -1,0 +1,29 @@
+/** Workspace .docx / .pptx: binary OOXML, preview-only in the web UI. */
+
+export const isWordDocument = (fileName: string): boolean => {
+  const n = fileName.trim().toLowerCase();
+  return n.endsWith('.docx');
+};
+
+export const isPowerPointDocument = (fileName: string): boolean => {
+  const n = fileName.trim().toLowerCase();
+  return n.endsWith('.pptx');
+};
+
+export const isBinaryOfficeDocument = (fileName: string): boolean =>
+  isWordDocument(fileName) || isPowerPointDocument(fileName);
+
+/**
+ * Microsoft Office Online embed requires a publicly reachable **HTTPS** URL.
+ * Returns null if the URL cannot be used for embedding.
+ */
+export const officeOnlineEmbedUrl = (publicUrl: string | null | undefined): string | null => {
+  if (!publicUrl || typeof publicUrl !== 'string') return null;
+  try {
+    const u = new URL(publicUrl.trim());
+    if (u.protocol !== 'https:') return null;
+    return `https://view.officeapps.live.com/op/embed.aspx?src=${encodeURIComponent(publicUrl.trim())}`;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
- FileRenderer: DOCX via mammoth HTML preview; PPTX via Office Online embed when publicUrl is https, else download fallback
- FileEditor: read-only Office pane without collab/Monaco on docx/pptx
- WorkspacePage: exit edit mode when selecting binary office files
- fileService: write non-text updates as base64-decoded buffers; MIME hints for docx/pptx extensions

Made-with: Cursor