### PR TITLE
fix(hitl): LangGraph v2 streams + resumed-run idle stall detection

### DIFF
--- a/agent/helpudoc_agent/app.py
+++ b/agent/helpudoc_agent/app.py
@@ -2092,6 +2092,7 @@ def create_app() -> FastAPI:
             self._tool_names: Dict[str, str] = {}
             self._tool_meta: Dict[str, Any] = {}
             self._active_llm_runs: Set[str] = set()
+            self._reported_llm_runs: Set[str] = set()
             self._to_text = text_fn
             self._has_events = False
             self._has_assistant_text = False
@@ -2122,6 +2123,22 @@ def create_app() -> FastAPI:
                     self._has_assistant_text = True
             await self.queue.put(payload)
 
+        async def _emit_model_start(self, serialized: Any, run_id: Any) -> None:
+            run_key = str(run_id)
+            if run_key in self._reported_llm_runs:
+                return
+            self._reported_llm_runs.add(run_key)
+            name = ""
+            if isinstance(serialized, dict):
+                name = str(serialized.get("name") or serialized.get("id") or "").strip()
+            await self._emit({"type": "model_start", "name": name or "model"})
+
+        async def on_llm_start(self, serialized, prompts, *, run_id, **_: Any) -> None:
+            await self._emit_model_start(serialized, run_id)
+
+        async def on_chat_model_start(self, serialized, messages, *, run_id, **_: Any) -> None:
+            await self._emit_model_start(serialized, run_id)
+
         async def on_llm_new_token(
             self,
             token: str,
@@ -2135,6 +2152,7 @@ def create_app() -> FastAPI:
             await self._emit({"type": "token", "content": token, "role": "assistant"})
 
         async def on_llm_end(self, response, *, run_id, **_: Any) -> None:
+            await self._emit({"type": "model_end", "name": "model"})
             run_key = str(run_id)
             if run_key in self._active_llm_runs:
                 self._active_llm_runs.discard(run_key)
@@ -2329,10 +2347,21 @@ def create_app() -> FastAPI:
     def _parse_multi_mode_chunk(raw_chunk: Any) -> tuple[str | None, Any]:
         if isinstance(raw_chunk, tuple) and len(raw_chunk) == 2 and isinstance(raw_chunk[0], str):
             return raw_chunk[0], raw_chunk[1]
+        if isinstance(raw_chunk, dict) and isinstance(raw_chunk.get("type"), str) and "data" in raw_chunk:
+            return raw_chunk.get("type"), raw_chunk.get("data")
         return None, raw_chunk
 
     def _extract_messages(chunk: Any) -> List[Any] | None:
         if chunk is None:
+            return None
+        mode, parsed_chunk = _parse_multi_mode_chunk(chunk)
+        if mode == "updates":
+            chunk = parsed_chunk
+        elif mode == "messages":
+            if isinstance(parsed_chunk, (list, tuple)) and parsed_chunk:
+                return [parsed_chunk[0]]
+            if parsed_chunk is not None:
+                return [parsed_chunk]
             return None
         if isinstance(chunk, dict):
             if "messages" in chunk:
@@ -2375,6 +2404,11 @@ def create_app() -> FastAPI:
         return normalize_interrupt_payload_value(interrupt_value, interrupt_id if isinstance(interrupt_id, str) else None)
 
     def _extract_interrupt_payload(chunk: Any) -> Dict[str, Any] | None:
+        mode, parsed_chunk = _parse_multi_mode_chunk(chunk)
+        if mode == "updates":
+            chunk = parsed_chunk
+        elif mode == "messages":
+            return None
         if not isinstance(chunk, dict):
             return None
         return _build_interrupt_payload(chunk.get("__interrupt__"))
@@ -2632,14 +2666,26 @@ def create_app() -> FastAPI:
                     stream_input = Command(resume={"decisions": resume_decisions})
                 elif resume_value is not None:
                     stream_input = Command(resume=resume_value)
+                streamed_message_events: List[Dict[str, Any]] = []
+                streamed_message_tracker = _DeltaTracker()
                 final_result = None
                 async for chunk in agent.astream(
                     stream_input,
                     config=stream_config,
                     context=runtime.workspace_state.context,
-                    stream_mode="values",
+                    stream_mode=["updates", "messages"],
+                    version="v2",
                 ):
-                    final_result = chunk
+                    mode, _parsed_chunk = _parse_multi_mode_chunk(chunk)
+                    if mode == "messages":
+                        for msg in _extract_messages(chunk) or []:
+                            text = _message_to_text(msg)
+                            role = _message_role(msg)
+                            delta = streamed_message_tracker.push(role, text)
+                            if delta:
+                                streamed_message_events.extend(_emit_text(role, delta))
+                    else:
+                        final_result = chunk
                     interrupt_payload = _extract_interrupt_payload(chunk)
                     if interrupt_payload:
                         saw_interrupt = True
@@ -2664,12 +2710,16 @@ def create_app() -> FastAPI:
                             emitted = True
                             for event_payload in _emit_text(role, delta):
                                 await handler._emit(event_payload)
-                elif not handler.has_assistant_text:
+                elif final_result is not None and not handler.has_assistant_text:
                     text = _message_to_text(final_result)
                     if text and not _is_internal_stream_text(text):
                         emitted = True
                         for event_payload in _emit_text("assistant", text):
                             await handler._emit(event_payload)
+                if not emitted and not handler.has_assistant_text and streamed_message_events:
+                    emitted = True
+                    for event_payload in streamed_message_events:
+                        await handler._emit(event_payload)
 
                 if not emitted and not handler.has_events:
                     await handler._emit(

--- a/backend/src/services/agentRunService.ts
+++ b/backend/src/services/agentRunService.ts
@@ -120,6 +120,11 @@ type PersistedRunMeta = Omit<RunMeta, 'pendingInterrupt'> & {
 };
 
 const STREAM_TTL_SECONDS = 60 * 60 * 24; // 24h
+const DEFAULT_RESUMED_RUN_IDLE_TIMEOUT_MS = 2 * 60 * 1000;
+const RESUMED_RUN_IDLE_TIMEOUT_MS = (() => {
+  const raw = Number(process.env.AGENT_RESUME_IDLE_TIMEOUT_MS || '');
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_RESUMED_RUN_IDLE_TIMEOUT_MS;
+})();
 const DEBUG_AGENT_RUN_STREAM =
   process.env.DEBUG_AGENT_RUN_STREAM === '1' || process.env.DEBUG_AGENT_RUN_STREAM === 'true';
 
@@ -239,6 +244,26 @@ const isRepeatedClarificationInterrupt = (
     return true;
   }
   return clarificationSignature(normalized) === clarificationSignature(previousInterrupt);
+};
+
+export const isRealRunProgressEvent = (parsed: Record<string, unknown> | null): boolean => {
+  const type = typeof parsed?.type === 'string' ? parsed.type : '';
+  return Boolean(type && type !== 'keepalive' && type !== 'policy' && type !== 'langfuse');
+};
+
+export const shouldFailResumedRunForIdle = (input: {
+  resumePayload?: ResumePayload;
+  sawInterruptPayload?: Record<string, unknown> | null;
+  activeToolCalls: number;
+  lastRealActivityAt: number;
+  now: number;
+  timeoutMs?: number;
+}): boolean => {
+  if (!input.resumePayload || input.sawInterruptPayload || input.activeToolCalls > 0) {
+    return false;
+  }
+  const timeoutMs = input.timeoutMs ?? RESUMED_RUN_IDLE_TIMEOUT_MS;
+  return timeoutMs > 0 && input.now - input.lastRealActivityAt >= timeoutMs;
 };
 
 const persistMeta = async (runId: string, meta: Partial<PersistedRunMeta>) => {
@@ -585,8 +610,32 @@ async function runAgentRunWorker(
   let sawInterruptPayload: Record<string, unknown> | null = null;
   let contractErrorMessage = '';
   let loopErrorMessage = '';
+  let stallErrorMessage = '';
   let settled = false;
   let processingQueue: Promise<void> = Promise.resolve();
+  let activeToolCalls = 0;
+  let lastRealActivityAt = Date.now();
+
+  const failIfResumedRunIsIdle = async () => {
+    if (stallErrorMessage || settled) {
+      return false;
+    }
+    if (!shouldFailResumedRunForIdle({
+      resumePayload,
+      sawInterruptPayload,
+      activeToolCalls,
+      lastRealActivityAt,
+      now: Date.now(),
+    })) {
+      return false;
+    }
+    stallErrorMessage = 'Agent stalled after human clarification. No tool call, token, interrupt, or completion was emitted after the clarification response.';
+    await appendStreamEvent(runId, JSON.stringify({ type: 'error', message: stallErrorMessage }));
+    if (upstream && !upstream.destroyed) {
+      upstream.destroy();
+    }
+    return true;
+  };
 
   const finalizeRun = async (status: AgentRunStatus, error?: string) => {
     if (settled) {
@@ -697,6 +746,9 @@ async function runAgentRunWorker(
         buffer = buffer.slice(newlineIndex + 1);
         if (line) {
           const parsed = parseLine(line);
+          if (isRealRunProgressEvent(parsed)) {
+            lastRealActivityAt = Date.now();
+          }
           if (parsed?.type === 'langfuse') {
             const traceId = typeof parsed.traceId === 'string' ? parsed.traceId.trim() : '';
             const traceUrl = typeof parsed.traceUrl === 'string' ? parsed.traceUrl.trim() : '';
@@ -732,6 +784,7 @@ async function runAgentRunWorker(
           }
           if (parsed?.type === 'tool_start' || parsed?.type === 'tool_end' || parsed?.type === 'tool_error') {
             if (parsed.type === 'tool_start') {
+              activeToolCalls += 1;
               toolCallCount += 1;
               if (parsed.name === 'load_skill' && typeof parsed.content === 'string') {
                 const skillMatch = parsed.content.match(/skill[_-]?id["']?\s*[:=]\s*["']([^"']+)["']/i);
@@ -741,7 +794,11 @@ async function runAgentRunWorker(
               }
             }
             if (parsed.type === 'tool_error') {
+              activeToolCalls = Math.max(0, activeToolCalls - 1);
               toolErrorCount += 1;
+            }
+            if (parsed.type === 'tool_end') {
+              activeToolCalls = Math.max(0, activeToolCalls - 1);
             }
             eventIndex += 1;
             if (runTelemetryService && typeof parsed.name === 'string' && parsed.name.trim()) {
@@ -781,6 +838,9 @@ async function runAgentRunWorker(
                 ? parsed.message
                 : 'Artifact contract validation failed.';
           }
+          if (parsed?.type === 'keepalive' && await failIfResumedRunIsIdle()) {
+            break;
+          }
         }
         newlineIndex = buffer.indexOf('\n');
       }
@@ -803,6 +863,9 @@ async function runAgentRunWorker(
       .filter((line) => line.length > 0);
     for (const line of lines) {
       const parsed = parseLine(line);
+      if (isRealRunProgressEvent(parsed)) {
+        lastRealActivityAt = Date.now();
+      }
       if (parsed?.type === 'langfuse') {
         const traceId = typeof parsed.traceId === 'string' ? parsed.traceId.trim() : '';
         const traceUrl = typeof parsed.traceUrl === 'string' ? parsed.traceUrl.trim() : '';
@@ -838,6 +901,7 @@ async function runAgentRunWorker(
       }
       if (parsed?.type === 'tool_start' || parsed?.type === 'tool_end' || parsed?.type === 'tool_error') {
         if (parsed.type === 'tool_start') {
+          activeToolCalls += 1;
           toolCallCount += 1;
           if (parsed.name === 'load_skill' && typeof parsed.content === 'string') {
             const skillMatch = parsed.content.match(/skill[_-]?id["']?\s*[:=]\s*["']([^"']+)["']/i);
@@ -847,7 +911,11 @@ async function runAgentRunWorker(
           }
         }
         if (parsed.type === 'tool_error') {
+          activeToolCalls = Math.max(0, activeToolCalls - 1);
           toolErrorCount += 1;
+        }
+        if (parsed.type === 'tool_end') {
+          activeToolCalls = Math.max(0, activeToolCalls - 1);
         }
         eventIndex += 1;
         if (runTelemetryService && typeof parsed.name === 'string' && parsed.name.trim()) {
@@ -886,6 +954,9 @@ async function runAgentRunWorker(
           typeof parsed.message === 'string' && parsed.message.trim()
             ? parsed.message
             : 'Artifact contract validation failed.';
+      }
+      if (parsed?.type === 'keepalive' && await failIfResumedRunIsIdle()) {
+        break;
       }
     }
   };
@@ -943,6 +1014,11 @@ async function runAgentRunWorker(
         return;
       }
 
+      if (stallErrorMessage) {
+        await finalizeRun('failed', stallErrorMessage);
+        return;
+      }
+
       if (controller.signal.aborted) {
         await finalizeRun('cancelled');
         return;
@@ -964,6 +1040,10 @@ async function runAgentRunWorker(
     upstream.on('error', async (error: Error) => {
       if (loopErrorMessage) {
         await finalizeRun('failed', loopErrorMessage);
+        return;
+      }
+      if (stallErrorMessage) {
+        await finalizeRun('failed', stallErrorMessage);
         return;
       }
       if (sawInterruptPayload) {

--- a/backend/tests/agentRunService.test.ts
+++ b/backend/tests/agentRunService.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  isRealRunProgressEvent,
+  shouldFailResumedRunForIdle,
+} from '../src/services/agentRunService';
+
+test('isRealRunProgressEvent ignores transport-only events', () => {
+  assert.equal(isRealRunProgressEvent({ type: 'keepalive' }), false);
+  assert.equal(isRealRunProgressEvent({ type: 'policy', skill: 'frontend-slides' }), false);
+  assert.equal(isRealRunProgressEvent({ type: 'langfuse', traceId: 'trace-1' }), false);
+  assert.equal(isRealRunProgressEvent({ type: 'model_start', name: 'gemini' }), true);
+  assert.equal(isRealRunProgressEvent({ type: 'tool_end', name: 'request_clarification' }), true);
+  assert.equal(isRealRunProgressEvent({ type: 'token', content: 'hello' }), true);
+});
+
+test('shouldFailResumedRunForIdle only fails resumed idle runs with no active tool', () => {
+  const resumePayload = { response: { message: 'ok' } } as any;
+
+  assert.equal(
+    shouldFailResumedRunForIdle({
+      resumePayload,
+      activeToolCalls: 0,
+      lastRealActivityAt: 1_000,
+      now: 4_001,
+      timeoutMs: 3_000,
+    }),
+    true,
+  );
+
+  assert.equal(
+    shouldFailResumedRunForIdle({
+      resumePayload,
+      activeToolCalls: 1,
+      lastRealActivityAt: 1_000,
+      now: 10_000,
+      timeoutMs: 3_000,
+    }),
+    false,
+  );
+
+  assert.equal(
+    shouldFailResumedRunForIdle({
+      activeToolCalls: 0,
+      lastRealActivityAt: 1_000,
+      now: 10_000,
+      timeoutMs: 3_000,
+    }),
+    false,
+  );
+});

--- a/tests/test_agent_main.py
+++ b/tests/test_agent_main.py
@@ -134,6 +134,33 @@ class RecordingStreamingAgent(StreamingAgent):
             yield chunk
 
 
+class V2MessageStreamingAgent:
+    async def astream(self, *_args, **_kwargs):
+        yield {"type": "messages", "data": ({"role": "assistant", "content": "Hel"}, {})}
+        yield {"type": "messages", "data": ({"role": "assistant", "content": "lo"}, {})}
+
+
+class V2InterruptStreamingAgent:
+    async def astream(self, *_args, **_kwargs):
+        yield {
+            "type": "updates",
+            "data": {
+                "__interrupt__": [
+                    SimpleNamespace(
+                        value={
+                            "kind": "clarification",
+                            "title": "Need detail",
+                            "description": "Pick a direction.",
+                            "step_index": 0,
+                            "step_count": 1,
+                        },
+                        id="interrupt-123",
+                    )
+                ]
+            },
+        }
+
+
 class AsyncInvokeAgent:
     def __init__(self, reply):
         self._reply = reply
@@ -482,6 +509,9 @@ def client_with_stubs(monkeypatch):
         "helpudoc_agent.app",
         "helpudoc_agent.graph",
         "helpudoc_agent.tools_and_schemas",
+        "paper2slides",
+        "paper2slides.raganything",
+        "paper2slides.raganything.parser",
     ]
     saved_modules = {name: sys.modules.pop(name, None) for name in module_names}
 
@@ -684,11 +714,54 @@ def test_skill_directive_survives_tagged_artifact_guidance(client_with_stubs, tm
     assert messages[0]["type"] == "policy"
     assert messages[0]["skill"] == "frontend-slides"
     assert agent.stream_inputs
+    stream_kwargs = agent.stream_inputs[0][1]
+    assert stream_kwargs["stream_mode"] == ["updates", "messages"]
+    assert stream_kwargs["version"] == "v2"
     stream_input = agent.stream_inputs[0][0][0]
     user_text = stream_input["messages"][-1]["content"]
     assert "Loaded skill: frontend-slides" in user_text
     assert "Use request_clarification before generating slides." in user_text
     assert "Artifact-first guidance:" in user_text
+    assert source_tracker.updated_workspaces == [runtime.workspace_state]
+
+
+def test_chat_stream_reads_v2_message_chunks(client_with_stubs):
+    client, registry, source_tracker = client_with_stubs
+    runtime = DummyRuntime("workspace-v2-message", V2MessageStreamingAgent())
+    registry.set_runtime("research", "workspace-v2-message", runtime)
+
+    with client.stream(
+        "POST",
+        "/agents/research/workspace/workspace-v2-message/chat/stream",
+        json={"message": "Say hello", "history": []},
+    ) as response:
+        assert response.status_code == 200
+        messages = _collect_stream_payloads(response)
+
+    token_text = "".join(item.get("content", "") for item in messages if item.get("type") == "token")
+    assert token_text == "Hello"
+    assert messages[-1]["type"] == "done"
+    assert source_tracker.updated_workspaces == [runtime.workspace_state]
+
+
+def test_chat_stream_reads_v2_interrupt_chunks(client_with_stubs):
+    client, registry, source_tracker = client_with_stubs
+    runtime = DummyRuntime("workspace-v2-interrupt", V2InterruptStreamingAgent())
+    registry.set_runtime("research", "workspace-v2-interrupt", runtime)
+
+    with client.stream(
+        "POST",
+        "/agents/research/workspace/workspace-v2-interrupt/chat/stream",
+        json={"message": "Need clarification", "history": []},
+    ) as response:
+        assert response.status_code == 200
+        messages = _collect_stream_payloads(response)
+
+    interrupt = next(item for item in messages if item.get("type") == "interrupt")
+    assert interrupt["kind"] == "clarification"
+    assert interrupt["title"] == "Need detail"
+    assert interrupt["interruptId"] == "interrupt-123"
+    assert messages[-1]["type"] == "done"
     assert source_tracker.updated_workspaces == [runtime.workspace_state]
 
 


### PR DESCRIPTION
## Summary
- **Agent**: LangGraph v2 multi-stream (`updates` + `messages`), wrapped chunk parsing, token streaming from message mode, `model_start` / `model_end` events.
- **Backend**: Idle stall detection after HITL resume (`AGENT_RESUME_IDLE_TIMEOUT_MS`), real vs transport-only stream events, fail run with clear error.
- **Tests**: Python stream/interrupt coverage; Node tests for stream helpers.

See commit `3352094` for full details.

Made with [Cursor](https://cursor.com)