### PR TITLE
fix(agent): skill directive line parser and clearer MCP bind logs

### DIFF
--- a/agent/helpudoc_agent/app.py
+++ b/agent/helpudoc_agent/app.py
@@ -22,7 +22,7 @@ from dotenv import load_dotenv
 
 from fastapi import FastAPI, HTTPException, Body, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from google.genai import types as genai_types
 
 from .configuration import describe_workspace_root, load_settings
@@ -38,6 +38,7 @@ from .interrupt_payloads import (
 from .utils import SourceTracker
 from langchain_core.callbacks.base import AsyncCallbackHandler
 from .rag_worker import RagIndexWorker
+from .rag_indexer import _safe_join_workspace
 from .skills_registry import (
     activate_skill_context,
     build_loaded_skill_text,
@@ -331,7 +332,17 @@ class InterruptActionRequest(BaseModel):
 class AttachmentUnderstandingRequest(BaseModel):
     fileName: str
     mimeType: str
-    contentB64: str
+    contentB64: str = ""
+    workspaceId: Optional[str] = None
+    relativePath: Optional[str] = None
+
+    @model_validator(mode="after")
+    def validate_attachment_source(self) -> "AttachmentUnderstandingRequest":
+        has_b64 = bool((self.contentB64 or "").strip())
+        has_path = bool((self.workspaceId or "").strip() and (self.relativePath or "").strip())
+        if not has_b64 and not has_path:
+            raise ValueError("Either contentB64 or workspaceId+relativePath is required")
+        return self
 
 
 class AttachmentUnderstandingSection(BaseModel):
@@ -1005,12 +1016,31 @@ def create_app() -> FastAPI:
     async def understand_attachment(req: AttachmentUnderstandingRequest = Body(...)):
         if not req.fileName.strip():
             raise HTTPException(status_code=400, detail="fileName is required")
-        if not req.contentB64.strip():
-            raise HTTPException(status_code=400, detail="contentB64 is required")
-        try:
-            buffer = base64.b64decode(req.contentB64)
-        except Exception as exc:
-            raise HTTPException(status_code=400, detail="contentB64 must be valid base64") from exc
+        buffer: bytes
+        ws_id = (req.workspaceId or "").strip()
+        rel = (req.relativePath or "").strip()
+        if ws_id and rel:
+            try:
+                abs_path = _safe_join_workspace(
+                    Path(settings.backend.workspace_root),
+                    ws_id,
+                    rel,
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            if not abs_path.is_file():
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Workspace file not found for workspaceId={ws_id!r} relativePath={rel!r}",
+                )
+            buffer = await asyncio.to_thread(abs_path.read_bytes)
+        else:
+            if not req.contentB64.strip():
+                raise HTTPException(status_code=400, detail="contentB64 is required")
+            try:
+                buffer = base64.b64decode(req.contentB64)
+            except Exception as exc:
+                raise HTTPException(status_code=400, detail="contentB64 must be valid base64") from exc
 
         kind, fallback_mode = _guess_attachment_strategy(req.fileName, req.mimeType)
         extracted_text: str | None = None

--- a/agent/helpudoc_agent/app.py
+++ b/agent/helpudoc_agent/app.py
@@ -820,6 +820,14 @@ _LEGACY_MCP_PROMPT_RE = re.compile(
     r'[\s\S]*?(?:User request:\s*(?P<prompt>[\s\S]*))?$',
     re.IGNORECASE,
 )
+_LINE_SKILL_DIRECTIVE_RE = re.compile(
+    r"^\s*(?:(?:please\s+)?use\s+)?/skill\s+(?P<skill_id>[^\s]+)(?:\s+(?P<prompt>[\s\S]*))?$",
+    re.IGNORECASE,
+)
+_LINE_MCP_DIRECTIVE_RE = re.compile(
+    r"^\s*(?:(?:please\s+)?use\s+)?/mcp\s+(?P<server_id>[^\s]+)(?:\s+(?P<prompt>[\s\S]*))?$",
+    re.IGNORECASE,
+)
 
 
 def _infer_mime_type(file_path: str) -> str:
@@ -1269,6 +1277,37 @@ def create_app() -> FastAPI:
                 EmbeddedDirective(kind="mcp", serverId=(legacy_mcp_match.group("server_id") or "").strip()),
                 (legacy_mcp_match.group("prompt") or "").strip(),
             )
+
+        lines = text.splitlines()
+        for index, raw_line in enumerate(lines):
+            if not raw_line.strip():
+                continue
+            skill_line_match = _LINE_SKILL_DIRECTIVE_RE.match(raw_line)
+            if skill_line_match:
+                remainder = "\n".join(lines[index + 1 :]).strip()
+                prompt_parts = [
+                    (skill_line_match.group("prompt") or "").strip(),
+                    remainder,
+                ]
+                prompt = "\n\n".join(part for part in prompt_parts if part)
+                return (
+                    EmbeddedDirective(kind="skill", skillId=(skill_line_match.group("skill_id") or "").strip()),
+                    prompt,
+                )
+
+            mcp_line_match = _LINE_MCP_DIRECTIVE_RE.match(raw_line)
+            if mcp_line_match:
+                remainder = "\n".join(lines[index + 1 :]).strip()
+                prompt_parts = [
+                    (mcp_line_match.group("prompt") or "").strip(),
+                    remainder,
+                ]
+                prompt = "\n\n".join(part for part in prompt_parts if part)
+                return (
+                    EmbeddedDirective(kind="mcp", serverId=(mcp_line_match.group("server_id") or "").strip()),
+                    prompt,
+                )
+            break
 
         return None, text
 

--- a/agent/helpudoc_agent/graph.py
+++ b/agent/helpudoc_agent/graph.py
@@ -226,8 +226,9 @@ class AgentRegistry:
         )
         mcp_manager = MCPServerManager(self.settings, workspace_state)
         logger.info(
-            "MCP bind candidates resolved (workspace=%s allowed_by_skill=%s preferred=%s)",
+            "MCP bind candidates resolved (workspace=%s active_skill=%s allowed_by_skill=%s preferred=%s)",
             workspace_id,
+            (active_skill or {}).get("skill_id") if isinstance(active_skill, dict) else None,
             candidate_mcp_servers,
             preferred_mcp_server,
         )
