### PR TITLE
[codex] Add workspace dashboard analytics

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,6 +14,8 @@ GOOGLE_OAUTH_POST_LOGIN_REDIRECT=http://localhost:5173/login
 GOOGLE_OAUTH_SCOPES=openid email profile https://www.googleapis.com/auth/bigquery https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/spreadsheets.readonly
 GOOGLE_WORKSPACE_MCP_URL=
 OAUTH_TOKEN_ENCRYPTION_KEY=
+# Optional: public Langfuse UI URL for admin dashboard "Open Langfuse" (e.g. https://langfuse.example.com)
+LANGFUSE_NEXTAUTH_URL=
 REDIS_URL=redis://localhost:6379
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "nodemon --watch 'src/**/*.ts' --exec 'ts-node -r tsconfig-paths/register' src/index.ts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node -r ts-node/register/transpile-only -r tsconfig-paths/register --test tests/workspaceDashboard.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -45,7 +45,7 @@ export default function(dbService: DatabaseService, userService: UserService) {
 
   router.use('/auth', authRoutes(userService, googleOAuthService));
   router.use('/agent', agentRoutes(workspaceService, fileService, googleOAuthService, userService));
-  router.use('/settings', requireSystemAdmin(userService), settingsRoutes(workspaceService));
+  router.use('/settings', requireSystemAdmin(userService), settingsRoutes(workspaceService, userService, dbService));
   router.use('/users', requireSystemAdmin(userService), usersRoutes(userService, workspaceService));
   router.use('/workspaces', workspaceRoutes(workspaceService, userService));
   router.use('/workspaces/:workspaceId/attachments', attachmentRoutes(workspaceService, attachmentPrepJobService));

--- a/backend/src/api/settings.ts
+++ b/backend/src/api/settings.ts
@@ -7,6 +7,11 @@ import crypto from 'crypto';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { existsSync } from 'fs';
 import type { WorkspaceService } from '../services/workspaceService';
