### PR TITLE
[codex] Tune Gemini modes and image defaults

### DIFF
--- a/agent/config/runtime.yaml
+++ b/agent/config/runtime.yaml
@@ -3,8 +3,11 @@ model:
   name: gemini-3-flash-preview
   fast_name: gemini-3-flash-preview
   lite_name: gemini-3.1-flash-lite-preview
-  pro_name: gemini-3-pro-preview
-  image_name: gemini-3-pro-image-preview
+  thinking_level: low
+  fast_thinking_level: low
+  lite_thinking_level: high
+  pro_thinking_level: high
+  image_name: gemini-3.1-flash-image-preview
   project: my-rd-coe-demo-gen-ai
   location: us-central1
   api_key: ${GEMINI_API_KEY}

--- a/agent/helpudoc_agent/configuration.py
+++ b/agent/helpudoc_agent/configuration.py
@@ -27,6 +27,10 @@ class ModelConfig(BaseModel):
     lite_name: Optional[str] = None
     pro_name: Optional[str] = None
     image_name: Optional[str] = None
+    thinking_level: Optional[str] = None
+    fast_thinking_level: Optional[str] = None
+    lite_thinking_level: Optional[str] = None
+    pro_thinking_level: Optional[str] = None
     project: Optional[str] = None
     location: Optional[str] = None
     api_key: Optional[str] = Field(default_factory=lambda: os.getenv("GEMINI_API_KEY"))
@@ -45,10 +49,21 @@ class ModelConfig(BaseModel):
         if normalized == "lite":
             return self.lite_name or self.fast_name or self.name
         if normalized == "pro":
-            return self.pro_name or self.name
+            return self.name
         if normalized == "fast":
             return self.fast_name or self.name
         return self.name
+
+    def resolve_thinking_level(self, mode: Optional[str]) -> Optional[str]:
+        """Resolve Gemini thinking depth for the requested mode."""
+        normalized = (mode or "").strip().lower()
+        if normalized == "lite":
+            return self.lite_thinking_level or self.fast_thinking_level or self.thinking_level
+        if normalized == "pro":
+            return self.pro_thinking_level or self.thinking_level
+        if normalized == "fast":
+            return self.fast_thinking_level or self.thinking_level
+        return self.thinking_level
 
     @property
     def image_model_name(self) -> str:

--- a/agent/helpudoc_agent/graph.py
+++ b/agent/helpudoc_agent/graph.py
@@ -111,17 +111,25 @@ class AgentRegistry:
             return "fast"
         return "fast"
 
-    def _get_model(self, model_name: str):
-        model = self._models.get(model_name)
+    def _get_model(self, model_name: str, *, thinking_level: str | None = None):
+        cache_key = json.dumps(
+            {"model": model_name, "thinking_level": thinking_level},
+            sort_keys=True,
+        )
+        model = self._models.get(cache_key)
         if model is not None:
             return model
         cfg = self.settings.model
+        model_kwargs = {}
+        if thinking_level:
+            model_kwargs["thinking_level"] = thinking_level
         if cfg.use_vertex_ai:
             model = init_chat_model(
                 model_name,
                 model_provider="google_vertex_ai",
                 project=cfg.project,
                 location=cfg.location,
+                **model_kwargs,
             )
         else:
             # Force public Gemini (API key) path to avoid accidental Vertex calls.
@@ -129,8 +137,9 @@ class AgentRegistry:
                 model_name,
                 model_provider="google_genai",
                 api_key=cfg.api_key,
+                **model_kwargs,
             )
-        self._models[model_name] = model
+        self._models[cache_key] = model
         return model
 
     async def get_or_create(
@@ -141,6 +150,7 @@ class AgentRegistry:
     ) -> AgentRuntimeState:
         mode = self._resolve_mode(agent_name)
         model_name = self.settings.model.resolve_chat_model_name(mode)
+        thinking_level = self.settings.model.resolve_thinking_level(mode)
         resolved_name = f"{self._default_agent_name}:{mode}"
         context_payload = initial_context or {}
         policy_key = json.dumps(context_payload.get("mcp_policy", {}) or {}, sort_keys=True, default=str)
@@ -270,7 +280,7 @@ class AgentRegistry:
             virtual_mode=self.settings.backend.virtual_mode,
         )
 
-        model = self._get_model(model_name)
+        model = self._get_model(model_name, thinking_level=thinking_level)
         interrupt_on = dict(self.settings.backend.interrupt_on or {})
         if bool(context_payload.get("skip_plan_approvals") or context_payload.get("skipPlanApprovals")):
             interrupt_on.pop("request_plan_approval", None)

--- a/agent/paper2slides/generator/image_generator.py
+++ b/agent/paper2slides/generator/image_generator.py
@@ -115,7 +115,7 @@ class ImageGenerator:
         model: str = None,
     ):
         self.api_key = api_key or os.getenv("IMAGE_GEN_API_KEY", "")
-        self.model = model or os.getenv("IMAGE_GEN_MODEL", "gemini-3-pro-image-preview")
+        self.model = model or os.getenv("IMAGE_GEN_MODEL", "gemini-3.1-flash-image-preview")
         self.client = create_client(api_key=self.api_key)
     
     def generate(

--- a/agent/paper2slides/utils/slide_assets.py
+++ b/agent/paper2slides/utils/slide_assets.py
@@ -42,7 +42,7 @@ def _env_int(name: str, default: int) -> int:
 
 
 DEFAULT_LAYOUT_MODEL = os.getenv("LAYOUT_MODEL") or os.getenv("LLM_MODEL", "gemini-2.5-flash")
-DEFAULT_IMAGE_MODEL = os.getenv("IMAGE_GEN_MODEL", "gemini-3-pro-image-preview")
+DEFAULT_IMAGE_MODEL = os.getenv("IMAGE_GEN_MODEL", "gemini-3.1-flash-image-preview")
 DEFAULT_CLEAN_IMAGE_MODEL = os.getenv("CLEAN_IMAGE_MODEL")
 DEFAULT_REFINE_ASSETS = _env_bool("REFINE_ASSETS", True)
 DEFAULT_CLEAN_ASSETS = _env_bool("CLEAN_ASSETS", True)

--- a/env/local/paper2slides.env.example
+++ b/env/local/paper2slides.env.example
@@ -8,7 +8,7 @@ GOOGLE_CLOUD_LOCATION=us-central1
 # Models
 LLM_MODEL=gemini-2.5-flash
 EMBEDDING_MODEL=models/gemini-embedding-001
-IMAGE_GEN_MODEL=gemini-3-pro-image-preview
+IMAGE_GEN_MODEL=gemini-3.1-flash-image-preview
 
 # Optional overrides
 RAG_LLM_API_KEY=


### PR DESCRIPTION
## Summary
- remove Gemini Pro chat/image model defaults from runtime configuration
- keep lite/fast/pro modes but map pro to Flash with high thinking
- bump lite thinking to high and switch Gemini image defaults to Flash image for agent and Paper2Slides

## Validation
- python3 -m pytest tests/test_mcp_configuration.py -q
- python3 -m graphify update .
- triggered Deploy Agent to GKE: https://github.com/plc1220/HelpUDoc/actions/runs/24763540956

## Notes
- Existing unrelated local changes were not included in this branch.