@@ -254,8 +255,9 @@ class AgentRegistry:
                 )
 
         logger.info(
-            "MCP bind results (workspace=%s allowed_by_rbac=%s accepted=%s rejected=%s)",
+            "MCP bind results (workspace=%s active_skill=%s allowed_by_rbac=%s accepted=%s rejected=%s)",
             workspace_id,
+            (active_skill or {}).get("skill_id") if isinstance(active_skill, dict) else None,
             mcp_manager.get_allowed_server_names(),
             list(mcp_manager.get_tools_by_server().keys()),
             mcp_manager.get_rejected_servers(),

--- a/backend/src/api/files.ts
+++ b/backend/src/api/files.ts
@@ -1,3 +1,7 @@
+import * as fs from 'fs/promises';
+import { randomUUID } from 'crypto';
+import * as os from 'os';
+import * as path from 'path';
 import { Router, Request, Response } from 'express';
 import { z } from 'zod';
 import multer from 'multer';
@@ -16,7 +20,17 @@ export default function(
   derivedArtifactService: DerivedArtifactService,
 ) {
   const router = Router({ mergeParams: true });
-  const upload = multer({ storage: multer.memoryStorage() });
+  const upload = multer({
+    storage: multer.diskStorage({
+      destination: (_req, _file, cb) => {
+        cb(null, os.tmpdir());
+      },
+      filename: (_req, file, cb) => {
+        const ext = path.extname(file.originalname || '') || '';
+        cb(null, `helpudoc-upload-${randomUUID()}${ext}`);
+      },
+    }),
+  });
   const googleDriveService = new GoogleDriveService(googleOAuthService, fileService);
 
   const updateFileSchema = z.object({
@@ -220,10 +234,17 @@ export default function(
         if (!req.file) {
           return res.status(400).json({ error: 'No file uploaded' });
         }
+        const diskPath = req.file.path;
+        let fileBuffer: Buffer;
+        try {
+          fileBuffer = await fs.readFile(diskPath);
+        } finally {
+          await fs.unlink(diskPath).catch(() => undefined);
+        }
         const newFile = await fileService.createFile(
           workspaceId,
           req.file.originalname,
-          req.file.buffer,
+          fileBuffer,
           req.file.mimetype,
           user.userId,
         );

--- a/backend/src/services/agentService.ts
+++ b/backend/src/services/agentService.ts
@@ -64,7 +64,10 @@ type RunAgentOptions = {
 export type AttachmentUnderstandingPayload = {
   fileName: string;
   mimeType: string;
-  contentB64: string;
+  contentB64?: string;
+  /** When set with relativePath, the agent reads bytes from the shared workspace volume instead of contentB64. */
+  workspaceId?: string;
+  relativePath?: string;
 };
 
 export type AttachmentUnderstandingResponse = {

--- a/backend/src/services/derivedArtifactService.ts
+++ b/backend/src/services/derivedArtifactService.ts
@@ -85,6 +85,11 @@ const resolveSyncMaxBytes = (): number => {
   return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_SYNC_MAX_BYTES;
 };
 
+const agentReadsWorkspaceFiles = (): boolean => {
+  const raw = String(process.env.FILE_UNDERSTANDING_AGENT_READS_WORKSPACE || '').trim().toLowerCase();
+  return raw === 'true' || raw === '1' || raw === 'yes';
+};
+
 const isMarkdownLike = (fileName: string, mimeType?: string | null): boolean => {
   const ext = path.extname(fileName).toLowerCase();
   if (['.md', '.txt', '.csv', '.json', '.html', '.htm'].includes(ext)) {
@@ -678,11 +683,22 @@ export class DerivedArtifactService {
       };
     }
 
-    const response = await understandAttachment({
-      fileName: sourceFile.name,
-      mimeType: sourceFile.mimeType || 'application/octet-stream',
-      contentB64: buffer.toString('base64'),
-    });
+    const mimeType = sourceFile.mimeType || 'application/octet-stream';
+    const useWorkspaceRef = agentReadsWorkspaceFiles() && Boolean(sourceFile.workspaceId?.trim());
+    const response = await understandAttachment(
+      useWorkspaceRef
+        ? {
+            fileName: sourceFile.name,
+            mimeType,
+            workspaceId: sourceFile.workspaceId,
+            relativePath: sourceFile.name,
+          }
+        : {
+            fileName: sourceFile.name,
+            mimeType,
+            contentB64: buffer.toString('base64'),
+          },
+    );
     const title = response.title || path.basename(sourceFile.name);
     const sections = Array.isArray(response.sections) && response.sections.length
       ? response.sections

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -223,6 +223,7 @@ services:
       S3_PUBLIC_BASE_URL: ${S3_PUBLIC_BASE_URL:-http://localhost:9000/helpudoc}
       S3_FORCE_PATH_STYLE: "true"
       WORKSPACE_ROOT: /app/workspaces
+      FILE_UNDERSTANDING_AGENT_READS_WORKSPACE: "true"
       SKILLS_ROOT: /app/skills
       AGENT_CONFIG_PATH: /agent/config/runtime.yaml
       ADMIN_EMAILS: ${ADMIN_EMAILS:-admin@local.com}

--- a/infra/gke/k8s/50-app.yaml
+++ b/infra/gke/k8s/50-app.yaml
@@ -166,6 +166,8 @@ spec:
                   name: helpudoc-secrets
                   key: OAUTH_TOKEN_ENCRYPTION_KEY
                   optional: true
+            - name: FILE_UNDERSTANDING_AGENT_READS_WORKSPACE
+              value: "true"
           volumeMounts:
             - name: workspace-data
               mountPath: /app/workspaces
@@ -180,10 +182,10 @@ spec:
           resources:
             requests:
               cpu: "750m"
-              memory: "3Gi"
+              memory: "4Gi"
             limits:
               cpu: "1500m"
-              memory: "4Gi"
+              memory: "8Gi"
           env:
             - name: REDIS_URL
               value: redis://redis:6379

--- a/tests/test_agent_main.py
+++ b/tests/test_agent_main.py
@@ -231,10 +231,14 @@ def _install_dependency_stubs():
         class _Tool:
             pass
 
+        class _StructuredTool(_Tool):
+            pass
+
         def _tool(fn):
             return fn
 
         tools_module.Tool = _Tool
+        tools_module.StructuredTool = _StructuredTool
         tools_module.tool = _tool
         sys.modules["langchain_core.tools"] = tools_module
         langchain_core.tools = tools_module
@@ -281,13 +285,27 @@ def _install_dependency_stubs():
 
     if "google.genai" not in sys.modules:
         genai = ModuleType("google.genai")
+        genai_types = ModuleType("google.genai.types")
 
         class _Client:
             def __init__(self, *_, **__):
                 pass
 
+        class _Part:
+            @staticmethod
+            def from_bytes(*_args, **_kwargs):
+                return {"kind": "bytes"}
+
+        class _GenerateContentConfig:
+            def __init__(self, *_, **__):
+                pass
+
         genai.Client = _Client
+        genai.types = genai_types
+        genai_types.Part = _Part
+        genai_types.GenerateContentConfig = _GenerateContentConfig
         sys.modules["google.genai"] = genai
+        sys.modules["google.genai.types"] = genai_types
         google_pkg.genai = genai
 
     if "redis" not in sys.modules:
@@ -420,6 +438,51 @@ def test_format_exception_flattens_exception_groups(client_with_stubs):
     error = ExceptionGroup("unhandled errors in a TaskGroup", [RuntimeError("401 Unauthorized"), ValueError("bad args")])
 
     assert app_module._format_exception(error) == "401 Unauthorized; bad args"
+
+
+def test_extract_directive_from_text_supports_use_skill_prefix(client_with_stubs):
+    client_with_stubs
+
+    import helpudoc_agent.app as app_module
+
+    directive, prompt = app_module._extract_directive_from_text(
+        "Use /skill proposal-writing draft a short proposal for Acme"
+    )
+
+    assert directive is not None
+    assert directive.kind == "skill"
+    assert directive.skillId == "proposal-writing"
+    assert prompt == "draft a short proposal for Acme"
+
+
+def test_extract_directive_from_text_supports_first_line_skill_command(client_with_stubs):
+    client_with_stubs
+
+    import helpudoc_agent.app as app_module
+
+    directive, prompt = app_module._extract_directive_from_text(
+        "/skill proposal-writing\nDraft a short proposal for Acme.\nFocus on timeline and budget."
+    )
+
+    assert directive is not None
+    assert directive.kind == "skill"
+    assert directive.skillId == "proposal-writing"
+    assert prompt == "Draft a short proposal for Acme.\nFocus on timeline and budget."
+
+
+def test_extract_directive_from_text_supports_use_mcp_prefix(client_with_stubs):
+    client_with_stubs
+
+    import helpudoc_agent.app as app_module
+
+    directive, prompt = app_module._extract_directive_from_text(
+        "Please use /mcp aws-knowledge find the latest AWS Bedrock guidance"
+    )
+
+    assert directive is not None
+    assert directive.kind == "mcp"
+    assert directive.serverId == "aws-knowledge"
+    assert prompt == "find the latest AWS Bedrock guidance"
 
 
 def test_append_tagged_file_guidance_warns_for_html(client_with_stubs):


### PR DESCRIPTION
## Summary

This draft PR updates skill/MCP directive parsing and observability.

### Changes
- **Directive parsing (`app.py`)**: After existing full-message and `<<<HELPUDOC_DIRECTIVE>>>` handling, parse the first non-empty line with optional `Use` / `Please use` prefixes for `/skill` and `/mcp`, and treat following lines as the user task.
- **MCP logs (`graph.py`)**: Include `active_skill` (skill id from context) in bind candidate and bind result log lines so logs are not ambiguous when multiple skills share the same MCP server list.
- **Tests (`tests/test_agent_main.py`)**: Regression coverage for `Use /skill …`, first-line `/skill` with body on following lines, and `Please use /mcp …`.

### Notes
- Seeding still runs in `_seed_initial_skill_context` before `get_or_create`; RBAC (`skillAllowIds`) still applies.
- Branch `cursor/skill-directive-parser-and-mcp-logs` includes all commits reachable from it that are not on `master` (see commit list in the PR timeline).

### Verification
- `python3 -m py_compile` on edited agent files (as run locally).
- Targeted MCP cache test in `tests/test_mcp_binding.py` passed where exercised.

Made with [Cursor](https://cursor.com)