+import type { DatabaseService } from '../services/databaseService';
+import type { UserService } from '../services/userService';
+import { buildWorkspaceOverview } from '../services/workspaceOverviewService';
+import { fetchLangfuseAggregates } from '../services/langfuseClient';
+import { collectSkillIds } from '../lib/skillsRegistry';
 import { HttpError } from '../errors';
 import { resolveWorkspaceRoot } from '../config/workspaceRoot';
 import {
@@ -282,24 +287,6 @@ function resolveSkillDir(id: string) {
     throw new Error('Invalid skill id');
   }
   return path.join(skillsRoot, normalizedId);
-}
-
-async function collectSkillIds(rootDir: string, relativeDir = ''): Promise<string[]> {
-  const entries = await fs.readdir(rootDir, { withFileTypes: true });
-  let ids: string[] = [];
-
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const relPath = relativeDir ? path.posix.join(relativeDir, entry.name) : entry.name;
-    const fullPath = path.join(rootDir, entry.name);
-    const skillFile = path.join(fullPath, 'SKILL.md');
-    if (await pathExists(skillFile)) {
-      ids.push(relPath);
-    }
-    ids = ids.concat(await collectSkillIds(fullPath, relPath));
-  }
-
-  return ids.sort((a, b) => a.localeCompare(b));
 }
 
 function isAllowedActionPath(relativePath: string, prefixes = ACTION_ALLOWED_PREFIXES): boolean {
@@ -609,8 +596,29 @@ function extractActionsFromText(text: string): unknown[] {
   throw new Error('No actions array found in input text');
 }
 
-export default function settingsRoutes(_workspaceService: WorkspaceService) {
+export default function settingsRoutes(
+  _workspaceService: WorkspaceService,
+  userService: UserService,
+  databaseService: DatabaseService,
+) {
   const router = Router();
+
+  router.get('/workspace-overview', async (_req, res) => {
+    try {
+      const body = await buildWorkspaceOverview({
+        db: databaseService.getDb(),
+        userService,
+        skillsRoot,
+        nodeEnv: process.env.NODE_ENV,
+        fetchLangfuse: fetchLangfuseAggregates,
+        now: () => Date.now(),
+      });
+      res.json(body);
+    } catch (error) {
+      console.error('Failed to load workspace overview', error);
+      res.status(500).json({ error: 'Failed to load workspace overview' });
+    }
+  });
 
   router.get('/agent-config', async (_req, res) => {
     try {

--- a/backend/src/lib/skillsRegistry.ts
+++ b/backend/src/lib/skillsRegistry.ts
@@ -1,0 +1,32 @@
+import path from 'path';
+import { promises as fs } from 'fs';
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.stat(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Recursively list skill package ids (directories containing SKILL.md) under a registry root.
+ */
+export async function collectSkillIds(rootDir: string, relativeDir = ''): Promise<string[]> {
+  const entries = await fs.readdir(rootDir, { withFileTypes: true });
+  let ids: string[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const relPath = relativeDir ? path.posix.join(relativeDir, entry.name) : entry.name;
+    const fullPath = path.join(rootDir, entry.name);
+    const skillFile = path.join(fullPath, 'SKILL.md');
+    if (await pathExists(skillFile)) {
+      ids.push(relPath);
+    }
+    ids = ids.concat(await collectSkillIds(fullPath, relPath));
+  }
+
+  return ids.sort((a, b) => a.localeCompare(b));
+}

--- a/backend/src/services/langfuseClient.ts
+++ b/backend/src/services/langfuseClient.ts
@@ -93,6 +93,34 @@ function sumDailyMetrics(
   return { traces, observations };
 }
 
+function readCountMetric(data: unknown): number {
+  const rows: Array<Record<string, unknown>> = Array.isArray((data as { data?: unknown })?.data)
+    ? ((data as { data: Array<Record<string, unknown>> }).data)
+    : Array.isArray(data)
+      ? (data as Array<Record<string, unknown>>)
+      : [];
+
+  let total = 0;
+  for (const row of rows) {
+    const raw = row.count_count ?? row.count;
+    const value = typeof raw === 'number' ? raw : Number(raw);
+    if (Number.isFinite(value)) {
+      total += value;
+    }
+  }
+  return total;
+}
+
+function buildMetricsQuery(view: 'traces' | 'observations', fromIso: string, toIso: string): string {
+  return JSON.stringify({
+    view,
+    metrics: [{ measure: 'count', aggregation: 'count' }],
+    filters: [],
+    fromTimestamp: fromIso,
+    toTimestamp: toIso,
+  });
+}
+
 /**
  * Fetches 7d aggregates and a few recent traces from Langfuse public API (self-hosted v3).
  * Uses legacy daily metrics when present; does not throw on 404/5xx.
@@ -138,14 +166,17 @@ export async function fetchLangfuseAggregates(
   if (dailyStatus === 404) {
     try {
       const v2Url = new URL('/api/public/metrics', base);
-      v2Url.searchParams.set('fromTimestamp', fromIso);
-      v2Url.searchParams.set('toTimestamp', toIso);
-      const v2 = await fetcher(v2Url.toString(), { method: 'GET', headers: commonHeaders });
-      if (v2.ok) {
-        const j = await v2.json();
-        const s = sumDailyMetrics(j);
-        traces = s.traces;
-        observations = s.observations;
+      v2Url.searchParams.set('query', buildMetricsQuery('traces', fromIso, toIso));
+      const traceMetrics = await fetcher(v2Url.toString(), { method: 'GET', headers: commonHeaders });
+      if (traceMetrics.ok) {
+        traces = readCountMetric(await traceMetrics.json());
+      }
+
+      const observationsUrl = new URL('/api/public/metrics', base);
+      observationsUrl.searchParams.set('query', buildMetricsQuery('observations', fromIso, toIso));
+      const observationMetrics = await fetcher(observationsUrl.toString(), { method: 'GET', headers: commonHeaders });
+      if (observationMetrics.ok) {
+        observations = readCountMetric(await observationMetrics.json());
       }
     } catch {
       // ignore

--- a/backend/src/services/langfuseClient.ts
+++ b/backend/src/services/langfuseClient.ts
@@ -1,0 +1,194 @@
+const USER_AGENT = 'helpudoc-backend/1.0 (workspace-overview)';
+
+export type LangfuseTracesListItem = {
+  id: string;
+  name?: string | null;
+  timestamp?: string | null;
+};
+
+type DailyMetricsRow = {
+  day?: string;
+  date?: string;
+  countTraces?: number;
+  countObservations?: number;
+  totalObservations?: number;
+  [key: string]: unknown;
+};
+
+function normalizeBaseUrl(base: string): string {
+  return base.replace(/\/+$/, '');
+}
+
+function basicHeader(publicKey: string, secretKey: string): string {
+  const token = Buffer.from(`${publicKey}:${secretKey}`, 'utf-8').toString('base64');
+  return `Basic ${token}`;
+}
+
+export function isLangfuseConfigured(): boolean {
+  const base = (process.env.LANGFUSE_BASE_URL || '').trim();
+  const publicKey = (process.env.LANGFUSE_PUBLIC_KEY || '').trim();
+  const secretKey = (process.env.LANGFUSE_SECRET_KEY || '').trim();
+  return Boolean(base && publicKey && secretKey);
+}
+
+type Fetcher = (input: string, init?: {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+}>;
+
+function getFetch(): Fetcher {
+  if (typeof globalThis.fetch === 'function') {
+    return globalThis.fetch as Fetcher;
+  }
+  throw new Error('global fetch is not available; use Node 18+');
+}
+
+export type LangfuseAggregates = {
+  available: boolean;
+  error?: string;
+  publicUrl: string | null;
+  toolCalls7d: number;
+  traces7d: number;
+  observations7d: number;
+  recentTraces: LangfuseTracesListItem[];
+};
+
+const emptyResult = (publicUrl: string | null): LangfuseAggregates => ({
+  available: false,
+  publicUrl,
+  toolCalls7d: 0,
+  traces7d: 0,
+  observations7d: 0,
+  recentTraces: [],
+});
+
+function readPublicUrl(): string | null {
+  const u = (process.env.LANGFUSE_NEXTAUTH_URL || '').trim();
+  return u || null;
+}
+
+function sumDailyMetrics(
+  data: unknown,
+): { traces: number; observations: number } {
+  let traces = 0;
+  let observations = 0;
+  const rows: DailyMetricsRow[] = Array.isArray((data as { data?: unknown })?.data)
+    ? ((data as { data: DailyMetricsRow[] }).data)
+    : Array.isArray((data as { metrics?: unknown })?.metrics)
+      ? ((data as { metrics: DailyMetricsRow[] }).metrics)
+      : Array.isArray(data)
+        ? (data as DailyMetricsRow[])
+        : [];
+  for (const row of rows) {
+    const t = row.countTraces;
+    const o = row.countObservations ?? row.totalObservations;
+    if (typeof t === 'number') traces += t;
+    if (typeof o === 'number') observations += o;
+  }
+  return { traces, observations };
+}
+
+/**
+ * Fetches 7d aggregates and a few recent traces from Langfuse public API (self-hosted v3).
+ * Uses legacy daily metrics when present; does not throw on 404/5xx.
+ */
+export async function fetchLangfuseAggregates(
+  fromIso: string,
+  toIso: string,
+): Promise<LangfuseAggregates> {
+  const publicUrl = readPublicUrl();
+  if (!isLangfuseConfigured()) {
+    return { ...emptyResult(publicUrl), available: false };
+  }
+
+  const base = normalizeBaseUrl((process.env.LANGFUSE_BASE_URL || '').trim());
+  const publicKey = (process.env.LANGFUSE_PUBLIC_KEY || '').trim();
+  const secretKey = (process.env.LANGFUSE_SECRET_KEY || '').trim();
+  const auth = basicHeader(publicKey, secretKey);
+  const fetcher = getFetch();
+  const commonHeaders = {
+    Authorization: auth,
+    Accept: 'application/json',
+    'User-Agent': USER_AGENT,
+  };
+
+  const dailyUrl = new URL('/api/public/metrics/daily', base);
+  dailyUrl.searchParams.set('fromTimestamp', fromIso);
+  dailyUrl.searchParams.set('toTimestamp', toIso);
+
+  let dailyJson: unknown;
+  let dailyStatus = 0;
+  let requestError: string | undefined;
+  try {
+    const res = await fetcher(dailyUrl.toString(), { method: 'GET', headers: commonHeaders });
+    dailyStatus = res.status;
+    if (res.ok) {
+      dailyJson = await res.json();
+    }
+  } catch (e) {
+    requestError = e instanceof Error ? e.message : String(e);
+  }
+
+  let { traces, observations } = sumDailyMetrics(dailyJson);
+  if (dailyStatus === 404) {
+    try {
+      const v2Url = new URL('/api/public/metrics', base);
+      v2Url.searchParams.set('fromTimestamp', fromIso);
+      v2Url.searchParams.set('toTimestamp', toIso);
+      const v2 = await fetcher(v2Url.toString(), { method: 'GET', headers: commonHeaders });
+      if (v2.ok) {
+        const j = await v2.json();
+        const s = sumDailyMetrics(j);
+        traces = s.traces;
+        observations = s.observations;
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  const recent: LangfuseTracesListItem[] = [];
+  let traceStatus = 0;
+  try {
+    const tracesUrl = new URL('/api/public/traces', base);
+    tracesUrl.searchParams.set('limit', '5');
+    tracesUrl.searchParams.set('page', '1');
+    const tRes = await fetcher(tracesUrl.toString(), { method: 'GET', headers: commonHeaders });
+    traceStatus = tRes.status;
+    if (tRes.ok) {
+      const body = (await tRes.json()) as { data?: Array<Record<string, unknown>> };
+      const list = body?.data;
+      if (Array.isArray(list)) {
+        for (const item of list) {
+          if (!item || typeof item !== 'object') continue;
+          const id = typeof item.id === 'string' ? item.id : String(item.id ?? '');
+          if (!id) continue;
+          recent.push({
+            id,
+            name: (item.name as string) || null,
+            timestamp: (item.timestamp as string) || (item.startTime as string) || null,
+          });
+        }
+      }
+    }
+  } catch {
+    // keep recent empty
+  }
+
+  const connected = dailyStatus === 200 || traceStatus === 200;
+
+  return {
+    available: connected,
+    error: requestError,
+    publicUrl,
+    toolCalls7d: observations,
+    traces7d: traces,
+    observations7d: observations,
+    recentTraces: recent,
+  };
+}

--- a/backend/src/services/workspaceOverviewService.ts
+++ b/backend/src/services/workspaceOverviewService.ts
@@ -1,0 +1,237 @@
+import type { Knex } from 'knex';
+import { promises as fs } from 'fs';
+import { fetchLangfuseAggregates, isLangfuseConfigured, type LangfuseTracesListItem } from './langfuseClient';
+import { collectSkillIds } from '../lib/skillsRegistry';
+import type { UserService, UserRecord } from './userService';
+
+export type AppActivityItem = {
+  source: 'app';
+  id: string;
+  title: string;
+  meta: string;
+  at: string;
+};
+
+export type LangfuseActivityItem = {
+  source: 'langfuse';
+  id: string;
+  title: string;
+  meta: string;
+  at: string;
+};
+
+export type WorkspaceOverviewActivity = AppActivityItem | LangfuseActivityItem;
+
+export type WorkspaceOverviewResponse = {
+  skills: { count: number };
+  users: { total: number; messaged24h: number };
+  langfuse: {
+    available: boolean;
+    configured: boolean;
+    publicUrl: string | null;
+    error?: string;
+    traces7d: number;
+    observations7d: number;
+    recentTraces: LangfuseTracesListItem[];
+  };
+  activity: { items: WorkspaceOverviewActivity[] };
+  focus: Array<{
+    title: string;
+    description: string;
+    to: string;
+    action: string;
+  }>;
+};
+
+const MS_24H = 24 * 60 * 60 * 1000;
+const MS_7D = 7 * 24 * 60 * 60 * 1000;
+const MAX_ACTIVITY = 8;
+
+function previewText(s: string, n = 80) {
+  const t = s.replace(/\s+/g, ' ').trim();
+  if (t.length <= n) return t;
+  return `${t.slice(0, n - 1)}…`;
+}
+
+export function buildFocusAreas(
+  input: { skillCount: number; totalUsers: number; messaged24h: number; langfuseConfigured: boolean; langfuseAvailable: boolean; langfuseError?: string },
+): Array<{ title: string; description: string; to: string; action: string }> {
+  const { skillCount, totalUsers, messaged24h, langfuseConfigured, langfuseAvailable, langfuseError } = input;
+  const out: Array<{ title: string; description: string; to: string; action: string }> = [];
+  if (skillCount === 0) {
+    out.push({
+      title: 'Seed core skills',
+      description: 'The registry is still empty. Add starter skills so the workspace feels ready on first use.',
+      to: '/settings/agents',
+      action: 'Open skill registry',
+    });
+  }
+  if (totalUsers > 0 && messaged24h < Math.max(1, totalUsers) && totalUsers > 1) {
+    out.push({
+      title: 'Adoption and access',
+      description: `Only ${messaged24h} user(s) had chat messages in the last 24 hours. Review users and access coverage as you scale the workspace.`,
+      to: '/settings/users',
+      action: 'Review users',
+    });
+  }
+  if (langfuseConfigured && (!langfuseAvailable || langfuseError)) {
+    out.push({
+      title: 'Check Langfuse',
+      description: 'Langfuse could not be reached for metrics, or the API returned an error. Verify the deployment and keys.',
+      to: '/settings',
+      action: 'Retry on refresh',
+    });
+  }
+  if (out.length < 3) {
+    out.push({
+      title: 'Track knowledge readiness',
+      description: 'Make ingestion health visible so indexed content is easy to trust and troubleshoot.',
+      to: '/settings/knowledge',
+      action: 'Review knowledge',
+    });
+  }
+  return out.slice(0, 3);
+}
+
+type RowMsg = {
+  id: string | number;
+  createdAt: Date;
+  text: string;
+  sender: string;
+  displayName: string | null;
+};
+
+function mergeActivity(
+  app: AppActivityItem[],
+  lf: LangfuseActivityItem[],
+): WorkspaceOverviewActivity[] {
+  return [...app, ...lf]
+    .map((it) => ({ it, t: Date.parse(it.at) }))
+    .filter((x) => !Number.isNaN(x.t))
+    .sort((a, b) => b.t - a.t)
+    .slice(0, MAX_ACTIVITY)
+    .map((x) => x.it);
+}
+
+export type BuildOverviewDeps = {
+  db: Knex;
+  userService: UserService;
+  skillsRoot: string;
+  nodeEnv?: string;
+  fetchLangfuse: typeof fetchLangfuseAggregates;
+  now: () => number;
+};
+
+export async function buildWorkspaceOverview(
+  deps: BuildOverviewDeps,
+): Promise<WorkspaceOverviewResponse> {
+  const { db, userService, skillsRoot, nodeEnv, fetchLangfuse, now } = deps;
+  const t0 = now();
+
+  await fs.mkdir(skillsRoot, { recursive: true });
+  const skillIds = await collectSkillIds(skillsRoot);
+
+  const users: UserRecord[] = await userService.listUsers();
+  const total = users.length;
+
+  const from24 = new Date(t0 - MS_24H);
+  const countRow = await db('conversation_messages')
+    .whereNotNull('authorId')
+    .andWhere('createdAt', '>=', from24)
+    .countDistinct('authorId as c')
+    .first() as { c?: string | number } | undefined;
+  const rawC = countRow?.c;
+  const messaged24h = typeof rawC === 'string' ? parseInt(rawC, 10) : Number(rawC) || 0;
+
+  const rows = await db('conversation_messages as m')
+    .leftJoin('users as u', 'm.authorId', 'u.id')
+    .select(
+      'm.id',
+      'm.createdAt',
+      'm.text',
+      'm.sender',
+      'u.displayName as displayName',
+    )
+    .orderBy('m.createdAt', 'desc')
+    .limit(5) as RowMsg[];
+
+  const appItems: AppActivityItem[] = rows.map((r) => {
+    const isUser = (r.sender || '') === 'user';
+    const who = isUser ? (r.displayName || 'User') : 'Assistant';
+    const at = r.createdAt instanceof Date
+      ? r.createdAt.toISOString()
+      : new Date(r.createdAt as string | number).toISOString();
+    const preview = previewText(r.text || '', 100);
+    return {
+      source: 'app' as const,
+      id: `m:${r.id}`,
+      title: isUser ? `${who}: ${preview}` : `Assistant: ${preview}`,
+      meta: isUser ? 'Chat · user message' : 'Chat · agent',
+      at,
+    };
+  });
+
+  const from7 = new Date(t0 - MS_7D).toISOString();
+  const to7 = new Date(t0).toISOString();
+  const langfuseConfigured = isLangfuseConfigured();
+  let langfuse: WorkspaceOverviewResponse['langfuse'] = {
+    available: false,
+    configured: langfuseConfigured,
+    publicUrl: (process.env.LANGFUSE_NEXTAUTH_URL || '').trim() || null,
+    traces7d: 0,
+    observations7d: 0,
+    recentTraces: [],
+  };
+
+  if (langfuseConfigured) {
+    try {
+      const agg = await fetchLangfuse(from7, to7);
+      const err = (nodeEnv === 'development' && agg.error) ? agg.error : undefined;
+      langfuse = {
+        available: agg.available,
+        configured: true,
+        publicUrl: agg.publicUrl,
+        error: err,
+        traces7d: agg.traces7d,
+        observations7d: agg.observations7d,
+        recentTraces: agg.recentTraces,
+      };
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      langfuse = {
+        available: false,
+        configured: true,
+        publicUrl: (process.env.LANGFUSE_NEXTAUTH_URL || '').trim() || null,
+        error: nodeEnv === 'development' ? message : undefined,
+        traces7d: 0,
+        observations7d: 0,
+        recentTraces: [],
+      };
+    }
+  }
+
+  const lfItems: LangfuseActivityItem[] = (langfuse.recentTraces || []).map((tr) => ({
+    source: 'langfuse' as const,
+    id: `t:${tr.id}`,
+    title: (tr.name && tr.name.trim()) || 'Trace',
+    meta: 'Langfuse',
+    at: (tr.timestamp && tr.timestamp.trim()) || new Date(t0).toISOString(),
+  }));
+
+  const focus = buildFocusAreas({
+    skillCount: skillIds.length,
+    totalUsers: total,
+    messaged24h,
+    langfuseConfigured: langfuse.configured,
+    langfuseAvailable: langfuse.available,
+    langfuseError: langfuse.error,
+  });
+
+  return {
+    skills: { count: skillIds.length },
+    users: { total, messaged24h },
+    langfuse,
+    activity: { items: mergeActivity(appItems, lfItems) },
+    focus,
+  };
+}

--- a/backend/tests/workspaceDashboard.test.ts
+++ b/backend/tests/workspaceDashboard.test.ts
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildFocusAreas } from '../src/services/workspaceOverviewService';
+import { fetchLangfuseAggregates, isLangfuseConfigured } from '../src/services/langfuseClient';
+
+test('buildFocusAreas suggests seeding skills when registry is empty', () => {
+  const f = buildFocusAreas({
+    skillCount: 0,
+    totalUsers: 5,
+    messaged24h: 2,
+    langfuseConfigured: false,
+    langfuseAvailable: false,
+  });
+  assert.ok(f.some((x) => x.title.includes('Seed') || x.title.toLowerCase().includes('skill')));
+});
+
+test('buildFocusAreas flags adoption when many users are quiet', () => {
+  const f = buildFocusAreas({
+    skillCount: 3,
+    totalUsers: 5,
+    messaged24h: 1,
+    langfuseConfigured: true,
+    langfuseAvailable: true,
+  });
+  assert.ok(
+    f.some((x) => x.title.toLowerCase().includes('adoption') || x.to === '/settings/users'),
+  );
+});
+
+test('buildFocusAreas warns when Langfuse is configured but unavailable', () => {
+  const f = buildFocusAreas({
+    skillCount: 2,
+    totalUsers: 2,
+    messaged24h: 2,
+    langfuseConfigured: true,
+    langfuseAvailable: false,
+  });
+  assert.ok(f.some((x) => x.title.toLowerCase().includes('langfuse')));
+});
+
+test('fetchLangfuseAggregates parses daily metrics and lists traces (mocked fetch)', async () => {
+  const prev = {
+    base: process.env.LANGFUSE_BASE_URL,
+    pk: process.env.LANGFUSE_PUBLIC_KEY,
+    sk: process.env.LANGFUSE_SECRET_KEY,
+    next: process.env.LANGFUSE_NEXTAUTH_URL,
+    fetch: globalThis.fetch,
+  };
+  process.env.LANGFUSE_BASE_URL = 'http://langfuse.test';
+  process.env.LANGFUSE_PUBLIC_KEY = 'lf_pk';
+  process.env.LANGFUSE_SECRET_KEY = 'lf_sk';
+  process.env.LANGFUSE_NEXTAUTH_URL = 'https://langfuse.example';
+  assert.equal(isLangfuseConfigured(), true);
+
+  (globalThis as { fetch: typeof globalThis.fetch }).fetch = (async (url: string) => {
+    if (url.includes('/api/public/metrics/daily')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [{ countTraces: 3, countObservations: 7 }] }),
+      } as unknown as Response;
+    }
+    if (url.includes('/api/public/traces')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [
+            { id: 'a', name: 'Test trace', timestamp: '2024-01-01T00:00:00.000Z' },
+          ],
+        }),
+      } as unknown as Response;
+    }
+    return { ok: false, status: 500, json: async () => ({}) } as unknown as Response;
+  }) as typeof fetch;
+
+  const out = await fetchLangfuseAggregates('2024-01-01T00:00:00.000Z', '2024-01-08T00:00:00.000Z');
+  assert.equal(out.available, true);
+  assert.equal(out.traces7d, 3);
+  assert.equal(out.observations7d, 7);
+  assert.equal(out.recentTraces.length, 1);
+  assert.equal(out.recentTraces[0]?.id, 'a');
+
+  if (prev.base === undefined) delete process.env.LANGFUSE_BASE_URL; else process.env.LANGFUSE_BASE_URL = prev.base;
+  if (prev.pk === undefined) delete process.env.LANGFUSE_PUBLIC_KEY; else process.env.LANGFUSE_PUBLIC_KEY = prev.pk;
+  if (prev.sk === undefined) delete process.env.LANGFUSE_SECRET_KEY; else process.env.LANGFUSE_SECRET_KEY = prev.sk;
+  if (prev.next === undefined) delete process.env.LANGFUSE_NEXTAUTH_URL; else process.env.LANGFUSE_NEXTAUTH_URL = prev.next;
+  globalThis.fetch = prev.fetch;
+});

--- a/backend/tests/workspaceDashboard.test.ts
+++ b/backend/tests/workspaceDashboard.test.ts
@@ -87,3 +87,59 @@ test('fetchLangfuseAggregates parses daily metrics and lists traces (mocked fetc
   if (prev.next === undefined) delete process.env.LANGFUSE_NEXTAUTH_URL; else process.env.LANGFUSE_NEXTAUTH_URL = prev.next;
   globalThis.fetch = prev.fetch;
 });
+
+test('fetchLangfuseAggregates sends metrics query payload when daily metrics 404', async () => {
+  const prev = {
+    base: process.env.LANGFUSE_BASE_URL,
+    pk: process.env.LANGFUSE_PUBLIC_KEY,
+    sk: process.env.LANGFUSE_SECRET_KEY,
+    next: process.env.LANGFUSE_NEXTAUTH_URL,
+    fetch: globalThis.fetch,
+  };
+  process.env.LANGFUSE_BASE_URL = 'http://langfuse.test';
+  process.env.LANGFUSE_PUBLIC_KEY = 'lf_pk';
+  process.env.LANGFUSE_SECRET_KEY = 'lf_sk';
+  process.env.LANGFUSE_NEXTAUTH_URL = 'https://langfuse.example';
+
+  const metricViews: string[] = [];
+  (globalThis as { fetch: typeof globalThis.fetch }).fetch = (async (url: string) => {
+    const parsed = new URL(url);
+    if (parsed.pathname === '/api/public/metrics/daily') {
+      return { ok: false, status: 404, json: async () => ({}) } as unknown as Response;
+    }
+    if (parsed.pathname === '/api/public/metrics') {
+      const query = JSON.parse(parsed.searchParams.get('query') || '{}') as {
+        view?: string;
+        metrics?: Array<{ measure?: string; aggregation?: string }>;
+        fromTimestamp?: string;
+        toTimestamp?: string;
+      };
+      assert.equal(query.metrics?.[0]?.measure, 'count');
+      assert.equal(query.metrics?.[0]?.aggregation, 'count');
+      assert.equal(query.fromTimestamp, '2024-01-01T00:00:00.000Z');
+      assert.equal(query.toTimestamp, '2024-01-08T00:00:00.000Z');
+      metricViews.push(query.view || '');
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [{ count_count: query.view === 'traces' ? '4' : '9' }] }),
+      } as unknown as Response;
+    }
+    if (parsed.pathname === '/api/public/traces') {
+      return { ok: true, status: 200, json: async () => ({ data: [] }) } as unknown as Response;
+    }
+    return { ok: false, status: 500, json: async () => ({}) } as unknown as Response;
+  }) as typeof fetch;
+
+  const out = await fetchLangfuseAggregates('2024-01-01T00:00:00.000Z', '2024-01-08T00:00:00.000Z');
+  assert.deepEqual(metricViews, ['traces', 'observations']);
+  assert.equal(out.available, true);
+  assert.equal(out.traces7d, 4);
+  assert.equal(out.observations7d, 9);
+
+  if (prev.base === undefined) delete process.env.LANGFUSE_BASE_URL; else process.env.LANGFUSE_BASE_URL = prev.base;
+  if (prev.pk === undefined) delete process.env.LANGFUSE_PUBLIC_KEY; else process.env.LANGFUSE_PUBLIC_KEY = prev.pk;
+  if (prev.sk === undefined) delete process.env.LANGFUSE_SECRET_KEY; else process.env.LANGFUSE_SECRET_KEY = prev.sk;
+  if (prev.next === undefined) delete process.env.LANGFUSE_NEXTAUTH_URL; else process.env.LANGFUSE_NEXTAUTH_URL = prev.next;
+  globalThis.fetch = prev.fetch;
+});

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
-import { Users2, Hammer, MessageCircle, Activity, Sparkles, ArrowRight, ShieldCheck, BookOpen } from 'lucide-react';
+import { Users2, Hammer, MessageCircle, Activity, Sparkles, ArrowRight, ShieldCheck, BookOpen, ExternalLink } from 'lucide-react';
 import SettingsShell from '../components/settings/SettingsShell';
 import {
   SettingsMetricCard,
@@ -7,51 +8,110 @@ import {
   SettingsSectionHeader,
   SettingsSurface,
 } from '../components/settings/SettingsScaffold';
+import { fetchWorkspaceOverview, type WorkspaceOverview } from '../services/settingsApi';
+
+const FOCUS_ICONS = [Sparkles, ShieldCheck, BookOpen] as const;
+
+function formatRelativeTime(iso: string): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return '';
+  const diff = Math.max(0, Date.now() - t);
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(t).toLocaleString(undefined, { month: 'short', day: 'numeric' });
+}
 
 const DashboardPage = () => {
-  const stats = [
-    { label: 'Total Skills', value: '0', hint: 'Skill registry size', icon: Users2 },
-    { label: 'Active Users', value: '1', hint: 'Last 24 hours', icon: MessageCircle },
-    { label: 'Tool Calls', value: '124', hint: 'This week', icon: Hammer },
-  ];
+  const [data, setData] = useState<WorkspaceOverview | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
-  const activities = [
-    { title: 'Skill registry refreshed', meta: '2m ago • general-assistant', icon: Sparkles },
-    { title: 'Tool call spike detected', meta: '1h ago • PDF Reader', icon: Activity },
-    { title: 'New user invited', meta: 'Yesterday • sso-signup', icon: MessageCircle },
-  ];
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setLoadError(null);
+      try {
+        const overview = await fetchWorkspaceOverview();
+        if (!cancelled) {
+          setData(overview);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setLoadError(e instanceof Error ? e.message : 'Failed to load dashboard');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
-  const focusAreas = [
-    {
-      title: 'Seed core skills',
-      description: 'The registry is still empty. Add starter skills so the workspace feels ready on first use.',
-      to: '/settings/agents',
-      action: 'Open skill registry',
-      icon: Sparkles,
-    },
-    {
-      title: 'Audit access coverage',
-      description: 'Only one user is active in the last 24 hours. Verify admin coverage and group mappings.',
-      to: '/settings/users',
-      action: 'Review users',
-      icon: ShieldCheck,
-    },
-    {
-      title: 'Track knowledge readiness',
-      description: 'Make ingestion health visible so indexed content is easy to trust and troubleshoot.',
-      to: '/settings/knowledge',
-      action: 'Review knowledge',
-      icon: BookOpen,
-    },
-  ];
+  const stats = useMemo(() => {
+    if (!data) {
+      return [
+        { label: 'Total skills', value: '…', hint: 'Skill registry size', icon: Users2, pulse: true },
+        { label: 'Users with messages (24h)', value: '…', hint: 'Distinct chat authors', icon: MessageCircle, pulse: true },
+        { label: 'Langfuse observations (7d)', value: '…', hint: 'Model and tool steps', icon: Hammer, pulse: true },
+      ];
+    }
+    const { skills, users, langfuse } = data;
+    const thirdHint = langfuse.configured
+      ? (langfuse.available ? 'Rolling 7 days · from Langfuse' : 'Could not reach Langfuse API')
+      : 'Set LANGFUSE_* on the server to enable';
+    const thirdValue = !langfuse.configured
+      ? '—'
+      : (!langfuse.available && langfuse.observations7d === 0 ? '—' : String(langfuse.observations7d));
+    return [
+      {
+        label: 'Total skills',
+        value: String(skills.count),
+        hint: 'Skill registry size',
+        icon: Users2,
+        pulse: false,
+      },
+      {
+        label: 'Users with messages (24h)',
+        value: String(users.messaged24h),
+        hint: `${users.total} registered total`,
+        icon: MessageCircle,
+        pulse: false,
+      },
+      {
+        label: 'Langfuse observations (7d)',
+        value: thirdValue,
+        hint: thirdHint,
+        icon: Hammer,
+        pulse: false,
+      },
+    ];
+  }, [data]);
+
+  const activities = data?.activity.items || [];
+  const focusAreas = data?.focus || [];
 
   return (
     <SettingsShell
       eyebrow="Overview"
       title="Workspace Dashboard"
-      description="Shared operational view for registry, people, knowledge, and tooling health."
+      description="Shared operational view for registry, people, knowledge, and LLM observability (Langfuse when configured)."
     >
       <div className="space-y-6">
+        {loadError ? (
+          <div className="rounded-2xl border border-amber-200 bg-amber-50/90 px-4 py-3 text-sm text-amber-950">
+            {loadError}
+          </div>
+        ) : null}
+
         <div className="grid gap-6 xl:grid-cols-[1.45fr_0.95fr]">
           <SettingsSurface className="space-y-6">
             <div className="flex flex-wrap items-center gap-2">
@@ -65,13 +125,20 @@ const DashboardPage = () => {
             <SettingsSectionHeader
               eyebrow="Snapshot"
               title="Key workspace signals"
-              description="A compact read on adoption, tooling activity, and admin readiness."
+              description="A compact read on adoption, chat activity, and Langfuse-backed run volume."
             />
             <SettingsMetricsGrid className="md:grid-cols-3">
-              {stats.map(({ label, value, hint, icon: Icon }) => (
-                <SettingsMetricCard key={label} label={label} value={value} hint={hint} icon={Icon} />
+              {stats.map(({ label, value, hint, icon: Icon, pulse }) => (
+                <div key={label} className={pulse ? 'animate-pulse' : undefined}>
+                  <SettingsMetricCard label={label} value={value} hint={hint} icon={Icon} />
+                </div>
               ))}
             </SettingsMetricsGrid>
+            {data?.langfuse.configured && data.langfuse.error ? (
+              <p className="text-xs text-slate-500">
+                Langfuse: {data.langfuse.error}
+              </p>
+            ) : null}
           </SettingsSurface>
 
           <SettingsSurface className="space-y-5">
@@ -81,26 +148,35 @@ const DashboardPage = () => {
               description="Use the admin portal to tighten setup, access, and content coverage."
             />
             <div className="space-y-3">
-              {focusAreas.map(({ title, description, to, action, icon: Icon }) => (
-                <div key={title} className="settings-portal-card rounded-[22px] p-4">
-                  <div className="flex items-start gap-4">
-                    <span className="settings-portal-icon-muted inline-flex h-11 w-11 items-center justify-center rounded-2xl ring-1 ring-slate-200">
-                      <Icon size={18} />
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <p className="text-sm font-semibold text-slate-900">{title}</p>
-                      <p className="mt-1 text-sm leading-6 text-slate-600">{description}</p>
-                      <Link
-                        to={to}
-                        className="mt-3 inline-flex items-center gap-2 text-sm font-medium text-blue-600 transition hover:text-blue-700"
-                      >
-                        {action}
-                        <ArrowRight size={16} />
-                      </Link>
+              {loading && !data ? (
+                <p className="text-sm text-slate-500">Loading recommendations…</p>
+              ) : null}
+              {!loading && focusAreas.length === 0 ? (
+                <p className="text-sm text-slate-500">No automated recommendations right now.</p>
+              ) : null}
+              {focusAreas.map(({ title, description, to, action }, i) => {
+                const Icon = FOCUS_ICONS[i % FOCUS_ICONS.length];
+                return (
+                  <div key={title} className="settings-portal-card rounded-[22px] p-4">
+                    <div className="flex items-start gap-4">
+                      <span className="settings-portal-icon-muted inline-flex h-11 w-11 items-center justify-center rounded-2xl ring-1 ring-slate-200">
+                        <Icon size={18} />
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-semibold text-slate-900">{title}</p>
+                        <p className="mt-1 text-sm leading-6 text-slate-600">{description}</p>
+                        <Link
+                          to={to}
+                          className="mt-3 inline-flex items-center gap-2 text-sm font-medium text-blue-600 transition hover:text-blue-700"
+                        >
+                          {action}
+                          <ArrowRight size={16} />
+                        </Link>
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </SettingsSurface>
         </div>
@@ -109,28 +185,55 @@ const DashboardPage = () => {
           <SettingsSectionHeader
             eyebrow="Activity"
             title="Recent activity"
-            description="Stay on top of what changed across your workspace."
+            description="In-app messages and the latest Langfuse traces when the API is reachable."
             actions={(
-              <Link
-                to="/settings/agents"
-                className="settings-portal-button-secondary inline-flex items-center gap-2 rounded-xl px-3.5 py-2.5 text-sm font-medium transition"
-              >
-                Manage skills
-              </Link>
+              <div className="flex flex-wrap items-center gap-2">
+                {data?.langfuse.publicUrl ? (
+                  <a
+                    href={data.langfuse.publicUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="settings-portal-button-secondary inline-flex items-center gap-2 rounded-xl px-3.5 py-2.5 text-sm font-medium transition"
+                  >
+                    Open Langfuse
+                    <ExternalLink size={16} />
+                  </a>
+                ) : null}
+                <Link
+                  to="/settings/agents"
+                  className="settings-portal-button-secondary inline-flex items-center gap-2 rounded-xl px-3.5 py-2.5 text-sm font-medium transition"
+                >
+                  Manage skills
+                </Link>
+              </div>
             )}
           />
           <div className="mt-6 space-y-3">
-            {activities.map(({ title, meta, icon: Icon }) => (
-              <div key={title} className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-4">
-                <span className="settings-portal-icon-muted inline-flex h-10 w-10 items-center justify-center rounded-2xl ring-1 ring-slate-200">
-                  <Icon size={18} />
-                </span>
-                <div className="min-w-0">
-                  <p className="text-sm font-medium text-slate-900">{title}</p>
-                  <p className="text-xs text-slate-500">{meta}</p>
+            {loading && activities.length === 0 ? (
+              <p className="text-sm text-slate-500">Loading recent activity…</p>
+            ) : null}
+            {!loading && activities.length === 0 ? (
+              <p className="text-sm text-slate-500">No recent activity yet. Start a chat or run the agent to populate this list.</p>
+            ) : null}
+            {activities.map((a) => {
+              const rel = formatRelativeTime(a.at);
+              const icon = a.source === 'langfuse' ? Activity : a.meta.includes('agent') ? MessageCircle : Sparkles;
+              const Icon = icon;
+              return (
+                <div key={a.id} className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-4">
+                  <span className="settings-portal-icon-muted inline-flex h-10 w-10 items-center justify-center rounded-2xl ring-1 ring-slate-200">
+                    <Icon size={18} />
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-slate-900">{a.title}</p>
+                    <p className="text-xs text-slate-500">
+                      {rel ? `${rel} · ` : ''}
+                      {a.meta}
+                    </p>
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </SettingsSurface>
       </div>

--- a/frontend/src/services/settingsApi.ts
+++ b/frontend/src/services/settingsApi.ts
@@ -115,6 +115,48 @@ const unwrapError = async (response: Response, fallback: string) => {
   throw new Error(message);
 };
 
+export type WorkspaceOverviewActivityItem = {
+  source: 'app' | 'langfuse';
+  id: string;
+  title: string;
+  meta: string;
+  at: string;
+};
+
+export type WorkspaceOverview = {
+  skills: { count: number };
+  users: { total: number; messaged24h: number };
+  langfuse: {
+    available: boolean;
+    configured: boolean;
+    publicUrl: string | null;
+    error?: string;
+    traces7d: number;
+    observations7d: number;
+    recentTraces: Array<{ id: string; name?: string | null; timestamp?: string | null }>;
+  };
+  activity: { items: WorkspaceOverviewActivityItem[] };
+  focus: Array<{
+    title: string;
+    description: string;
+    to: string;
+    action: string;
+  }>;
+};
+
+export const fetchWorkspaceOverview = async (): Promise<WorkspaceOverview> => {
+  const response = await apiFetch(`${API_URL}/settings/workspace-overview`);
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    const apiError = typeof data.error === 'string' ? data.error : '';
+    if (response.status === 401 || response.status === 403 || /admin access required/i.test(apiError)) {
+      throw new Error('Admin access required to open Settings.');
+    }
+    throw new Error(apiError || 'Failed to load workspace overview');
+  }
+  return response.json() as Promise<WorkspaceOverview>;
+};
+
 export const fetchAgentConfig = async (): Promise<string> => {
   const response = await apiFetch(`${API_URL}/settings/agent-config`);
   if (!response.ok) {

--- a/infra/gke/k8s/50-app.yaml
+++ b/infra/gke/k8s/50-app.yaml
@@ -383,6 +383,12 @@ spec:
                   name: helpudoc-secrets
                   key: LANGFUSE_SECRET_KEY
                   optional: true
+            - name: LANGFUSE_NEXTAUTH_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: helpudoc-config
+                  key: LANGFUSE_NEXTAUTH_URL
+                  optional: true
           volumeMounts:
             - name: workspace-data
               mountPath: /app/workspaces


### PR DESCRIPTION
## Summary

Adds the workspace dashboard analytics view and backend overview endpoint for admin settings. The dashboard now surfaces skill count, recent chat activity, user message activity, and Langfuse-backed trace/observation volume when configured.

## Fix Included

Addresses the Langfuse Metrics API fallback by sending the documented URL-encoded `query` payload to `/api/public/metrics` when `/api/public/metrics/daily` is unavailable, querying both `traces` and `observations` counts.

## Validation

- `npm test` in `backend`
- `npx tsc --noEmit` in `backend`

Note: `graphify update .` was attempted earlier but `graphify` was not available on PATH in this environment.