### PR TITLE
Replace Streamlit dashboards with native interactive dashboard rendering

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -27,5 +27,6 @@ RUN PIP_INDEX_URL="${PYTORCH_CPU_INDEX_URL}" \
 COPY agent/ /app/agent/
 COPY skills/ /app/skills/
 
+ENV PYTHONPATH=/app
 EXPOSE 8001
 CMD ["uvicorn", "agent.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/agent/helpudoc_agent/app.py
+++ b/agent/helpudoc_agent/app.py
@@ -22,7 +22,7 @@ from uuid import uuid4
 from dotenv import load_dotenv
 
 from fastapi import FastAPI, HTTPException, Body, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field, model_validator
 from langchain_core.messages import HumanMessage, SystemMessage
 
@@ -79,7 +79,12 @@ def _skill_id_from_loaded_skill_output(text: str) -> Optional[str]:
 _LOCAL_DEV_AGENT_JWT_SECRET = "helpudoc-local-dev-agent-jwt-secret"
 _RAG_PREFETCHABLE_EXTENSIONS: Set[str] = {".pdf", ".doc", ".docx", ".md", ".html", ".htm"}
 _TAGGED_HTML_EXTENSIONS: Set[str] = {".html", ".htm"}
+_TAGGED_DATASET_EXTENSIONS: Set[str] = {".parquet", ".csv"}
 _TAGGED_RAG_CONTEXT_CHAR_BUDGET = 6000
+_STRICT_DASHBOARD_QUERY_BUDGET = 5
+_STRICT_DASHBOARD_PREVIEW_BUDGET = 1
+_STRICT_DASHBOARD_SCHEMA_BUDGET = 1
+_STRICT_DASHBOARD_CHART_BUDGET = 5
 
 
 def _get_agent_jwt_secret() -> str:
@@ -112,6 +117,45 @@ def _filter_rag_prefetchable_tagged_files(tagged_paths: Sequence[str]) -> List[s
         if suffix in _RAG_PREFETCHABLE_EXTENSIONS:
             candidates.append(cleaned)
     return candidates
+
+
+def _filter_tagged_dataset_files(tagged_paths: Sequence[str]) -> List[str]:
+    candidates: List[str] = []
+    for raw in tagged_paths:
+        if not isinstance(raw, str):
+            continue
+        cleaned = raw.strip()
+        if not cleaned:
+            continue
+        suffix = Path(cleaned).suffix.lower()
+        if suffix in _TAGGED_DATASET_EXTENSIONS:
+            candidates.append(cleaned)
+    return candidates
+
+
+def _extract_tagged_files_from_text(content: str) -> List[str]:
+    if not content:
+        return []
+    lines = content.splitlines()
+    tagged: List[str] = []
+    in_block = False
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            if in_block:
+                break
+            continue
+        if stripped.startswith("Tagged files"):
+            in_block = True
+            continue
+        if in_block:
+            if stripped.startswith("-"):
+                candidate = stripped.lstrip("-").strip()
+                if candidate:
+                    tagged.append(candidate)
+            else:
+                break
+    return tagged
 
 
 def _normalize_tagged_file_paths(tagged_paths: Sequence[str]) -> List[str]:
@@ -300,6 +344,47 @@ def _append_artifact_first_guidance(
         guidance_lines.append("- Tagged derived artifacts:")
         guidance_lines.extend(f"  - {path}" for path in tagged_paths)
     return f"{prompt.rstrip()}\n\n" + "\n".join(guidance_lines)
+
+
+def _build_dashboard_mode_context(
+    context: Dict[str, Any],
+    tagged_paths: Sequence[str],
+) -> Dict[str, Any] | None:
+    if str(context.get("active_skill") or "").strip() != "data/dashboard":
+        return None
+    dataset_paths = _filter_tagged_dataset_files(tagged_paths)
+    return {
+        "strictLocalDatasets": bool(dataset_paths),
+        "taggedDatasetPaths": dataset_paths,
+        "queryBudget": _STRICT_DASHBOARD_QUERY_BUDGET,
+        "preApprovalPreviewBudget": _STRICT_DASHBOARD_PREVIEW_BUDGET,
+        "schemaBudget": _STRICT_DASHBOARD_SCHEMA_BUDGET,
+        "chartBudget": _STRICT_DASHBOARD_CHART_BUDGET,
+    }
+
+
+def _build_dashboard_runtime_guidance(user_request: str) -> str:
+    tagged_paths = _extract_tagged_files_from_text(user_request)
+    dataset_paths = _filter_tagged_dataset_files(tagged_paths)
+    guidance_lines = [
+        "Dashboard runtime guidance:",
+        "- This skill is low-variance and review-first.",
+        "- Before request_plan_approval: inspect schema once and use at most one lightweight preview query only if needed.",
+        "- Before approval, do not run aggregate analysis, do not generate charts, and do not materialize new warehouse datasets.",
+        "- After approval, use one bounded prep bundle for KPI summary, time trend, top geography breakdowns, top device/browser breakdowns, top category drivers, and an optional driver table.",
+        "- Reuse aggregate outputs instead of re-querying the same dimension repeatedly.",
+        "- Do not run duplicate country, device, browser, or category passes unless the approved plan explicitly requires a distinct visual.",
+        "- Generate 3 to 5 approved charts only, then call generate_dashboard exactly once.",
+        "- If the dataset cannot support the approved visuals, stop with a clear insufficiency message instead of ending with charts only.",
+    ]
+    if dataset_paths:
+        guidance_lines.insert(
+            1,
+            "- Tagged local dataset(s): "
+            + ", ".join(dataset_paths)
+            + ". Use these as the source of truth and do not rediscover upstream tables.",
+        )
+    return "\n".join(guidance_lines)
 
 
 class ChatRequest(BaseModel):
@@ -1521,11 +1606,15 @@ def create_app() -> FastAPI:
             )
 
         activate_skill_context(runtime.workspace_state.context, skill)
+        dashboard_guidance = ""
+        if skill.skill_id == "data/dashboard":
+            dashboard_guidance = _build_dashboard_runtime_guidance(user_request)
         return "\n\n".join(
             [
                 f"The selected skill '{skill.skill_id}' is already loaded and active for this turn.",
                 "Do not call list_skills or load_skill again unless you need to switch to a different skill.",
                 build_loaded_skill_text(skill, content),
+                dashboard_guidance,
                 f"User request:\n{fallback_request}",
             ]
         )
@@ -1730,28 +1819,7 @@ def create_app() -> FastAPI:
 
 
     def _extract_tagged_files(content: str) -> List[str]:
-        if not content:
-            return []
-        lines = content.splitlines()
-        tagged: List[str] = []
-        in_block = False
-        for line in lines:
-            stripped = line.strip()
-            if not stripped:
-                if in_block:
-                    break
-                continue
-            if stripped.startswith("Tagged files"):
-                in_block = True
-                continue
-            if in_block:
-                if stripped.startswith("-"):
-                    candidate = stripped.lstrip("-").strip()
-                    if candidate:
-                        tagged.append(candidate)
-                else:
-                    break
-        return tagged
+        return _extract_tagged_files_from_text(content)
 
     def _normalize_file_context_refs(raw_refs: Any) -> List[Dict[str, Any]]:
         normalized: List[Dict[str, Any]] = []
@@ -2257,6 +2325,8 @@ def create_app() -> FastAPI:
                 loaded_skill_id = _skill_id_from_loaded_skill_output(text)
                 if loaded_skill_id:
                     patch_current_trace_skill(loaded_skill_id)
+            if meta and meta.get("dashboardArtifact"):
+                payload["dashboardArtifact"] = meta["dashboardArtifact"]
             await self._emit(payload)
 
         async def on_tool_error(self, error, *, run_id, **_: Any) -> None:
@@ -2281,8 +2351,17 @@ def create_app() -> FastAPI:
             run_id,
             **_: Any,
         ) -> None:
+            run_key = str(run_id)
             if name == "tool_artifacts" and isinstance(data, dict):
-                self._tool_meta[str(run_id)] = data
+                bucket = self._tool_meta.get(run_key) or {}
+                bucket["files"] = list(data.get("files") or [])
+                self._tool_meta[run_key] = bucket
+                return
+            if name == "dashboard_artifact" and isinstance(data, dict):
+                bucket = self._tool_meta.get(run_key) or {}
+                bucket["dashboardArtifact"] = data
+                self._tool_meta[run_key] = bucket
+                await self._emit({"type": "dashboard_artifact", "dashboardArtifact": data})
 
     class _DeltaTracker:
         def __init__(self) -> None:
@@ -2495,6 +2574,7 @@ def create_app() -> FastAPI:
         context.pop("tagged_rag_context", None)
         context.pop("loaded_skill_ids_this_turn", None)
         context.pop("skill_load_attempts_this_turn", None)
+        context.pop("dashboard_mode", None)
         context["tagged_files_only"] = False
         context["plan_approved"] = skip_plan_approvals
         context["pre_plan_search_count"] = 0
@@ -2587,7 +2667,19 @@ def create_app() -> FastAPI:
                     break
             prompt_for_tagged_files = guided_prompt
         runtime.workspace_state.context["tagged_files"] = tagged_files
-        runtime.workspace_state.context["tagged_files_only"] = False
+        dashboard_mode = _build_dashboard_mode_context(runtime.workspace_state.context, tagged_files)
+        if dashboard_mode is not None:
+            runtime.workspace_state.context["dashboard_mode"] = dashboard_mode
+        else:
+            runtime.workspace_state.context.pop("dashboard_mode", None)
+        tagged_files_rag_only = (os.getenv("TAGGED_FILES_RAG_ONLY", "false") or "false").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "y",
+            "on",
+        }
+        runtime.workspace_state.context["tagged_files_only"] = bool(tagged_files) and tagged_files_rag_only
         if tagged_files:
             rag_context = await _prefetch_rag_context(
                 runtime.workspace_state.workspace_id,
@@ -2892,5 +2984,27 @@ def create_app() -> FastAPI:
         )
         stream = _stream_agent_response(runtime, placeholder, resume_value=action_payload)
         return StreamingResponse(stream, media_type="application/jsonl")
+
+    @app.get("/skills/{skill_id:path}/contract")
+    async def skill_contract(skill_id: str):
+        skills_root = settings.backend.skills_root
+        skill = find_skill(skills_root, skill_id)
+        if skill is None:
+            raise HTTPException(status_code=404, detail=f"Skill '{skill_id}' not found.")
+        policy = skill.policy
+        return JSONResponse(
+            {
+                "skillId": skill.skill_id,
+                "name": skill.name,
+                "description": skill.description,
+                "tools": list(skill.tools),
+                "mcpServers": list(skill.mcp_servers),
+                "requiresHitlPlan": bool(policy.requires_hitl_plan),
+                "requiresWorkspaceArtifacts": bool(policy.requires_workspace_artifacts),
+                "requiredArtifactsMode": policy.required_artifacts_mode,
+                "prePlanSearchLimit": int(policy.pre_plan_search_limit or 0),
+                "sourcePath": str(skill.path),
+            }
+        )
 
     return app

--- a/agent/helpudoc_agent/data_agent_tools.py
+++ b/agent/helpudoc_agent/data_agent_tools.py
@@ -8,11 +8,13 @@ import multiprocessing as mp
 import os
 import re
 import shutil
+import threading
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from queue import Empty
 from typing import Annotated, Any, Dict, List, Optional, Set, Tuple
+from uuid import uuid4
 
 import duckdb
 import numpy as np
@@ -67,6 +69,10 @@ MAX_RESULT_ROWS = 20
 MAX_SESSION_ROWS = 1000
 MAX_QUERY_COUNT = 10
 MAX_CHART_COUNT = 5
+STRICT_DASHBOARD_QUERY_COUNT = 5
+STRICT_DASHBOARD_PREVIEW_QUERY_COUNT = 1
+STRICT_DASHBOARD_SCHEMA_COUNT = 1
+STRICT_DASHBOARD_MIN_CHART_COUNT = 3
 DEFAULT_CACHE_TTL_HOURS = 24
 MAX_MATERIALIZED_ROWS = 100000
 MAX_QUERY_RESULT_ROWS = MAX_SESSION_ROWS + 1
@@ -88,6 +94,15 @@ WORKSPACE_SCAN_EXCLUDED_DIRS = {
     ".vscode",
 }
 DATA_FILE_EXTENSIONS = {".csv", ".parquet"}
+STRICT_DASHBOARD_DIMENSION_FIELDS = (
+    "country",
+    "device_type",
+    "browser",
+    "traffic_source",
+    "category",
+    "product_category",
+    "age_group",
+)
 DATA_DISCOVERY_DIR_CANDIDATES = (
     "data",
     "datasets",
@@ -130,16 +145,19 @@ class DataAgentSessionState:
 
     def reset(self) -> None:
         self.schema_inspected = False
+        self.schema_read_count = 0
         self.query_count = 0
         self.chart_count = 0
         self.summary_generated = False
         self.dashboard_generated = False
         self.last_query_result: Optional[pd.DataFrame] = None
         self.last_query_sql: Optional[str] = None
+        self.last_schema_result: Optional[str] = None
         self.query_history: List[_QueryRecord] = []
         self.chart_history: List[_ChartRecord] = []
         self.materialization_history: List[_MaterializationRecord] = []
         self.run_artifacts: List[Dict[str, Any]] = []
+        self.dashboard_dimension_signatures: Set[str] = set()
 
 
 class SafePandasProxy:
@@ -192,7 +210,7 @@ def _utc_now() -> datetime:
 
 
 def _workspace_rel(path: Path, root: Path) -> str:
-    return path.relative_to(root).as_posix()
+    return path.resolve().relative_to(root.resolve()).as_posix()
 
 
 def _safe_slug(value: str, default: str) -> str:
@@ -381,6 +399,69 @@ def _query_looks_aggregated(query: str) -> bool:
         re.search(r"\bgroup\s+by\b", query, re.IGNORECASE)
         or re.search(r"\bhaving\b", query, re.IGNORECASE)
     )
+
+
+def _get_dashboard_mode(workspace_state: WorkspaceState) -> Dict[str, Any]:
+    context = getattr(workspace_state, "context", {}) or {}
+    raw = context.get("dashboard_mode")
+    if isinstance(raw, dict):
+        return raw
+    active_skill = str(context.get("active_skill") or "").strip()
+    tagged_files = context.get("tagged_files") or []
+    tagged_dataset_paths = [
+        str(path).strip()
+        for path in tagged_files
+        if str(path).strip() and Path(str(path).strip()).suffix.lower() in DATA_FILE_EXTENSIONS
+    ]
+    return {
+        "strictLocalDatasets": active_skill == "data/dashboard" and bool(tagged_dataset_paths),
+        "taggedDatasetPaths": tagged_dataset_paths,
+    }
+
+
+def _is_strict_dashboard_mode(workspace_state: WorkspaceState) -> bool:
+    mode = _get_dashboard_mode(workspace_state)
+    return bool(mode.get("strictLocalDatasets"))
+
+
+def _is_plan_approved(workspace_state: WorkspaceState) -> bool:
+    context = getattr(workspace_state, "context", {}) or {}
+    if context.get("skip_plan_approvals"):
+        return True
+    return bool(context.get("plan_approved"))
+
+
+def _dashboard_plan_gate_message() -> str:
+    return (
+        "Dashboard planning mode is active. Draft the dashboard plan, call request_plan_approval, "
+        "and wait for approval before running aggregate analysis or generating charts."
+    )
+
+
+def _looks_like_preview_query(query: str) -> bool:
+    if _query_looks_aggregated(query):
+        return False
+    limit_match = re.search(r"\blimit\s+(\d+)\b", query, re.IGNORECASE)
+    if limit_match:
+        try:
+            return int(limit_match.group(1)) <= 50
+        except ValueError:
+            return False
+    return bool(re.search(r"\bselect\s+\*\s+from\b", query, re.IGNORECASE))
+
+
+def _extract_dashboard_dimension_signature(query: str) -> Optional[str]:
+    if not _query_looks_aggregated(query):
+        return None
+    lower = query.lower()
+    matched = [
+        field
+        for field in STRICT_DASHBOARD_DIMENSION_FIELDS
+        if re.search(rf"\b{re.escape(field)}\b", lower)
+    ]
+    if not matched:
+        return None
+    return "|".join(sorted(set(matched)))
 
 
 def _json_safe_chart_value(value: Any) -> Any:
@@ -715,6 +796,34 @@ def _resolve_workspace_html_path(
     return resolved
 
 
+def _resolve_workspace_dashboard_dir(
+    workspace_root: Path,
+    output_path: str,
+    *,
+    default_dir: str,
+    default_stem: str,
+) -> Path:
+    raw = (output_path or "").strip()
+    if not raw:
+        raw = f"{default_dir}/{default_stem}"
+    elif raw.endswith("/"):
+        raw = raw.rstrip("/")
+    else:
+        candidate = Path(raw)
+        suffix = candidate.suffix.lower()
+        if suffix in {".html", ".htm"}:
+            raw = str(candidate.with_suffix(""))
+
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        candidate = Path(str(candidate).lstrip("/"))
+    resolved = (workspace_root / candidate).resolve()
+    root_resolved = workspace_root.resolve()
+    if root_resolved not in resolved.parents and resolved != root_resolved:
+        raise ValueError("output_path must remain inside the workspace.")
+    return resolved
+
+
 def _resolve_workspace_data_path(workspace_root: Path, raw_path: str) -> Path:
     candidate = Path((raw_path or "").strip())
     if not str(candidate):
@@ -793,6 +902,39 @@ def _load_dashboard_dataset(workspace_root: Path, dataset_path: str) -> Tuple[Li
     return records, schema, format_name
 
 
+def _build_dataset_reference(workspace_root: Path, dataset_path: str) -> Dict[str, Any]:
+    cleaned = _coerce_text_arg(dataset_path).strip()
+    if not cleaned:
+        return {}
+    resolved = _resolve_workspace_data_path(workspace_root, cleaned)
+    if not resolved.exists():
+        return {"path": cleaned}
+    stat = resolved.stat()
+    return {
+        "path": _workspace_rel(resolved, workspace_root),
+        "format": resolved.suffix.lower().lstrip("."),
+        "size": stat.st_size,
+        "updatedAt": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+        "version": f"{int(stat.st_mtime)}-{stat.st_size}",
+    }
+
+
+def _build_dashboard_dataset_block(
+    workspace_root: Path,
+    dashboard_dataset_path: str,
+    dataset_records: List[Dict[str, Any]],
+    preview_rel_path: str,
+) -> Dict[str, Any]:
+    """Canonical dataset path plus browser-friendly preview rows (v1 JSON)."""
+    base = _build_dataset_reference(workspace_root, dashboard_dataset_path)
+    if not dataset_records:
+        return base
+    block = dict(base)
+    block["previewPath"] = preview_rel_path
+    block["rowCount"] = len(dataset_records)
+    return block
+
+
 def _normalize_filter_schema(raw_filters: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
     normalized: List[Dict[str, Any]] = []
     for idx, raw in enumerate(raw_filters or [], start=1):
@@ -832,7 +974,11 @@ def _normalize_chart_bindings(raw_bindings: Optional[List[Dict[str, Any]]]) -> D
             "chart_type": _coerce_text_arg(raw.get("chart_type"), "bar").strip().lower() or "bar",
             "x_field": _coerce_text_arg(raw.get("x_field")).strip(),
             "y_field": _coerce_text_arg(raw.get("y_field")).strip(),
+            "dimension_field": _coerce_text_arg(raw.get("dimension_field")).strip(),
+            "metric_field": _coerce_text_arg(raw.get("metric_field")).strip(),
             "aggregation": _coerce_text_arg(raw.get("aggregation"), "count").strip().lower() or "count",
+            "numerator_field": _coerce_text_arg(raw.get("numerator_field")).strip(),
+            "denominator_field": _coerce_text_arg(raw.get("denominator_field")).strip(),
             "series_field": _coerce_text_arg(raw.get("series_field")).strip(),
             "orientation": _coerce_text_arg(raw.get("orientation")).strip().lower(),
             "sort_by": _coerce_text_arg(raw.get("sort_by"), "y").strip().lower() or "y",
@@ -842,9 +988,194 @@ def _normalize_chart_bindings(raw_bindings: Optional[List[Dict[str, Any]]]) -> D
             "title": _coerce_text_arg(raw.get("title")).strip(),
             "x_title": _coerce_text_arg(raw.get("x_title")).strip(),
             "y_title": _coerce_text_arg(raw.get("y_title")).strip(),
+            "question_answered": _coerce_text_arg(raw.get("question_answered")).strip(),
+            "why_it_matters": _coerce_text_arg(raw.get("why_it_matters")).strip(),
+            "highlight_rule": _coerce_text_arg(raw.get("highlight_rule")).strip(),
+            "format": _coerce_text_arg(raw.get("format")).strip(),
+            "interactive": _coerce_bool_arg(raw.get("interactive"), True),
+            "layout_span": _coerce_text_arg(raw.get("layout_span"), "half").strip().lower() or "half",
+            "layout_section": _coerce_text_arg(raw.get("layout_section"), "drivers").strip().lower() or "drivers",
             "static_reason": _coerce_text_arg(raw.get("static_reason")).strip(),
         }
     return normalized
+
+
+def _schema_type_map(dataset_schema: List[Dict[str, Any]]) -> Dict[str, str]:
+    return {
+        str(item.get("name") or "").strip(): str(item.get("type") or "").strip().lower()
+        for item in dataset_schema
+        if str(item.get("name") or "").strip()
+    }
+
+
+def _is_numeric_schema_type(type_name: str) -> bool:
+    normalized = str(type_name or "").strip().lower()
+    return any(
+        token in normalized
+        for token in ("int", "float", "double", "decimal", "numeric", "real", "bigint", "smallint")
+    )
+
+
+def _build_dashboard_chart_specs(
+    normalized_bindings: Dict[int, Dict[str, Any]],
+    dataset_schema: List[Dict[str, Any]],
+) -> Dict[int, Dict[str, Any]]:
+    schema_types = _schema_type_map(dataset_schema)
+    normalized_specs: Dict[int, Dict[str, Any]] = {}
+    for chart_index, binding in normalized_bindings.items():
+        x_field = _coerce_text_arg(binding.get("x_field")).strip()
+        y_field = _coerce_text_arg(binding.get("y_field")).strip()
+        dimension_field = _coerce_text_arg(binding.get("dimension_field")).strip() or x_field
+        metric_field = _coerce_text_arg(binding.get("metric_field")).strip() or y_field
+        orientation = _coerce_text_arg(binding.get("orientation")).strip().lower()
+        numerator_field = _coerce_text_arg(binding.get("numerator_field")).strip()
+        denominator_field = _coerce_text_arg(binding.get("denominator_field")).strip()
+
+        if orientation == "h" and x_field and y_field:
+            x_is_numeric = _is_numeric_schema_type(schema_types.get(x_field, ""))
+            y_is_numeric = _is_numeric_schema_type(schema_types.get(y_field, ""))
+            if x_is_numeric and not y_is_numeric:
+                dimension_field = y_field
+                metric_field = x_field
+
+        aggregation = _coerce_text_arg(binding.get("aggregation"), "count").strip().lower() or "count"
+        if numerator_field and denominator_field and aggregation in {"avg", "mean"}:
+            aggregation = "ratio"
+
+        live_capable = bool(
+            dimension_field
+            and (
+                aggregation == "count"
+                or metric_field
+                or (numerator_field and denominator_field)
+            )
+        )
+        chart_id = _coerce_text_arg(binding.get("chart_id"), f"chart_{chart_index}").strip() or f"chart_{chart_index}"
+        normalized_specs[chart_index] = {
+            "chartId": chart_id,
+            "chartIndex": chart_index,
+            "chartType": _coerce_text_arg(binding.get("chart_type"), "bar").strip().lower() or "bar",
+            "dimensionField": dimension_field,
+            "metricField": metric_field,
+            "numeratorField": numerator_field,
+            "denominatorField": denominator_field,
+            "aggregation": aggregation,
+            "orientation": orientation,
+            "seriesField": _coerce_text_arg(binding.get("series_field")).strip(),
+            "sort": {
+                "by": _coerce_text_arg(binding.get("sort_by"), "y").strip().lower() or "y",
+                "direction": _coerce_text_arg(binding.get("sort_direction"), "desc").strip().lower() or "desc",
+            },
+            "limit": _coerce_int_arg(binding.get("limit"), 0, minimum=0),
+            "mode": _coerce_text_arg(binding.get("mode"), "lines+markers").strip(),
+            "labels": {
+                "title": _coerce_text_arg(binding.get("title")).strip(),
+                "x": _coerce_text_arg(binding.get("x_title")).strip(),
+                "y": _coerce_text_arg(binding.get("y_title")).strip(),
+            },
+            "questionAnswered": _coerce_text_arg(binding.get("question_answered")).strip(),
+            "whyItMatters": _coerce_text_arg(binding.get("why_it_matters")).strip(),
+            "highlightRule": _coerce_text_arg(binding.get("highlight_rule")).strip(),
+            "format": _coerce_text_arg(binding.get("format")).strip(),
+            "interactive": _coerce_bool_arg(binding.get("interactive"), True),
+            "layoutSpan": _coerce_text_arg(binding.get("layout_span"), "half").strip().lower() or "half",
+            "layoutSection": _coerce_text_arg(binding.get("layout_section"), "drivers").strip().lower() or "drivers",
+            "filters": list(binding.get("filters") or []),
+            "liveCapable": live_capable,
+            "snapshotOnly": not live_capable,
+            "staticReason": _coerce_text_arg(binding.get("static_reason")).strip(),
+        }
+    return normalized_specs
+
+
+_GENERIC_DASHBOARD_TITLE_TOKENS = {
+    "chart",
+    "overview",
+    "analysis",
+    "trends",
+    "breakdown",
+    "geographic trends",
+    "top categories",
+    "browser/device segmentation",
+    "country comparison",
+}
+
+
+def _looks_schema_like_title(value: str) -> bool:
+    normalized = re.sub(r"\s+", " ", _coerce_text_arg(value).strip().lower())
+    if not normalized:
+        return True
+    if normalized in _GENERIC_DASHBOARD_TITLE_TOKENS:
+        return True
+    return bool(re.fullmatch(r"[a-z0-9_ /-]+", normalized) and "_" in normalized)
+
+
+def _validate_dashboard_spec_inputs(
+    *,
+    strict_dashboard_mode: bool,
+    dashboard_dataset_path: str,
+    audience: str,
+    business_question: str,
+    decision_questions: List[str],
+    layout_template: str,
+    metric_cards: List[Dict[str, str]],
+    chart_specs: Dict[int, Dict[str, Any]],
+) -> Optional[str]:
+    if not chart_specs:
+        return (
+            "Dashboard package incomplete: no structured charts were provided. "
+            "Pass approved chart bindings so the live runtime has charts to render."
+        )
+    if not _coerce_text_arg(dashboard_dataset_path).strip():
+        return (
+            "Dashboard package incomplete: dashboard_dataset_path is required so the live runtime "
+            "and snapshot share the same canonical dataset."
+        )
+    if not strict_dashboard_mode:
+        return None
+    if not audience.strip():
+        return "Dashboard spec incomplete: audience is required for executive dashboard mode."
+    if not business_question.strip():
+        return "Dashboard spec incomplete: business_question is required for executive dashboard mode."
+    if not decision_questions:
+        return "Dashboard spec incomplete: provide at least one decision question for executive dashboard mode."
+    if not layout_template.strip():
+        return "Dashboard spec incomplete: layout_template is required for executive dashboard mode."
+    if not metric_cards or len(metric_cards) > 3:
+        return "Dashboard spec incomplete: provide 2 to 3 KPI cards for the executive hero."
+    if len(chart_specs) < STRICT_DASHBOARD_MIN_CHART_COUNT or len(chart_specs) > MAX_CHART_COUNT:
+        return (
+            f"Dashboard spec incomplete: provide {STRICT_DASHBOARD_MIN_CHART_COUNT} to {MAX_CHART_COUNT} "
+            "structured charts for executive dashboard mode."
+        )
+    for chart_spec in chart_specs.values():
+        title = _coerce_text_arg((chart_spec.get("labels") or {}).get("title"))
+        if _looks_schema_like_title(title):
+            return (
+                "Dashboard spec validation failed: chart titles must be business-readable and insight-led, "
+                f"not generic placeholders ('{title or 'untitled'}')."
+            )
+        if not _coerce_text_arg(chart_spec.get("questionAnswered")).strip():
+            return f"Dashboard spec validation failed: {title} is missing questionAnswered."
+        if not _coerce_text_arg(chart_spec.get("whyItMatters")).strip():
+            return f"Dashboard spec validation failed: {title} is missing whyItMatters."
+    return None
+
+
+def _emit_dashboard_artifact(
+    callbacks: Optional[CallbackManagerForToolRun],
+    payload: Dict[str, Any],
+) -> None:
+    if not callbacks or not payload:
+        return
+    try:
+        run_id = getattr(callbacks, "run_id", None)
+        if run_id is not None:
+            callbacks.on_custom_event("dashboard_artifact", payload, run_id=run_id)
+        else:
+            callbacks.on_custom_event("dashboard_artifact", payload)
+    except Exception:  # pragma: no cover - best effort
+        logger.warning("Failed to dispatch dashboard_artifact event", exc_info=True)
 
 
 def _cache_key_for_query(sql_query: str, workspace_id: str, cache_key_hint: str) -> str:
@@ -893,6 +1224,10 @@ class DuckDBManager:
     def __init__(self, workspace_state: WorkspaceState):
         self.workspace_state = workspace_state
         self.con = duckdb.connect(database=":memory:")
+        # The agent can emit multiple local SQL tool calls in one model step. DuckDB's
+        # Python connection is not safe for overlapping use, so serialize all access
+        # through a per-manager lock to avoid orphaned/stuck runs.
+        self._con_lock = threading.RLock()
         self.session = DataAgentSessionState()
         self._registered_tables: Set[str] = set()
         self._register_files()
@@ -904,78 +1239,89 @@ class DuckDBManager:
 
     def _register_files(self):
         """Scans workspace for CSV and Parquet files and registers them as tables."""
-        self._registered_tables.clear()
-        root = self.workspace_state.root_path
-        preferred_dirs = tuple(
-            dirname
-            for dirname in DATA_DISCOVERY_DIR_CANDIDATES
-            if (root / dirname).exists()
-        )
-        data_files = _iter_workspace_files(
-            root,
-            allowed_extensions=DATA_FILE_EXTENSIONS,
-            preferred_dirs=preferred_dirs,
-        )
-        used_names: Set[str] = set()
-        for file_path in sorted(data_files):
-            relative_stem = file_path.relative_to(root).with_suffix("").as_posix()
-            base_name = re.sub(r"[^a-zA-Z0-9_]", "_", file_path.stem)
-            path_name = re.sub(r"[^a-zA-Z0-9_]", "_", relative_stem)
-            ext_name = f"{base_name}_{file_path.suffix.lstrip('.').lower()}"
-            table_name = base_name
-            if table_name in used_names:
-                table_name = path_name or ext_name
-            if table_name in used_names:
-                table_name = ext_name
-            safe_path = file_path.as_posix().replace("'", "''")
-            try:
-                if file_path.suffix.lower() == ".csv":
-                    self.con.execute(
-                        f"CREATE OR REPLACE TABLE {table_name} "
-                        f"AS SELECT * FROM read_csv_auto('{safe_path}')"
-                    )
-                else:
-                    self.con.execute(
-                        f"CREATE OR REPLACE TABLE {table_name} "
-                        f"AS SELECT * FROM read_parquet('{safe_path}')"
-                    )
-                used_names.add(table_name)
-                self._registered_tables.add(table_name)
-                logger.info("Registered table %s from %s", table_name, file_path)
-            except Exception as exc:
-                logger.error("Failed to register %s: %s", file_path, exc)
+        with self._con_lock:
+            self._registered_tables.clear()
+            root = self.workspace_state.root_path
+            preferred_dirs = tuple(
+                dirname
+                for dirname in DATA_DISCOVERY_DIR_CANDIDATES
+                if (root / dirname).exists()
+            )
+            data_files = _iter_workspace_files(
+                root,
+                allowed_extensions=DATA_FILE_EXTENSIONS,
+                preferred_dirs=preferred_dirs,
+            )
+            used_names: Set[str] = set()
+            for file_path in sorted(data_files):
+                relative_stem = file_path.relative_to(root).with_suffix("").as_posix()
+                base_name = re.sub(r"[^a-zA-Z0-9_]", "_", file_path.stem)
+                path_name = re.sub(r"[^a-zA-Z0-9_]", "_", relative_stem)
+                ext_name = f"{base_name}_{file_path.suffix.lstrip('.').lower()}"
+                table_name = base_name
+                if table_name in used_names:
+                    table_name = path_name or ext_name
+                if table_name in used_names:
+                    table_name = ext_name
+                safe_path = file_path.as_posix().replace("'", "''")
+                try:
+                    if file_path.suffix.lower() == ".csv":
+                        self.con.execute(
+                            f"CREATE OR REPLACE TABLE {table_name} "
+                            f"AS SELECT * FROM read_csv_auto('{safe_path}')"
+                        )
+                    else:
+                        self.con.execute(
+                            f"CREATE OR REPLACE TABLE {table_name} "
+                            f"AS SELECT * FROM read_parquet('{safe_path}')"
+                        )
+                    used_names.add(table_name)
+                    self._registered_tables.add(table_name)
+                    logger.info("Registered table %s from %s", table_name, file_path)
+                except Exception as exc:
+                    logger.error("Failed to register %s: %s", file_path, exc)
 
     def get_schema(self, table_names: Optional[List[str]] = None) -> str:
-        tables = self.con.execute("SHOW TABLES").fetchall()
-        if not tables:
-            return "No tables found in the workspace."
-
-        schema_lines: List[str] = []
-        for table in tables:
-            table_name = table[0]
-            if table_names and table_name not in table_names:
-                continue
-
-            schema_lines.append(f"Table: {table_name}")
-            columns = self.con.execute(f"DESCRIBE {table_name}").fetchall()
-            sample_rows = self.con.execute(f"SELECT * FROM {table_name} LIMIT 3").df()
-            for col in columns:
-                sample_values: List[str] = []
-                if not sample_rows.empty and col[0] in sample_rows.columns:
-                    non_null = sample_rows[col[0]].dropna().tolist()
-                    for value in non_null:
-                        formatted = _format_sample_value(value)
-                        if formatted not in sample_values:
-                            sample_values.append(formatted)
-                        if len(sample_values) == 2:
-                            break
-                sample_suffix = (
-                    f" [examples: {', '.join(sample_values)}]" if sample_values else ""
+        if _is_strict_dashboard_mode(self.workspace_state):
+            if self.session.last_schema_result is not None and self.session.schema_read_count >= STRICT_DASHBOARD_SCHEMA_COUNT:
+                return (
+                    "Dashboard planning mode reuses the existing schema snapshot to avoid duplicated discovery.\n\n"
+                    f"{self.session.last_schema_result}"
                 )
-                schema_lines.append(f"  - {col[0]} ({col[1]}){sample_suffix}")
-            schema_lines.append("")
+        with self._con_lock:
+            tables = self.con.execute("SHOW TABLES").fetchall()
+            if not tables:
+                return "No tables found in the workspace."
 
-        return "\n".join(schema_lines).strip()
+            schema_lines: List[str] = []
+            for table in tables:
+                table_name = table[0]
+                if table_names and table_name not in table_names:
+                    continue
+
+                schema_lines.append(f"Table: {table_name}")
+                columns = self.con.execute(f"DESCRIBE {table_name}").fetchall()
+                sample_rows = self.con.execute(f"SELECT * FROM {table_name} LIMIT 3").df()
+                for col in columns:
+                    sample_values: List[str] = []
+                    if not sample_rows.empty and col[0] in sample_rows.columns:
+                        non_null = sample_rows[col[0]].dropna().tolist()
+                        for value in non_null:
+                            formatted = _format_sample_value(value)
+                            if formatted not in sample_values:
+                                sample_values.append(formatted)
+                            if len(sample_values) == 2:
+                                break
+                    sample_suffix = (
+                        f" [examples: {', '.join(sample_values)}]" if sample_values else ""
+                    )
+                    schema_lines.append(f"  - {col[0]} ({col[1]}){sample_suffix}")
+                schema_lines.append("")
+
+            rendered = "\n".join(schema_lines).strip()
+            self.session.schema_read_count += 1
+            self.session.last_schema_result = rendered
+            return rendered
 
     def run_query(
         self,
@@ -984,24 +1330,31 @@ class DuckDBManager:
         record_sql: Optional[str] = None,
         truncated: bool = False,
     ) -> pd.DataFrame:
-        if self.session.query_count >= MAX_QUERY_COUNT:
-            raise ValueError(
-                f"Query budget exhausted: at most {MAX_QUERY_COUNT} queries are allowed per run."
+        with self._con_lock:
+            strict_dashboard_mode = _is_strict_dashboard_mode(self.workspace_state)
+            max_query_count = STRICT_DASHBOARD_QUERY_COUNT if strict_dashboard_mode else MAX_QUERY_COUNT
+            if self.session.query_count >= max_query_count:
+                raise ValueError(
+                    f"Query budget exhausted: at most {max_query_count} queries are allowed per run."
+                )
+            df = self.con.execute(query).df()
+            self.session.query_count += 1
+            self.session.last_query_result = df
+            stored_sql = record_sql or query
+            self.session.last_query_sql = stored_sql
+            if strict_dashboard_mode:
+                signature = _extract_dashboard_dimension_signature(stored_sql)
+                if signature:
+                    self.session.dashboard_dimension_signatures.add(signature)
+            self.session.query_history.append(
+                _QueryRecord(
+                    sql=stored_sql,
+                    row_count=len(df),
+                    preview=df.head(MAX_RESULT_ROWS).copy(),
+                    truncated=truncated,
+                )
             )
-        df = self.con.execute(query).df()
-        self.session.query_count += 1
-        self.session.last_query_result = df
-        stored_sql = record_sql or query
-        self.session.last_query_sql = stored_sql
-        self.session.query_history.append(
-            _QueryRecord(
-                sql=stored_sql,
-                row_count=len(df),
-                preview=df.head(MAX_RESULT_ROWS).copy(),
-                truncated=truncated,
-            )
-        )
-        return df
+            return df
 
     def record_chart(self, title: str, artifact_paths: List[str]) -> None:
         self.session.chart_count += 1
@@ -1155,6 +1508,25 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
             cleaned_query = sql_query.strip()
             if cleaned_query.endswith(";"):
                 cleaned_query = cleaned_query[:-1].rstrip()
+            strict_dashboard_mode = _is_strict_dashboard_mode(workspace_state)
+            if strict_dashboard_mode and not _is_plan_approved(workspace_state):
+                if db_manager.session.query_count >= STRICT_DASHBOARD_PREVIEW_QUERY_COUNT:
+                    return (
+                        f"{_dashboard_plan_gate_message()} Only {STRICT_DASHBOARD_PREVIEW_QUERY_COUNT} preview query "
+                        "is allowed before approval."
+                    )
+                if not _looks_like_preview_query(cleaned_query):
+                    return (
+                        f"{_dashboard_plan_gate_message()} Before approval, only one lightweight preview query "
+                        "with a small LIMIT is allowed."
+                    )
+            if strict_dashboard_mode and _is_plan_approved(workspace_state):
+                signature = _extract_dashboard_dimension_signature(cleaned_query)
+                if signature and signature in db_manager.session.dashboard_dimension_signatures:
+                    return (
+                        "Duplicate dashboard dimension pass blocked. Reuse the existing aggregate for this dimension "
+                        "or update the approved plan before querying it again."
+                    )
             cleaned_query = _rewrite_virtual_paths(
                 cleaned_query, db_manager.workspace_state.root_path
             )
@@ -1220,6 +1592,13 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
         blocked = tagged_files_mode_guard(workspace_state.context, "cache_bigquery_query")
         if blocked:
             return blocked
+        if workspace_state.context.get("tagged_files_only"):
+            return "Tool disabled: tagged files were provided, use rag_query only."
+        if _is_strict_dashboard_mode(workspace_state):
+            return (
+                "Dashboard planning mode is bound to tagged local datasets. "
+                "Skip warehouse rediscovery and use the tagged parquet/csv as the source of truth."
+            )
 
         normalized_sql = _coerce_text_arg(sql_query).strip().rstrip(";")
         if not normalized_sql:
@@ -1447,6 +1826,13 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
         callbacks: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Generate visualizations from the last SQL query result."""
+        if _is_strict_dashboard_mode(workspace_state) and not _is_plan_approved(workspace_state):
+            return _dashboard_plan_gate_message()
+        if _is_strict_dashboard_mode(workspace_state):
+            return (
+                "Dashboard mode uses structured chart specs instead of generated chart code. "
+                "Skip generate_chart_config and pass the approved chart bindings directly to generate_dashboard."
+            )
         try:
             db_manager.require_query_before_chart()
             db_manager.require_chart_budget()
@@ -1555,6 +1941,11 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
         callbacks: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Produce a summary of the results and save it as a self-contained HTML report."""
+        if str(workspace_state.context.get("active_skill") or "").strip() == "data/dashboard":
+            return (
+                "The active skill is data/dashboard. Stay on the dashboard path: request plan approval, "
+                "generate the approved charts, then call generate_dashboard."
+            )
         if db_manager.session.query_count == 0:
             return "Run at least one SQL query before summarizing the findings."
         try:
@@ -1733,13 +2124,49 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
             str,
             Field(description="Short paragraph describing what this dashboard shows and who it's for"),
         ],
+        audience: Annotated[
+            str,
+            Field(description="Primary audience for this dashboard, such as Ops leadership or the Board."),
+        ] = "",
+        business_question: Annotated[
+            str,
+            Field(description="The core business question this dashboard answers."),
+        ] = "",
+        decision_questions: Annotated[
+            Optional[List[str]],
+            Field(description="Ordered list of the decisions or questions the dashboard should help answer."),
+        ] = None,
+        layout_template: Annotated[
+            str,
+            Field(description="Named layout template to use for the dashboard, such as executive_driver_dashboard."),
+        ] = "executive_driver_dashboard",
+        hero_eyebrow: Annotated[
+            str,
+            Field(description="Optional short eyebrow label displayed above the dashboard title."),
+        ] = "Interactive Dashboard",
+        headline_takeaway: Annotated[
+            str,
+            Field(description="Optional one-line headline takeaway shown in the hero section."),
+        ] = "",
+        insights: Annotated[
+            Optional[List[str]],
+            Field(description="Optional list of executive takeaways rendered near the top of the dashboard."),
+        ] = None,
+        known_risks: Annotated[
+            Optional[List[str]],
+            Field(description="Optional list of known dashboard caveats or risks."),
+        ] = None,
+        data_quality_notes: Annotated[
+            Optional[List[str]],
+            Field(description="Optional list of data quality or normalization notes."),
+        ] = None,
         section_titles: Annotated[
             Optional[List[str]],
             Field(description="Optional ordered list of section headings, one per chart produced in this run."),
         ] = None,
         output_path: Annotated[
             str,
-            Field(description="Optional stable HTML output path such as dashboards/orders_overview.html."),
+            Field(description="Optional stable dashboard package path such as dashboards/orders_overview or dashboards/orders_overview/."),
         ] = "",
         dashboard_dataset_path: Annotated[
             str,
@@ -1768,29 +2195,62 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
                 )
             ),
         ] = None,
+        metric_cards: Annotated[
+            Optional[List[Dict[str, Any]]],
+            Field(
+                description=(
+                    "Optional KPI cards for the hero section. Each item may include label, value, and meta."
+                )
+            ),
+        ] = None,
         callbacks: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Assemble all charts and query history from the current run into one HTML dashboard."""
+        if _is_strict_dashboard_mode(workspace_state) and not _is_plan_approved(workspace_state):
+            return _dashboard_plan_gate_message()
         try:
             db_manager.ensure_single_dashboard()
         except ValueError as exc:
             return str(exc)
         if db_manager.session.query_count == 0:
             return "Run at least one SQL query before building a dashboard."
-        if not db_manager.session.chart_history:
+        strict_dashboard_mode = _is_strict_dashboard_mode(workspace_state)
+        normalized_bindings = _normalize_chart_bindings(chart_bindings)
+        if strict_dashboard_mode and len(normalized_bindings) < STRICT_DASHBOARD_MIN_CHART_COUNT:
+            return (
+                "Dashboard plan incomplete: pass 3 to 5 approved chart bindings to generate_dashboard "
+                "before building the dashboard package."
+            )
+        if strict_dashboard_mode and not _coerce_text_arg(dashboard_dataset_path).strip():
+            return "Dashboard mode requires dashboard_dataset_path so the native renderer and HTML export share the same dataset."
+        if not strict_dashboard_mode and not db_manager.session.chart_history:
             return "Generate at least one chart before building a dashboard."
+        if strict_dashboard_mode and len(normalized_bindings) > MAX_CHART_COUNT:
+            return (
+                f"Dashboard plan too large: at most {MAX_CHART_COUNT} approved charts are allowed per dashboard package."
+            )
 
         stable_title = _safe_slug(title, "dashboard")
-        dashboard_path = _resolve_workspace_html_path(
+        dashboard_dir = _resolve_workspace_dashboard_dir(
             workspace_state.root_path,
             output_path,
             default_dir="dashboards",
             default_stem=stable_title,
         )
+        dashboard_rel_path = _workspace_rel(dashboard_dir, workspace_state.root_path)
+        dashboard_meta_path = dashboard_dir / "dashboard.meta.json"
+        dashboard_spec_path = dashboard_dir / "dashboard.spec.json"
+        dashboard_snapshot_path = dashboard_dir / "dashboard.snapshot.html"
+        dashboard_meta_rel_path = _workspace_rel(dashboard_meta_path, workspace_state.root_path)
+        dashboard_spec_rel_path = _workspace_rel(dashboard_spec_path, workspace_state.root_path)
+        dashboard_snapshot_rel_path = _workspace_rel(dashboard_snapshot_path, workspace_state.root_path)
+        dashboard_data_dir = dashboard_dir / "data"
+        dashboard_rows_path = dashboard_data_dir / "dashboard.rows.json"
+        dashboard_rows_rel_path = _workspace_rel(dashboard_rows_path, workspace_state.root_path)
 
         chart_entries: List[Dict[str, Any]] = []
+        chart_entries_by_index: Dict[int, Dict[str, Any]] = {}
         chosen_titles = list(section_titles or [])
-        normalized_bindings = _normalize_chart_bindings(chart_bindings)
 
         for chart_index, chart_record in enumerate(db_manager.session.chart_history, start=1):
             preferred_path: Optional[Path] = None
@@ -1818,7 +2278,7 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
                 else chart_record.title
                 or _chart_title_from_path(preferred_path)
             )
-            chart_entries.append(
+            chart_entry = (
                 {
                     "chart_index": chart_index,
                     "title": section_title,
@@ -1827,6 +2287,8 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
                     "binding": normalized_bindings.get(chart_index),
                 }
             )
+            chart_entries.append(chart_entry)
+            chart_entries_by_index[chart_index] = chart_entry
 
         filter_config = _normalize_filter_schema(filter_schema)
         dataset_records: List[Dict[str, Any]] = []
@@ -1839,57 +2301,130 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
                 dashboard_dataset_path,
             )
             data_filtering_enabled = bool(dataset_records and filter_config)
+        if strict_dashboard_mode and not dataset_records:
+            return (
+                "Dashboard mode could not load the canonical dataset. "
+                "Confirm dashboard_dataset_path points to a valid workspace CSV, Parquet, or JSON artifact."
+            )
+
+        normalized_chart_specs = _build_dashboard_chart_specs(normalized_bindings, dataset_schema)
+        normalized_decision_questions = [
+            _coerce_text_arg(item).strip() for item in (decision_questions or []) if _coerce_text_arg(item).strip()
+        ]
+        normalized_insights = [
+            _coerce_text_arg(item).strip() for item in (insights or []) if _coerce_text_arg(item).strip()
+        ]
+        normalized_known_risks = [
+            _coerce_text_arg(item).strip() for item in (known_risks or []) if _coerce_text_arg(item).strip()
+        ]
+        normalized_data_quality_notes = [
+            _coerce_text_arg(item).strip() for item in (data_quality_notes or []) if _coerce_text_arg(item).strip()
+        ]
+        workspace_id = _coerce_text_arg(getattr(workspace_state, "workspace_id", "")).strip() or "workspace"
+        dashboard_id = uuid4().hex
+        dashboard_meta: Dict[str, Any] = {
+            "dashboardId": dashboard_id,
+            "slug": stable_title,
+            "title": title,
+            "specVersion": 2,
+            "runtimeKind": "native",
+            "createdAt": _utc_now().isoformat(),
+            "updatedAt": _utc_now().isoformat(),
+            "status": "generating",
+            "snapshotPath": dashboard_snapshot_rel_path,
+            "specPath": dashboard_spec_rel_path,
+            "metaPath": dashboard_meta_rel_path,
+            "datasetRef": _build_dataset_reference(workspace_state.root_path, dashboard_dataset_path),
+        }
+        dashboard_dir.mkdir(parents=True, exist_ok=True)
+        dashboard_meta_path.write_text(_json_dump(dashboard_meta), encoding="utf-8")
+        _emit_dashboard_artifact(
+            callbacks,
+            {
+                "dashboardPath": dashboard_rel_path,
+                "workspaceId": workspace_id,
+                "dashboardId": dashboard_id,
+                "title": title,
+                "status": "generating",
+            },
+        )
 
         bound_cards: List[str] = []
         static_cards: List[str] = []
         chart_runtime_defs: List[Dict[str, Any]] = []
+        normalized_dashboard_charts: List[Dict[str, Any]] = []
+        dataset_backed_charts_enabled = bool(dataset_records)
+        approved_chart_count = max(len(normalized_chart_specs), len(chart_entries))
 
-        for entry in chart_entries:
-            chart_index = entry["chart_index"]
-            section_title = entry["title"]
-            chart_path = entry["path"]
-            chart_kind = entry["kind"]
-            binding = entry.get("binding") or {}
-            binding_is_compatible = bool(
-                data_filtering_enabled
-                and binding
-                and binding.get("x_field")
-                and (binding.get("aggregation") == "count" or binding.get("y_field"))
+        for chart_index in range(1, approved_chart_count + 1):
+            entry = chart_entries_by_index.get(chart_index)
+            chart_spec = normalized_chart_specs.get(chart_index) or {}
+            binding = normalized_bindings.get(chart_index) or {}
+            section_title = (
+                _coerce_text_arg((chart_spec.get("labels") or {}).get("title"))
+                or _coerce_text_arg(binding.get("title"))
+                or (entry or {}).get("title")
+                or (chosen_titles[chart_index - 1] if chart_index - 1 < len(chosen_titles) else "")
+                or f"Chart {chart_index}"
             )
 
+            if chart_spec:
+                normalized_dashboard_charts.append(
+                    {
+                        **chart_spec,
+                        "title": section_title,
+                    }
+                )
+
+            binding_is_compatible = bool(
+                dataset_backed_charts_enabled
+                and chart_spec
+                and chart_spec.get("liveCapable")
+            )
             if binding_is_compatible:
                 div_id = f"dashboard-chart-{chart_index}"
                 chart_runtime_defs.append(
                     {
+                        "chartId": chart_spec.get("chartId") or f"chart_{chart_index}",
                         "chartIndex": chart_index,
                         "divId": div_id,
                         "title": section_title,
-                        "chartType": binding.get("chart_type") or "bar",
-                        "xField": binding.get("x_field"),
-                        "yField": binding.get("y_field"),
-                        "aggregation": binding.get("aggregation") or "count",
-                        "seriesField": binding.get("series_field") or "",
-                        "orientation": binding.get("orientation") or "",
-                        "sortBy": binding.get("sort_by") or "y",
-                        "sortDirection": binding.get("sort_direction") or "desc",
-                        "limit": binding.get("limit") or 0,
-                        "mode": binding.get("mode") or "lines+markers",
-                        "xTitle": binding.get("x_title") or "",
-                        "yTitle": binding.get("y_title") or "",
+                        "chartType": chart_spec.get("chartType") or "bar",
+                        "dimensionField": chart_spec.get("dimensionField") or "",
+                        "metricField": chart_spec.get("metricField") or "",
+                        "numeratorField": chart_spec.get("numeratorField") or "",
+                        "denominatorField": chart_spec.get("denominatorField") or "",
+                        "xField": chart_spec.get("dimensionField") or "",
+                        "yField": chart_spec.get("metricField") or "",
+                        "aggregation": chart_spec.get("aggregation") or "count",
+                        "seriesField": chart_spec.get("seriesField") or "",
+                        "orientation": chart_spec.get("orientation") or "",
+                        "sortBy": ((chart_spec.get("sort") or {}).get("by")) or "y",
+                        "sortDirection": ((chart_spec.get("sort") or {}).get("direction")) or "desc",
+                        "limit": chart_spec.get("limit") or 0,
+                        "mode": chart_spec.get("mode") or "lines+markers",
+                        "xTitle": ((chart_spec.get("labels") or {}).get("x")) or "",
+                        "yTitle": ((chart_spec.get("labels") or {}).get("y")) or "",
                     }
                 )
+                chart_descriptor = "Filter-aware chart bound to the canonical dashboard dataset" if data_filtering_enabled else "Interactive chart bound to the canonical dashboard dataset"
                 bound_cards.append(
                     f"<article class=\"chart-card filter-aware\" data-chart-index=\"{chart_index}\">"
                     f"<h3>{html.escape(section_title)}</h3>"
-                    f"<p class=\"chart-meta\">Filter-aware chart bound to the canonical dashboard dataset</p>"
+                    f"<p class=\"chart-meta\">{html.escape(chart_descriptor)}</p>"
                     f"<div id=\"{div_id}\" class=\"plotly-embed\"></div>"
                     f"<p class=\"chart-note\" id=\"{div_id}-status\"></p>"
                     f"</article>"
                 )
                 continue
 
+            if not entry:
+                continue
+
+            chart_path = entry["path"]
+            chart_kind = entry["kind"]
             static_reason = (
-                _coerce_text_arg(binding.get("static_reason"))
+                _coerce_text_arg(chart_spec.get("staticReason") or binding.get("static_reason"))
                 or "Static appendix artifact because this chart is not bound to the dashboard dataset."
             )
             try:
@@ -1949,28 +2484,62 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
             f"Charts embedded: {len(bound_cards) + len(static_cards)} • "
             f"Queries embedded: {len(db_manager.session.query_history)}"
         )
-        dashboard_metric_cards = [
+        normalized_metric_cards: List[Dict[str, str]] = []
+        for raw_card in metric_cards or []:
+            if not isinstance(raw_card, dict):
+                continue
+            label = _coerce_text_arg(raw_card.get("label")).strip()
+            value = _coerce_text_arg(raw_card.get("value")).strip()
+            meta = _coerce_text_arg(raw_card.get("meta")).strip()
+            if not label or not value:
+                continue
+            normalized_metric_cards.append({"label": label, "value": value, "meta": meta})
+        dashboard_metric_cards = normalized_metric_cards[:3] if normalized_metric_cards else [
             {
-                "label": "Charts Embedded",
-                "value": str(len(bound_cards) + len(static_cards)),
-                "meta": "Across live and appendix sections",
+                "label": "Charts",
+                "value": str(len(chart_runtime_defs) or len(normalized_dashboard_charts)),
+                "meta": "Approved visuals in the dashboard package",
             },
             {
-                "label": "Filter-Aware",
-                "value": str(len(bound_cards)),
-                "meta": "Charts bound to the canonical dataset",
-            },
-            {
-                "label": "Static Appendix",
-                "value": str(len(static_cards)),
-                "meta": "Snapshot-only visual artifacts",
+                "label": "Shared Filters",
+                "value": str(len(filter_config)),
+                "meta": "Controls applied across the dashboard dataset",
             },
             {
                 "label": "Dataset Rows",
                 "value": str(len(dataset_records)) if dataset_records else "n/a",
-                "meta": "Browser-side filter dataset payload",
+                "meta": "Canonical dataset rows available to the native renderer",
             },
         ]
+        validation_error = _validate_dashboard_spec_inputs(
+            strict_dashboard_mode=strict_dashboard_mode,
+            dashboard_dataset_path=dashboard_dataset_path,
+            audience=audience,
+            business_question=business_question,
+            decision_questions=normalized_decision_questions,
+            layout_template=layout_template,
+            metric_cards=dashboard_metric_cards,
+            chart_specs=normalized_chart_specs,
+        )
+        if validation_error:
+            dashboard_meta.update(
+                {
+                    "updatedAt": _utc_now().isoformat(),
+                    "status": "error",
+                }
+            )
+            dashboard_meta_path.write_text(_json_dump(dashboard_meta), encoding="utf-8")
+            _emit_dashboard_artifact(
+                callbacks,
+                {
+                    "dashboardPath": dashboard_rel_path,
+                    "workspaceId": workspace_id,
+                    "dashboardId": dashboard_id,
+                    "title": title,
+                    "status": "error",
+                },
+            )
+            return validation_error
         filter_panel_html = ""
         if data_filtering_enabled:
             filter_panel_html = (
@@ -1991,36 +2560,172 @@ def build_data_agent_tools(workspace_state: WorkspaceState, source_tracker: Any 
                 "</div>"
                 "</details>"
             )
-        html_output = render_dashboard_html(
-            title=title,
-            description=description,
-            generated_at=generated_at,
-            hero_meta=hero_meta,
-            metric_cards=dashboard_metric_cards,
-            filter_panel_html=filter_panel_html,
-            primary_cards=bound_cards or static_cards,
-            appendix_cards=static_cards if bound_cards and static_cards else [],
-            query_items=query_items,
-            dataset_records=dataset_records,
-            filter_config=filter_config,
-            chart_runtime_defs=chart_runtime_defs,
-            dataset_schema=dataset_schema,
-            highlights_heading="Highlights" if bound_cards else "Charts",
+        try:
+            html_output = render_dashboard_html(
+                title=title,
+                description=description,
+                hero_eyebrow=hero_eyebrow,
+                audience=audience,
+                business_question=business_question,
+                headline_takeaway=headline_takeaway,
+                generated_at=generated_at,
+                hero_meta=hero_meta,
+                metric_cards=dashboard_metric_cards,
+                filter_panel_html=filter_panel_html,
+                primary_cards=bound_cards or static_cards,
+                appendix_cards=static_cards if bound_cards and static_cards else [],
+                query_items=query_items,
+                decision_questions=normalized_decision_questions,
+                insights=normalized_insights,
+                known_risks=normalized_known_risks,
+                data_quality_notes=normalized_data_quality_notes,
+                layout_template=layout_template,
+                dataset_records=dataset_records,
+                filter_config=filter_config,
+                chart_runtime_defs=chart_runtime_defs,
+                dataset_schema=dataset_schema,
+                highlights_heading="Decision Drivers" if bound_cards else "Charts",
+            )
+        except Exception:
+            dashboard_meta.update(
+                {
+                    "updatedAt": _utc_now().isoformat(),
+                    "status": "error",
+                }
+            )
+            try:
+                dashboard_meta_path.write_text(_json_dump(dashboard_meta), encoding="utf-8")
+            except Exception:
+                logger.warning("Failed to persist dashboard error manifest", exc_info=True)
+            _emit_dashboard_artifact(
+                callbacks,
+                {
+                    "dashboardPath": dashboard_rel_path,
+                    "workspaceId": workspace_id,
+                    "dashboardId": dashboard_id,
+                    "title": title,
+                    "status": "error",
+                },
+            )
+            raise
+        preview_rel_written = ""
+        if dataset_records:
+            dashboard_data_dir.mkdir(parents=True, exist_ok=True)
+            dashboard_rows_path.write_text(_json_dump({"rows": dataset_records}), encoding="utf-8")
+            preview_rel_written = dashboard_rows_rel_path
+        dataset_block = _build_dashboard_dataset_block(
+            workspace_state.root_path,
+            dashboard_dataset_path,
+            dataset_records,
+            preview_rel_written,
         )
+        dashboard_spec = {
+            "version": 2,
+            "dashboardId": dashboard_id,
+            "runtimeKind": "native",
+            "slug": stable_title,
+            "title": title,
+            "audience": audience,
+            "businessQuestion": business_question,
+            "decisionQuestions": normalized_decision_questions,
+            "description": description,
+            "generatedAt": generated_at,
+            "dashboardPath": dashboard_rel_path,
+            "snapshotPath": dashboard_snapshot_rel_path,
+            "specPath": dashboard_spec_rel_path,
+            "metaPath": dashboard_meta_rel_path,
+            "heroMeta": hero_meta,
+            "highlightsHeading": "Decision Drivers" if bound_cards else "Charts",
+            "hero": {
+                "eyebrow": hero_eyebrow,
+                "description": description,
+                "headlineTakeaway": headline_takeaway,
+                "kpis": dashboard_metric_cards,
+            },
+            "filters": filter_config,
+            "charts": normalized_dashboard_charts,
+            "chartRuntimeDefs": chart_runtime_defs,
+            "metricCards": dashboard_metric_cards,
+            "layout": {
+                "template": layout_template,
+                "gridColumns": 2,
+                "maxFirstScreenVisuals": 5,
+            },
+            "insights": normalized_insights,
+            "knownRisks": normalized_known_risks,
+            "dataQualityNotes": normalized_data_quality_notes,
+            "dataset": dataset_block,
+            "datasetRef": dataset_block,
+            "datasetSchema": dataset_schema,
+            "fallbackMode": "read_only_html",
+        }
 
         try:
-            dashboard_path.parent.mkdir(parents=True, exist_ok=True)
-            dashboard_path.write_text(html_output, encoding="utf-8")
+            dashboard_dir.mkdir(parents=True, exist_ok=True)
+            dashboard_spec_path.write_text(_json_dump(dashboard_spec), encoding="utf-8")
+            dashboard_snapshot_path.write_text(html_output, encoding="utf-8")
+            dashboard_meta.update(
+                {
+                    "updatedAt": _utc_now().isoformat(),
+                    "status": "ready",
+                    "runtimeKind": "native",
+                    "specVersion": 2,
+                    "datasetRef": dashboard_spec.get("dataset") or {},
+                }
+            )
+            dashboard_meta_path.write_text(_json_dump(dashboard_meta), encoding="utf-8")
             db_manager.mark_dashboard_generated()
-            artifact = {
-                "path": _workspace_rel(dashboard_path, workspace_state.root_path),
-                "mimeType": ALLOWED_ARTIFACT_EXTENSIONS[".html"],
-                "size": dashboard_path.stat().st_size,
-            }
-            db_manager.register_artifact(artifact)
-            _emit_artifacts(callbacks, [artifact])
-            return f"Dashboard saved to: {_workspace_rel(dashboard_path, workspace_state.root_path)}"
+            artifacts_out: List[Dict[str, Any]] = [
+                {
+                    "path": dashboard_snapshot_rel_path,
+                    "mimeType": ALLOWED_ARTIFACT_EXTENSIONS[".html"],
+                    "size": dashboard_snapshot_path.stat().st_size,
+                }
+            ]
+            if preview_rel_written:
+                artifacts_out.append(
+                    {
+                        "path": preview_rel_written,
+                        "mimeType": ALLOWED_ARTIFACT_EXTENSIONS[".json"],
+                        "size": dashboard_rows_path.stat().st_size,
+                    }
+                )
+            for art in artifacts_out:
+                db_manager.register_artifact(art)
+            _emit_artifacts(callbacks, artifacts_out)
+            _emit_dashboard_artifact(
+                callbacks,
+                {
+                    "dashboardPath": dashboard_rel_path,
+                    "workspaceId": workspace_id,
+                    "dashboardId": dashboard_id,
+                    "title": title,
+                    "status": "ready",
+                },
+            )
+            return f"Dashboard package saved to: {dashboard_rel_path}"
         except Exception as exc:  # pragma: no cover - defensive
+            dashboard_meta.update(
+                {
+                    "updatedAt": _utc_now().isoformat(),
+                    "status": "error",
+                }
+            )
+            try:
+                dashboard_dir.mkdir(parents=True, exist_ok=True)
+                dashboard_meta_path.write_text(_json_dump(dashboard_meta), encoding="utf-8")
+            except Exception:
+                logger.warning("Failed to persist dashboard error manifest", exc_info=True)
+            _emit_dashboard_artifact(
+                callbacks,
+                {
+                    "dashboardPath": dashboard_rel_path,
+                    "workspaceId": workspace_id,
+                    "dashboardId": dashboard_id,
+                    "title": title,
+                    "status": "error",
+                },
+            )
             logger.warning("Failed to save dashboard HTML: %s", exc)
             return f"Failed to save dashboard file: {exc}"
 

--- a/agent/helpudoc_agent/data_report_renderers.py
+++ b/agent/helpudoc_agent/data_report_renderers.py
@@ -106,6 +106,17 @@ SUMMARY_CSS = """
       padding: 18px;
       min-height: 132px;
     }
+    .section-copy {
+      margin: 6px 0 18px;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+    .decision-list {
+      margin: 0;
+      padding-left: 18px;
+      color: #455467;
+      line-height: 1.7;
+    }
     .metric-label {
       color: var(--muted);
       font-size: 0.8rem;
@@ -740,22 +751,44 @@ DASHBOARD_FILTER_SCRIPT = """
       }
 
       function aggregateRows(rows, chartDef) {
+        const dimensionField = chartDef.dimensionField || chartDef.xField;
+        const metricField = chartDef.metricField || chartDef.yField;
+        const numeratorField = chartDef.numeratorField || '';
+        const denominatorField = chartDef.denominatorField || '';
         const map = new Map();
         rows.forEach((row) => {
-          const xValue = row[chartDef.xField];
+          const xValue = dimensionField ? row[dimensionField] : '__all__';
           const seriesValue = chartDef.seriesField ? row[chartDef.seriesField] : '__single__';
           const key = JSON.stringify([xValue, seriesValue]);
           if (!map.has(key)) {
-            map.set(key, { x: xValue, series: seriesValue, count: 0, sum: 0, min: null, max: null, values: [] });
+            map.set(key, {
+              x: xValue,
+              series: seriesValue,
+              count: 0,
+              sum: 0,
+              min: null,
+              max: null,
+              values: [],
+              numeratorSum: 0,
+              denominatorSum: 0,
+            });
           }
           const bucket = map.get(key);
           bucket.count += 1;
-          const yRaw = chartDef.yField ? parseNumericValue(row[chartDef.yField]) : null;
+          const yRaw = metricField ? parseNumericValue(row[metricField]) : null;
+          const numeratorRaw = numeratorField ? parseNumericValue(row[numeratorField]) : null;
+          const denominatorRaw = denominatorField ? parseNumericValue(row[denominatorField]) : null;
           if (yRaw !== null) {
             bucket.sum += yRaw;
             bucket.min = bucket.min === null ? yRaw : Math.min(bucket.min, yRaw);
             bucket.max = bucket.max === null ? yRaw : Math.max(bucket.max, yRaw);
             bucket.values.push(yRaw);
+          }
+          if (numeratorRaw !== null) {
+            bucket.numeratorSum += numeratorRaw;
+          }
+          if (denominatorRaw !== null) {
+            bucket.denominatorSum += denominatorRaw;
           }
         });
 
@@ -779,6 +812,10 @@ DASHBOARD_FILTER_SCRIPT = """
             case 'count_distinct':
               yValue = new Set(bucket.values).size;
               break;
+            case 'ratio':
+            case 'rate':
+              yValue = bucket.denominatorSum ? bucket.numeratorSum / bucket.denominatorSum : 0;
+              break;
             case 'count':
             default:
               yValue = bucket.count;
@@ -800,6 +837,8 @@ DASHBOARD_FILTER_SCRIPT = """
       }
 
       function buildPlotlyPayload(rows, chartDef) {
+        const dimensionField = chartDef.dimensionField || chartDef.xField;
+        const metricField = chartDef.metricField || chartDef.yField;
         const grouped = aggregateRows(rows, chartDef);
         const seriesValues = chartDef.seriesField
           ? [...new Set(grouped.map((item) => item.series))]
@@ -844,8 +883,16 @@ DASHBOARD_FILTER_SCRIPT = """
             paper_bgcolor: 'rgba(0,0,0,0)',
             plot_bgcolor: 'rgba(0,0,0,0)',
             margin: { t: 56, r: 24, b: 56, l: 56 },
-            xaxis: chartDef.chartType === 'pie' ? undefined : { title: chartDef.xTitle || chartDef.xField },
-            yaxis: chartDef.chartType === 'pie' ? undefined : { title: chartDef.yTitle || chartDef.yField || chartDef.aggregation },
+            xaxis: chartDef.chartType === 'pie' ? undefined : {
+              title: chartDef.xTitle || (chartDef.chartType === 'bar' && chartDef.orientation === 'h'
+                ? metricField || chartDef.aggregation
+                : dimensionField),
+            },
+            yaxis: chartDef.chartType === 'pie' ? undefined : {
+              title: chartDef.yTitle || (chartDef.chartType === 'bar' && chartDef.orientation === 'h'
+                ? dimensionField
+                : metricField || chartDef.aggregation),
+            },
             legend: { orientation: 'h' },
           },
           config: { responsive: true, displayModeBar: false },
@@ -1022,6 +1069,10 @@ def render_dashboard_html(
     *,
     title: str,
     description: str,
+    hero_eyebrow: str,
+    audience: str,
+    business_question: str,
+    headline_takeaway: str,
     generated_at: str,
     hero_meta: str,
     metric_cards: List[Dict[str, str]],
@@ -1029,6 +1080,11 @@ def render_dashboard_html(
     primary_cards: List[str],
     appendix_cards: List[str],
     query_items: List[str],
+    decision_questions: List[str],
+    insights: List[str],
+    known_risks: List[str],
+    data_quality_notes: List[str],
+    layout_template: str,
     dataset_records: List[Dict[str, Any]],
     filter_config: List[Dict[str, Any]],
     chart_runtime_defs: List[Dict[str, Any]],
@@ -1051,6 +1107,33 @@ def render_dashboard_html(
         + "".join(query_items)
         + "</details>"
     )
+    insight_html = (
+        "<section class=\"panel\"><h2>Executive Takeaways</h2><div class=\"stack\">"
+        + "".join(f"<article class=\"stack-item\"><p>{html.escape(item)}</p></article>" for item in insights)
+        + "</div></section>"
+        if insights
+        else ""
+    )
+    decision_html = (
+        "<section class=\"panel\"><h2>Decision Questions</h2><ul class=\"decision-list\">"
+        + "".join(f"<li>{html.escape(item)}</li>" for item in decision_questions)
+        + "</ul></section>"
+        if decision_questions
+        else ""
+    )
+    note_sections = []
+    if known_risks:
+        note_sections.append(
+            "<details class=\"appendix\"><summary>Known Risks</summary><ul class=\"decision-list\">"
+            + "".join(f"<li>{html.escape(item)}</li>" for item in known_risks)
+            + "</ul></details>"
+        )
+    if data_quality_notes:
+        note_sections.append(
+            "<details class=\"appendix\"><summary>Data Quality Notes</summary><ul class=\"decision-list\">"
+            + "".join(f"<li>{html.escape(item)}</li>" for item in data_quality_notes)
+            + "</ul></details>"
+        )
     return "\n".join(
         [
             "<!doctype html>",
@@ -1067,20 +1150,35 @@ def render_dashboard_html(
             "<body>",
             "  <div class=\"shell\">",
             "    <section class=\"hero\">",
-            "      <div class=\"eyebrow\">Interactive Dashboard</div>",
+            f"      <div class=\"eyebrow\">{html.escape(hero_eyebrow or 'Interactive Dashboard')}</div>",
             f"      <h1>{html.escape(title)}</h1>",
             f"      <p>{html.escape(description)}</p>",
+            (
+                f"      <div class=\"hero-meta\"><strong>Audience:</strong> {html.escape(audience)}"
+                f" • <strong>Business question:</strong> {html.escape(business_question)}</div>"
+                if audience or business_question
+                else ""
+            ),
+            (
+                f"      <div class=\"hero-meta\"><strong>Headline takeaway:</strong> {html.escape(headline_takeaway)}</div>"
+                if headline_takeaway
+                else ""
+            ),
             f"      <div class=\"hero-meta\">Generated {html.escape(generated_at)} • {html.escape(hero_meta)}</div>",
-            _render_metric_cards(metric_cards, "Quick Pulse"),
+            _render_metric_cards(metric_cards, "Executive Snapshot"),
             "    </section>",
+            decision_html,
+            insight_html,
             filter_panel_html,
             "    <section class=\"section\">",
             f"      <h2>{html.escape(highlights_heading)}</h2>",
+            f"      <p class=\"section-copy\">Template: {html.escape(layout_template)} • First-screen visuals are intentionally limited for executive scanning.</p>",
             "      <div class=\"chart-grid\">",
             primary_cards_html,
             "      </div>",
             appendix_html,
             query_html,
+            *note_sections,
             "    </section>",
             "  </div>",
             "  <script>",

--- a/agent/tests/test_data_agent_tools.py
+++ b/agent/tests/test_data_agent_tools.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from helpudoc_agent.data_agent_tools import (
     DuckDBManager,
+    _build_dashboard_chart_specs,
     _format_sample_value,
     _snapshot_workspace,
     build_data_agent_tools,
@@ -251,6 +252,51 @@ class DataAgentToolsTest(unittest.TestCase):
             manager = workspace.context["data_agent_manager"]
             self.assertFalse(manager.session.chart_history)
 
+    def test_build_dashboard_chart_specs_swaps_horizontal_bar_dimension_and_metric(self) -> None:
+        bindings = {
+            1: {
+                "chart_index": 1,
+                "chart_type": "bar",
+                "x_field": "cancellation_rate",
+                "y_field": "country",
+                "orientation": "h",
+                "aggregation": "avg",
+            }
+        }
+        dataset_schema = [
+            {"name": "country", "type": "object"},
+            {"name": "cancellation_rate", "type": "float64"},
+        ]
+
+        specs = _build_dashboard_chart_specs(bindings, dataset_schema)
+
+        self.assertEqual(specs[1]["dimensionField"], "country")
+        self.assertEqual(specs[1]["metricField"], "cancellation_rate")
+        self.assertTrue(specs[1]["liveCapable"])
+
+    def test_build_dashboard_chart_specs_promotes_ratio_binding(self) -> None:
+        bindings = {
+            1: {
+                "chart_index": 1,
+                "chart_type": "bar",
+                "x_field": "country",
+                "aggregation": "avg",
+                "numerator_field": "cancelled_orders",
+                "denominator_field": "total_orders",
+            }
+        }
+        dataset_schema = [
+            {"name": "country", "type": "object"},
+            {"name": "cancelled_orders", "type": "int64"},
+            {"name": "total_orders", "type": "int64"},
+        ]
+
+        specs = _build_dashboard_chart_specs(bindings, dataset_schema)
+
+        self.assertEqual(specs[1]["aggregation"], "ratio")
+        self.assertEqual(specs[1]["numeratorField"], "cancelled_orders")
+        self.assertEqual(specs[1]["denominatorField"], "total_orders")
+
     def test_run_sql_query_caps_scalar_subquery_aggregate_results(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -279,6 +325,89 @@ class DataAgentToolsTest(unittest.TestCase):
             manager = workspace.context["data_agent_manager"]
             self.assertEqual(len(manager.session.last_query_result), 1000)
             self.assertTrue(manager.session.query_history[-1].truncated)
+
+    def test_generate_dashboard_writes_package_folder(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "datasets").mkdir()
+            (root / "datasets" / "orders.csv").write_text(
+                "country,cancelled_orders,total_orders,cancellation_rate\n"
+                "Spain,5,100,0.05\n"
+                "Japan,8,120,0.0667\n"
+                "Spain,4,80,0.05\n",
+                encoding="utf-8",
+            )
+            workspace = self._workspace(root)
+            tools = self._tool_map(workspace)
+
+            tools["get_table_schema"].invoke({"table_names": ["orders"]})
+            tools["run_sql_query"].invoke(
+                {
+                    "sql_query": (
+                        "SELECT country, cancelled_orders, total_orders, cancellation_rate "
+                        "FROM orders"
+                    )
+                }
+            )
+            tools["generate_chart_config"].invoke(
+                {
+                    "chart_title": "Cancellation_Rate",
+                    "python_code": (
+                        "chart_config = {\n"
+                        "  'data': [{'x': df['country'].tolist(), 'y': df['cancellation_rate'].tolist(), 'type': 'bar'}],\n"
+                        "  'layout': {'title': 'Cancellation rate'}\n"
+                        "}\n"
+                    ),
+                }
+            )
+
+            raw = tools["generate_dashboard"].invoke(
+                {
+                    "title": "Order Cancellations",
+                    "description": "Tracks cancellation risk by country.",
+                    "output_path": "dashboards/order_cancellations",
+                    "dashboard_dataset_path": "datasets/orders.csv",
+                    "filter_schema": [{"id": "country", "field": "country", "label": "Country"}],
+                    "chart_bindings": [
+                        {
+                            "chart_index": 1,
+                            "chart_type": "bar",
+                            "x_field": "country",
+                            "y_field": "cancellation_rate",
+                            "aggregation": "avg",
+                        }
+                    ],
+                }
+            )
+
+            self.assertIn("Dashboard package saved to: dashboards/order_cancellations", raw)
+
+            meta_path = root / "dashboards" / "order_cancellations" / "dashboard.meta.json"
+            spec_path = root / "dashboards" / "order_cancellations" / "dashboard.spec.json"
+            snapshot_path = root / "dashboards" / "order_cancellations" / "dashboard.snapshot.html"
+
+            self.assertTrue(meta_path.exists())
+            self.assertTrue(spec_path.exists())
+            self.assertTrue(snapshot_path.exists())
+
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            spec = json.loads(spec_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(meta["status"], "ready")
+            self.assertEqual(meta["runtimeKind"], "native")
+            self.assertEqual(meta["snapshotPath"], "dashboards/order_cancellations/dashboard.snapshot.html")
+            self.assertEqual(spec["dashboardPath"], "dashboards/order_cancellations")
+            self.assertEqual(spec["runtimeKind"], "native")
+            self.assertEqual(spec["dataset"]["path"], "datasets/orders.csv")
+            self.assertIn("previewPath", spec["dataset"])
+            self.assertTrue(spec["dataset"]["previewPath"].endswith("data/dashboard.rows.json"))
+            self.assertEqual(spec["fallbackMode"], "read_only_html")
+
+            rows_path = root / "dashboards" / "order_cancellations" / "data" / "dashboard.rows.json"
+            self.assertTrue(rows_path.exists())
+            rows_payload = json.loads(rows_path.read_text(encoding="utf-8"))
+            self.assertIn("rows", rows_payload)
+            self.assertGreater(len(rows_payload["rows"]), 0)
 
 
 if __name__ == "__main__":

--- a/backend/src/api/files.ts
+++ b/backend/src/api/files.ts
@@ -178,6 +178,32 @@ export default function(
     }
   });
 
+  router.get('/preview/raw', async (req: Request<{ workspaceId: string }>, res: Response) => {
+    try {
+      const { workspaceId } = req.params;
+      const user = requireUserContext(req);
+      const relativePath = req.query.path;
+      if (typeof relativePath !== 'string') {
+        return res.status(400).json({ error: 'Missing file path' });
+      }
+      const preview = await fileService.getWorkspaceFilePreview(workspaceId, relativePath, user.userId);
+      res.setHeader('Content-Type', preview.mimeType || 'application/octet-stream');
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      const lower = relativePath.toLowerCase();
+      if (lower.endsWith('.html') || lower.endsWith('.htm')) {
+        const baseName = relativePath.split(/[/\\]/).pop() || 'export.html';
+        res.setHeader('Content-Disposition', `attachment; filename="${baseName.replace(/"/g, '')}"`);
+      }
+      if (preview.encoding === 'base64') {
+        res.send(Buffer.from(preview.content, 'base64'));
+        return;
+      }
+      res.send(preview.content);
+    } catch (error) {
+      handleError(res, error, 'Failed to preview file');
+    }
+  });
+
   router.get('/:fileId/content', async (req: Request<{ fileId: string }>, res: Response) => {
     try {
       const { fileId } = req.params;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -24,7 +24,6 @@ import { userContextMiddleware } from './middleware/userContext';
 import { blockingRedisClient, redisClient } from './services/redisService';
 import { startCollabServer } from './collab/collabServer';
 import { logWorkspaceRootDiagnostic } from './config/workspaceRoot';
-
 const app = express();
 const port = process.env.PORT || 3000;
 

--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -154,9 +154,13 @@ flowchart TB
 - The frontend is a separate Kubernetes deployment and service.
 - Caddy is the runtime reverse proxy. It routes `/api` to the backend, `/helpudoc` to MinIO, and other paths to the frontend.
 - The backend and agent are co-located in the same `helpudoc-app` pod today. Backend-to-agent traffic uses `http://localhost:8001`.
+- The current dashboard runtime is a shared Streamlit runtime hosted inside the
+  agent image and proxied through the backend under `/api/dashboard/*`.
 - Delegated MCP auth is not a standalone service. The backend signs a short-lived context JWT for the agent and can embed per-server `mcpAuth` headers for delegated access.
 - Code execution is currently restricted in process for specific tools, not isolated in a dedicated sandbox enclave.
 - Langfuse should be shown as a planned observability sink until instrumentation is actually added to the backend and agent services.
+- For recent dashboard-runtime decisions, current gaps, and likely next steps,
+  see `docs/dashboard-runtime-status.md`.
 
 ## Repo Sources
 

--- a/docs/dashboard-runtime-status.md
+++ b/docs/dashboard-runtime-status.md
@@ -1,0 +1,318 @@
+# Dashboard Runtime Status
+
+This document captures the recent dashboard-runtime work for the `data/dashboard`
+skill: what we planned, what is currently implemented, the main problems we hit
+during QA, and the likely next changes.
+
+It is intentionally practical. The goal is to give product, engineering, and QA
+one shared view of the current dashboard state before more iteration.
+
+## Summary
+
+The dashboard effort moved through several phases:
+
+1. A workspace-native dashboard object model
+2. A live same-origin runtime with session restore and snapshot fallback
+3. Experiments with Dash- and Streamlit-backed sidecar runtimes (now retired for
+   the main product path)
+4. **Current:** a **durable dashboard package** rendered **natively in the
+   frontend** (React + Plotly), driven by a **shared TypeScript engine** and
+   **`chartRuntimeDefs`** in `dashboard.spec.json`, with browser-friendly rows in
+   `data/dashboard.rows.json`. The agent streams **`dashboard_artifact`** (not a
+   dashboard session); there is **no Streamlit proxy, no backend session TTL, and
+   no sidecar** on the critical path.
+
+The user-facing model:
+
+- users invoke `/skill data/dashboard`
+- a dashboard appears as one folder object under `dashboards/`
+- the canvas loads the package from the workspace (spec, rows, snapshot HTML)
+- interactive filtering and charts use the shared engine + Plotly in the browser
+
+The largest remaining gaps are less about transport and more about:
+
+- dashboard spec quality and validation
+- generator discipline under real QA prompts
+- snapshot HTML robustness for very large outputs
+- eventual per-chart filter scoping (`applies_to`) and richer aggregates if the
+  spec grows
+
+## What We Planned
+
+The target dashboard architecture had these goals:
+
+- dashboards should be first-class workspace objects, not loose HTML files
+- the durable artifact should live under `dashboards/<slug>/`
+- the frontend should show one dashboard row in the file tree
+- the canvas should render from the **saved package** (native) rather than
+  depending on a short-lived server session
+- the system should keep a read-only snapshot HTML fallback
+- the agent should generate declarative dashboard specs, not arbitrary app code
+- tagged local Parquet or CSV should be the primary source for interactive
+  dashboards
+
+We also wanted the dashboard skill to behave like the research and slides flows:
+
+- inspect the dataset
+- produce a plan
+- ask for review
+- only then build the dashboard
+
+Later, we refined the quality goal further:
+
+- optimize for executive-polish dashboards
+- use a stronger layout contract
+- freeze chart lineup after approval
+- avoid freeform chart-code retries in the happy path
+
+## What We Implemented
+
+### Workspace object model
+
+Dashboard generation targets a **package folder** rather than a flat HTML file.
+
+The intended package shape includes:
+
+- `dashboards/<slug>/dashboard.meta.json`
+- `dashboards/<slug>/dashboard.spec.json`
+- `dashboards/<slug>/dashboard.snapshot.html`
+- `dashboards/<slug>/data/dashboard.rows.json` (row-level data for the browser)
+
+The frontend treats the folder itself as the primary dashboard object and opens
+it in the canvas. Artifact selection continues to flow through the file pane.
+
+### Dashboard skill flow
+
+`data/dashboard` uses a review-first contract:
+
+- it requests clarification when the dataset/runtime choice is ambiguous
+- it produces a dashboard plan
+- it requires approval before the build phase
+- strict dashboard mode prefers tagged local datasets over fresh BigQuery
+  rediscovery
+
+### Native canvas runtime (current)
+
+The live sidecar (Streamlit/Dash) and backend proxy/session paths were removed
+from the product shape in favor of:
+
+- **`runtimeKind: "native"`** in generated metadata/spec
+- **`chartRuntimeDefs`** as the executable chart contract (deterministic;
+  frontend does not interpret open-ended narrative chart metadata)
+- **`@helpudoc/shared`** dashboard module: filters, aggregates, Plotly payload
+  building
+- stream events: **`dashboard_artifact`** carrying paths/ids for the package the
+  user should open
+
+### Snapshot and package handling
+
+The canvas supports:
+
+- loading `dashboard.spec.json`, `data/dashboard.rows.json`, and related assets
+  from the workspace API
+- Plotly charts rendered in-app
+- HTML snapshot fallback when needed
+
+We also have:
+
+- folder-path normalization for dashboard packages
+- hidden/internal artifact handling in the workspace tree
+- raw preview endpoints for large HTML snapshots where applicable
+
+### Dashboard spec and renderer improvements
+
+`dashboard.spec.json` aims to carry structured fields (version, title, filters,
+layout, charts, dataset refs, etc.). The **native** path emphasizes:
+
+- **`chartRuntimeDefs`** for what to render
+- shared engine parity between snapshot generation and browser interactivity
+  (same filter/aggregate semantics as far as practical)
+
+## What Went Well
+
+- The workspace-native dashboard object model is much clearer than the original
+  loose HTML artifact model.
+- The **durable package + native renderer** removes an entire class of
+  same-origin proxy, session TTL, and sidecar failures.
+- The dashboard skill supports plan approval instead of jumping straight to
+  generation.
+- Tagged local datasets are a better fit for iterative dashboard work than
+  repeated warehouse exploration.
+- The package model makes snapshot and spec output easier to reason about than
+  ad hoc generated HTML.
+
+## Main Difficulties We Faced
+
+_Historical note: several items below reflect the earlier sidecar/session era.
+They remain relevant for understanding past QA pain and for snapshot/HTML edge
+cases._
+
+### 1. Runtime shape changed while the product contract stayed similar
+
+We iterated through Dash- and Streamlit-oriented runtimes before settling on the
+native package. User-facing flows stayed familiar, but implementation churn
+surfaced restore and transport regressions along the way.
+
+### 2. Agent generation still wandered too much
+
+Even after stricter dashboard-mode guidance, real runs still showed:
+
+- repeated discovery steps
+- repeated clarification
+- unnecessary fallback to BigQuery materialization
+- query budget waste on recovery instead of dashboard intent
+
+This is a generator-discipline problem more than a transport problem.
+
+### 3. Chart generation remained brittle
+
+Several runs still fell back into weak chart bindings or empty structured specs.
+
+Observed issues included:
+
+- syntax errors while generating chart code (legacy paths)
+- empty structured chart specs
+- semantically swapped metric vs dimension bindings
+- dashboards saved with little or no interactive content
+
+### 4. Session restore after refresh was fragile (legacy sidecar)
+
+When the canvas depended on an in-memory live session, refresh or container
+restart could break hydration even though the package existed on disk. The
+**native** path avoids that coupling; any remaining issues are workspace load
+and path normalization, not session TTL.
+
+### 5. Snapshot rendering was brittle for large outputs
+
+Some dashboard snapshots grew large enough that JSON preview plus `iframe
+srcDoc` paths were fragile. Raw preview and direct URL loading help; this area
+still benefits from QA on large HTML.
+
+### 6. Package path normalization was easy to get wrong
+
+Some generated dashboards were accidentally written one folder too deep, which
+made the file tree select the wrong folder and broke asset lookup.
+
+### 7. Clarification UX had input and loop issues
+
+Observed clarification issues included:
+
+- spaces being stripped while typing structured clarification responses
+- repeated clarification loops when the agent judged the response too vague
+- dead-loop protection terminating the run instead of giving a more helpful
+  explanation
+
+## Current State
+
+Today, the dashboard system is best described as:
+
+- **Architecturally aligned** with the durable package + native renderer plan
+- **Deterministic chart execution** via `chartRuntimeDefs` and the shared TS
+  engine
+- Still subject to **generator and spec-quality** variance in real QA
+
+What is true right now:
+
+- the dashboard package model exists **including** `data/dashboard.rows.json`
+- the **native** renderer path is the intended default; sidecar sessions are
+  not part of the core flow
+- snapshot HTML is still generated for fallback and export-style viewing
+- review-first dashboard planning exists
+- the agent emits **`dashboard_artifact`** for the UI to route users to the new
+  package
+
+What is not yet consistently true:
+
+- every dashboard run produces a strong structured spec
+- every snapshot renders reliably at extreme sizes
+- every generated chart binding is semantically correct
+- every output looks polished enough for executive use
+- filters may apply globally to all charts until `applies_to` (or equivalent)
+  is wired through the engine
+
+## Why Failures Still Happen
+
+### Failure class: empty or weak spec
+
+Some dashboards were saved with:
+
+- empty `charts` / `chartRuntimeDefs`
+- empty `filters`
+- empty `datasetRef`
+
+That creates a technically valid package folder but not a useful dashboard.
+
+### Failure class: wrong package path
+
+Some dashboards were saved inside an extra nested folder. The runtime package
+was valid, but the UI selected the outer folder and could not find the real
+files.
+
+### Failure class: snapshot delivery path too fragile
+
+The snapshot file can exist on disk, but the UI still shows problems if the
+preview path is wrong for very large HTML payloads.
+
+### Failure class: ambiguous clarification
+
+Some dashboard runs failed because the clarification answer stayed too vague,
+causing the agent to emit the same clarification again and trip the loop guard.
+
+## Likely Next Changes
+
+### 1. Harden package load and snapshot delivery
+
+- verify large HTML snapshot paths end-to-end
+- keep path normalization and tree selection robust for oddly nested outputs
+
+### 2. Make strict dashboard mode truly spec-first
+
+- fail hard if `datasetRef`, `charts`, or `chartRuntimeDefs` are empty where
+  required
+- forbid legacy chart-code fallback on the main dashboard happy path
+- build the package directly from approved structured specs and bounded query
+  results
+
+### 3. Tighten generator discipline
+
+- one schema inspection
+- one optional preview query
+- one bounded aggregate bundle
+- no duplicate clarification once dataset and goal are known
+- no warehouse materialization when the tagged local dataset is sufficient
+
+### 4. Strengthen spec validation
+
+- require meaningful business metadata where we enforce quality bars
+- validate metric vs dimension semantics by chart type
+
+### 5. Engine enhancements (when spec demands it)
+
+- respect **`filter_schema.applies_to`** (or equivalent) so filters target
+  specific charts
+- extend **`count_distinct`** (and similar) to non-numeric categorical fields if
+  generated specs need it
+
+### 6. Separate debugging classes
+
+Track separately:
+
+- workspace/preview/snapshot plumbing
+- dashboard quality and aesthetics
+
+## Recommended Near-Term Plan
+
+1. Harden package open + snapshot preview for large artifacts.
+2. Enforce spec-first dashboard generation with strict validation at save time.
+3. Tighten spec validation before package save.
+4. Add or refine executive templates once strict mode is dependable.
+5. Iterate on filter scoping and aggregate coverage as the spec evolves.
+
+## Documents To Keep In Sync
+
+When the dashboard system changes again, update these docs together:
+
+- `docs/current-architecture.md`
+- `docs/data-analytics-platform-user-flow.md`
+- `docs/data-skill-migration.md`
+- `skills/data/dashboard/SKILL.md`

--- a/docs/data-analytics-platform-user-flow.md
+++ b/docs/data-analytics-platform-user-flow.md
@@ -2,6 +2,9 @@
 
 This document explains how a user would use HelpUDoc as a data analytics platform after the snapshot-refresh workflow changes.
 
+For the current dashboard-runtime implementation status, known QA issues, and
+likely next changes, also see `docs/dashboard-runtime-status.md`.
+
 The short version:
 
 - BigQuery remains the system of record.

--- a/docs/data-skill-migration.md
+++ b/docs/data-skill-migration.md
@@ -4,6 +4,9 @@ This document records the current migration from the legacy `data-analysis` skil
 to the newer `data/*` skill family, along with the remaining work required before
 `data-analysis` can be safely removed.
 
+For the current `data/dashboard` runtime status and the Streamlit-based dashboard
+package work, also see `docs/dashboard-runtime-status.md`.
+
 ## Summary
 
 The data skill surface has been expanded from a single end-to-end skill into a

--- a/frontend/Dockerfile.gke
+++ b/frontend/Dockerfile.gke
@@ -1,8 +1,9 @@
 # syntax=docker/dockerfile:1.7
 FROM node:20-bookworm-slim AS deps
-WORKDIR /app/frontend
-COPY frontend/package*.json ./
-RUN --mount=type=cache,target=/root/.npm npm ci
+WORKDIR /app
+COPY frontend/package*.json ./frontend/
+COPY packages/shared/package*.json ./packages/shared/
+RUN --mount=type=cache,target=/root/.npm cd frontend && npm ci
 
 FROM node:20-bookworm-slim AS build
 WORKDIR /app

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@copilotkit/react-ui": "^1.51.3",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@helpudoc/shared": "file:../packages/shared",
         "@hocuspocus/provider": "^3.4.3",
         "@mdxeditor/editor": "^3.48.0",
         "@monaco-editor/react": "^4.7.0",
@@ -61,6 +62,10 @@
         "typescript-eslint": "^8.45.0",
         "vite": "^7.1.7"
       }
+    },
+    "../packages/shared": {
+      "name": "@helpudoc/shared",
+      "version": "0.1.0"
     },
     "node_modules/@0no-co/graphql.web": {
       "version": "1.2.0",
@@ -3684,6 +3689,10 @@
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
       }
+    },
+    "node_modules/@helpudoc/shared": {
+      "resolved": "../packages/shared",
+      "link": true
     },
     "node_modules/@hocuspocus/common": {
       "version": "3.4.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "e2e": "playwright test --project=chromium"
   },
   "dependencies": {
+    "@helpudoc/shared": "file:../packages/shared",
     "@copilotkit/react-core": "^1.51.3",
     "@copilotkit/react-ui": "^1.51.3",
     "@emotion/react": "^11.14.0",

--- a/frontend/src/components/WorkspaceFileTree.tsx
+++ b/frontend/src/components/WorkspaceFileTree.tsx
@@ -10,7 +10,7 @@ import {
   Edit,
 } from 'lucide-react';
 
-import type { File as WorkspaceFile } from '../types';
+import type { DashboardArtifactInfo, File as WorkspaceFile } from '../types';
 import { getFileDisplayName, getFileTypeIcon } from '../utils/files';
 import {
   buildWorkspaceFileTree,
@@ -25,11 +25,14 @@ interface WorkspaceFileTreeProps {
   files: WorkspaceFile[];
   colorMode: 'light' | 'dark';
   selectedFileId: string | null;
+  selectedDashboardPath?: string | null;
   selectedFiles: Set<string>;
   copiedPublicUrlFileId: string | null;
+  dashboardArtifactsByPath?: Record<string, DashboardArtifactInfo>;
   ragStatuses: Record<string, { status?: string; updatedAt?: string; error?: string }>;
   isDraftWorkspaceFile: (file?: WorkspaceFile | null) => boolean;
   onSelectFile: (file: WorkspaceFile) => void;
+  onSelectFolder?: (folderPath: string) => void;
   onToggleFileSelection: (fileId: string) => void;
   onCopyPublicUrl: (file: WorkspaceFile) => void;
   onRenameFile: (file: WorkspaceFile) => void;
@@ -52,6 +55,30 @@ const getFolderLabel = (node: WorkspaceFileTreeFolderNode) => {
     return 'Derived artifacts';
   }
   return node.name;
+};
+
+const isDashboardFolderPath = (folderPath: string) => {
+  const normalized = (folderPath || '').replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/+$/, '');
+  const parts = normalized.split('/').filter(Boolean);
+  return parts.length === 2 && parts[0] === 'dashboards';
+};
+
+const getDashboardArtifactForFolderPath = (
+  dashboardArtifactsByPath: Record<string, DashboardArtifactInfo> | undefined,
+  folderPath: string,
+) => {
+  if (!dashboardArtifactsByPath) {
+    return undefined;
+  }
+  const normalized = (folderPath || '').replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/+$/, '');
+  const exact = dashboardArtifactsByPath[normalized];
+  if (exact) {
+    return exact;
+  }
+  const descendantArtifacts = Object.entries(dashboardArtifactsByPath)
+    .filter(([path]) => path.startsWith(`${normalized}/`))
+    .map(([, artifact]) => artifact);
+  return descendantArtifacts.length === 1 ? descendantArtifacts[0] : undefined;
 };
 
 const getRagStatus = (
@@ -106,6 +133,7 @@ const TreeFileRow: React.FC<{
   node: WorkspaceFileTreeLeafNode;
   selected: boolean;
   selectedFiles: Set<string>;
+  dashboardArtifactsByPath?: Record<string, DashboardArtifactInfo>;
   ragStatuses: Record<string, { status?: string; updatedAt?: string; error?: string }>;
   isDraftWorkspaceFile: (file?: WorkspaceFile | null) => boolean;
   onSelectFile: (file: WorkspaceFile) => void;
@@ -122,6 +150,7 @@ const TreeFileRow: React.FC<{
   node,
   selected,
   selectedFiles,
+  dashboardArtifactsByPath,
   ragStatuses,
   isDraftWorkspaceFile,
   onSelectFile,
@@ -163,6 +192,9 @@ const TreeFileRow: React.FC<{
   const actionButtonClassName = isDarkMode
     ? 'pointer-events-auto rounded p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-100'
     : 'pointer-events-auto rounded p-1.5 text-slate-500 hover:bg-slate-200 hover:text-slate-700';
+  const dashboardPath = (file.path || file.name || '').replace(/\\/g, '/');
+  const dashboardArtifact = dashboardPath ? dashboardArtifactsByPath?.[dashboardPath] : undefined;
+  const dashboardBadge = dashboardArtifact?.status;
 
   return (
     <div
@@ -222,6 +254,21 @@ const TreeFileRow: React.FC<{
               {fileIcon}
             </span>
             <SlidingFileName name={displayName} colorMode={colorMode} />
+            {dashboardBadge && (
+              <span
+                className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                  dashboardBadge === 'ready'
+                    ? 'bg-emerald-100 text-emerald-800'
+                    : dashboardBadge === 'generating'
+                      ? 'bg-amber-100 text-amber-800'
+                      : dashboardBadge === 'error'
+                        ? 'bg-rose-100 text-rose-800'
+                        : 'bg-blue-100 text-blue-800'
+                }`}
+              >
+                {dashboardBadge}
+              </span>
+            )}
           </div>
           {(isUnderstandingPending || understandingFailed || understandingPartial) && (
             <span className={`pl-6 text-[11px] leading-none ${
@@ -293,6 +340,8 @@ const TreeFileRow: React.FC<{
 const TreeFolderRow: React.FC<{
   node: WorkspaceFileTreeFolderNode;
   expanded: boolean;
+  dashboardArtifact?: DashboardArtifactInfo;
+  onSelectFolder?: (folderPath: string) => void;
   onToggle: (folderPath: string) => void;
   onDeleteFolder: (folder: WorkspaceFileTreeFolderNode) => void;
   onDropFileToFolder: (fileId: string, folderPath: string) => void;
@@ -304,6 +353,8 @@ const TreeFolderRow: React.FC<{
 }> = ({
   node,
   expanded,
+  dashboardArtifact,
+  onSelectFolder,
   onToggle,
   onDeleteFolder,
   onDropFileToFolder,
@@ -323,6 +374,8 @@ const TreeFolderRow: React.FC<{
     : isDarkMode
       ? 'hover:bg-slate-800/80'
       : 'hover:bg-slate-100/80';
+  const isDashboardFolder = isDashboardFolderPath(node.path);
+  const dashboardBadge = dashboardArtifact?.status;
 
   return (
     <div className="select-none">
@@ -370,12 +423,33 @@ const TreeFolderRow: React.FC<{
         {expanded ? <FolderOpen size={16} className="shrink-0 text-amber-500" /> : <Folder size={16} className="shrink-0 text-amber-500" />}
         <button
           type="button"
-          onClick={() => onToggle(node.path)}
+          onClick={() => {
+            if (isDashboardFolder && onSelectFolder) {
+              onSelectFolder(node.path);
+              return;
+            }
+            onToggle(node.path);
+          }}
           className="min-w-0 flex-1 text-left"
           title={node.path || node.name}
         >
           <div className="flex items-center gap-2">
             <span className={`truncate text-[13px] font-medium ${isDarkMode ? 'text-slate-200' : 'text-slate-800'}`}>{getFolderLabel(node)}</span>
+            {dashboardBadge && (
+              <span
+                className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                  dashboardBadge === 'ready'
+                    ? 'bg-emerald-100 text-emerald-800'
+                    : dashboardBadge === 'generating'
+                      ? 'bg-amber-100 text-amber-800'
+                      : dashboardBadge === 'error'
+                        ? 'bg-rose-100 text-rose-800'
+                        : 'bg-blue-100 text-blue-800'
+                }`}
+              >
+                {dashboardBadge}
+              </span>
+            )}
             <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
               isDarkMode ? 'bg-slate-800 text-slate-400' : 'bg-slate-200 text-slate-600'
             }`}>
@@ -410,10 +484,13 @@ const renderTreeNodes = (
   options: {
     expandedFolders: Set<string>;
     selectedFileId: string | null;
+    selectedDashboardPath?: string | null;
     selectedFiles: Set<string>;
+    dashboardArtifactsByPath?: Record<string, DashboardArtifactInfo>;
     ragStatuses: Record<string, { status?: string; updatedAt?: string; error?: string }>;
     isDraftWorkspaceFile: (file?: WorkspaceFile | null) => boolean;
     onSelectFile: (file: WorkspaceFile) => void;
+    onSelectFolder?: (folderPath: string) => void;
     onToggleFileSelection: (fileId: string) => void;
     onCopyPublicUrl: (file: WorkspaceFile) => void;
     copiedPublicUrlFileId: string | null;
@@ -437,6 +514,8 @@ const renderTreeNodes = (
           key={node.id}
           node={node}
           expanded={expanded}
+          dashboardArtifact={getDashboardArtifactForFolderPath(options.dashboardArtifactsByPath, node.path)}
+          onSelectFolder={options.onSelectFolder}
           onToggle={options.onToggleFolder}
           onDeleteFolder={options.onDeleteFolder}
           onDropFileToFolder={options.onDropFileToFolder}
@@ -456,6 +535,7 @@ const renderTreeNodes = (
         node={node}
         selected={options.selectedFileId === node.file.id}
         selectedFiles={options.selectedFiles}
+        dashboardArtifactsByPath={options.dashboardArtifactsByPath}
         ragStatuses={options.ragStatuses}
         isDraftWorkspaceFile={options.isDraftWorkspaceFile}
         onSelectFile={options.onSelectFile}
@@ -477,10 +557,13 @@ export default function WorkspaceFileTree({
   files,
   colorMode,
   selectedFileId,
+  selectedDashboardPath,
   selectedFiles,
+  dashboardArtifactsByPath,
   ragStatuses,
   isDraftWorkspaceFile,
   onSelectFile,
+  onSelectFolder,
   onToggleFileSelection,
   onCopyPublicUrl,
   copiedPublicUrlFileId,
@@ -530,6 +613,27 @@ export default function WorkspaceFileTree({
       return changed ? next : prev;
     });
   }, [fileById, selectedFileId]);
+
+  useEffect(() => {
+    if (!selectedDashboardPath) {
+      return;
+    }
+    const nextPaths = getWorkspaceAncestorFolderPaths(selectedDashboardPath);
+    if (!nextPaths.length) {
+      return;
+    }
+    setExpandedFolders((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const path of nextPaths) {
+        if (!next.has(path)) {
+          next.add(path);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [selectedDashboardPath]);
 
   const handleToggleFolder = (folderPath: string) => {
     setExpandedFolders((prev) => {
@@ -582,10 +686,13 @@ export default function WorkspaceFileTree({
             {renderTreeNodes(tree.children, {
               expandedFolders,
               selectedFileId,
+              selectedDashboardPath,
               selectedFiles,
+              dashboardArtifactsByPath,
               ragStatuses,
               isDraftWorkspaceFile,
               onSelectFile,
+              onSelectFolder,
               onToggleFileSelection,
               onCopyPublicUrl,
               copiedPublicUrlFileId,

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -835,9 +835,10 @@ export default function ChatMessageBubble({
     setInterruptStructuredAnswersByMessageId((prev) => {
       const next = { ...prev };
       const current = { ...(next[messageKey] || {}) };
-      const normalizedValue = value.trim();
-      if (normalizedValue) {
-        current[questionId] = normalizedValue;
+      const trimmedValue = value.trim();
+      if (trimmedValue) {
+        // Preserve internal spaces while still treating all-whitespace input as empty.
+        current[questionId] = value;
       } else {
         delete current[questionId];
       }

--- a/frontend/src/components/dashboard/DashboardCanvas.tsx
+++ b/frontend/src/components/dashboard/DashboardCanvas.tsx
@@ -1,0 +1,234 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import PlotlyChart from '../PlotlyChart';
+import type { PlotlySpec } from '../PlotlyChart';
+import { getWorkspaceFilePreview } from '../../services/fileApi';
+import { apiFetch, buildApiUrl } from '../../services/apiClient';
+import {
+  applyDashboardFilters,
+  buildPlotlyPayload,
+  type ChartRuntimeDef,
+  type DashboardFilterDef,
+  type DashboardRow,
+  type DatasetSchemaColumn,
+  type FilterValues,
+} from '@helpudoc/shared/dashboard';
+import DashboardFilters from './DashboardFilters';
+
+function normalizePath(value: string): string {
+  return String(value || '')
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .trim();
+}
+
+type DashboardSpec = {
+  title?: string;
+  filters?: DashboardFilterDef[];
+  chartRuntimeDefs?: ChartRuntimeDef[];
+  datasetSchema?: DatasetSchemaColumn[];
+  dataset?: {
+    path?: string;
+    previewPath?: string;
+    rowCount?: number;
+  };
+};
+
+type Props = {
+  workspaceId: string;
+  dashboardPath: string;
+  onDownloadHtmlExport?: () => void;
+};
+
+const DashboardCanvas = ({ workspaceId, dashboardPath, onDownloadHtmlExport }: Props) => {
+  const base = normalizePath(dashboardPath);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [spec, setSpec] = useState<DashboardSpec | null>(null);
+  const [rows, setRows] = useState<DashboardRow[]>([]);
+  const [filterValues, setFilterValues] = useState<FilterValues>({});
+
+  const load = useCallback(async () => {
+    setLoadError(null);
+    setSpec(null);
+    setRows([]);
+    try {
+      const specPath = `${base}/dashboard.spec.json`;
+      const specPreview = await getWorkspaceFilePreview(workspaceId, specPath);
+      const specText = typeof specPreview?.content === 'string' ? specPreview.content : '';
+      if (!specText.trim()) {
+        setLoadError('Dashboard spec is empty or missing.');
+        return;
+      }
+      const parsed = JSON.parse(specText) as DashboardSpec;
+      setSpec(parsed);
+
+      const previewPath =
+        typeof parsed.dataset?.previewPath === 'string' && parsed.dataset.previewPath.trim()
+          ? normalizePath(parsed.dataset.previewPath)
+          : `${base}/data/dashboard.rows.json`;
+
+      const rowsPreview = await getWorkspaceFilePreview(workspaceId, previewPath);
+      const rowsText = typeof rowsPreview?.content === 'string' ? rowsPreview.content : '';
+      if (!rowsText.trim()) {
+        setLoadError('Dashboard preview rows are missing. Regenerate the dashboard package.');
+        return;
+      }
+      const rowsPayload = JSON.parse(rowsText) as { rows?: DashboardRow[] } | DashboardRow[];
+      const list = Array.isArray(rowsPayload) ? rowsPayload : rowsPayload.rows;
+      if (!Array.isArray(list)) {
+        setLoadError('dashboard.rows.json must contain a "rows" array.');
+        return;
+      }
+      setRows(list);
+    } catch (e) {
+      console.error(e);
+      setLoadError(e instanceof Error ? e.message : 'Failed to load dashboard.');
+    }
+  }, [base, workspaceId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const schema = spec?.datasetSchema && spec.datasetSchema.length ? spec.datasetSchema : inferSchemaFromRows(rows);
+  const filters = (spec?.filters || []) as DashboardFilterDef[];
+  const chartDefs = (spec?.chartRuntimeDefs || []) as ChartRuntimeDef[];
+
+  const filteredRows = useMemo(
+    () => applyDashboardFilters(rows, filters, filterValues, schema),
+    [filterValues, filters, rows, schema],
+  );
+
+  const chartSpecs = useMemo(() => {
+    return chartDefs.map((def, idx) => {
+      const payload = buildPlotlyPayload(filteredRows, def);
+      const specChart: PlotlySpec = {
+        data: payload.data as PlotlySpec['data'],
+        layout: {
+          ...payload.layout,
+          autosize: true,
+        },
+        config: payload.config as PlotlySpec['config'],
+      };
+      return { key: def.chartId || `chart-${def.chartIndex ?? idx}`, title: def.title || `Chart ${idx + 1}`, specChart };
+    });
+  }, [chartDefs, filteredRows]);
+
+  const title = spec?.title || base.split('/').filter(Boolean).pop() || 'Dashboard';
+
+  if (loadError) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 bg-white px-6 text-center">
+        <p className="text-sm font-medium text-slate-800">Could not open dashboard</p>
+        <p className="text-xs text-slate-500">{loadError}</p>
+        <button
+          type="button"
+          className="mt-2 rounded-md border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
+          onClick={() => void load()}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!spec && !loadError) {
+    return (
+      <div className="flex h-full items-center justify-center bg-white text-sm text-slate-500">
+        Loading dashboard…
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-slate-50">
+      <div className="shrink-0 border-b border-slate-200 bg-white px-4 py-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <h2 className="text-base font-semibold text-slate-900">{title}</h2>
+            <p className="text-xs text-slate-500">
+              {filteredRows.length} of {rows.length} rows after filters
+              {typeof spec?.dataset?.rowCount === 'number' ? ` · package rowCount ${spec.dataset.rowCount}` : ''}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {onDownloadHtmlExport ? (
+              <button
+                type="button"
+                className="rounded-md border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
+                onClick={onDownloadHtmlExport}
+              >
+                Download HTML export
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="rounded-md border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
+              onClick={() => void load()}
+            >
+              Reload data
+            </button>
+          </div>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+        <div className="mx-auto flex max-w-[1400px] flex-col gap-4">
+          <DashboardFilters
+            filters={filters}
+            datasetSchema={schema}
+            allRows={rows}
+            values={filterValues}
+            onChange={setFilterValues}
+          />
+          {chartSpecs.length === 0 ? (
+            <p className="text-sm text-slate-500">No interactive charts in this dashboard spec.</p>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2">
+              {chartSpecs.map((c) => (
+                <article
+                  key={c.key}
+                  className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm"
+                >
+                  <h3 className="mb-2 text-sm font-semibold text-slate-800">{c.title}</h3>
+                  <PlotlyChart spec={c.specChart} minHeight={320} className="w-full" />
+                </article>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+function inferSchemaFromRows(sample: DashboardRow[]): DatasetSchemaColumn[] {
+  if (!sample.length) return [];
+  const row = sample[0];
+  return Object.keys(row).map((name) => {
+    const v = row[name];
+    let t = 'object';
+    if (typeof v === 'number') t = 'float64';
+    else if (typeof v === 'boolean') t = 'bool';
+    else if (typeof v === 'string') t = 'string';
+    return { name, type: t };
+  });
+}
+
+export default DashboardCanvas;
+
+/** Fetch snapshot HTML as a download (avoids executing HTML in a same-origin iframe). */
+export async function downloadDashboardHtmlExport(workspaceId: string, dashboardPath: string, filename?: string) {
+  const base = normalizePath(dashboardPath);
+  const path = `${base}/dashboard.snapshot.html`;
+  const url = buildApiUrl(`/workspaces/${workspaceId}/files/preview/raw`);
+  url.searchParams.set('path', path);
+  const res = await apiFetch(url.toString());
+  if (!res.ok) {
+    throw new Error('Failed to download HTML export');
+  }
+  const blob = await res.blob();
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = filename || 'dashboard.snapshot.html';
+  a.click();
+  URL.revokeObjectURL(a.href);
+}

--- a/frontend/src/components/dashboard/DashboardFilters.tsx
+++ b/frontend/src/components/dashboard/DashboardFilters.tsx
@@ -1,0 +1,155 @@
+import { useMemo } from 'react';
+import {
+  distinctFieldValues,
+  inferFieldType,
+  type DashboardFilterDef,
+  type DashboardRow,
+  type DatasetSchemaColumn,
+  type FilterValues,
+} from '@helpudoc/shared/dashboard';
+
+type Props = {
+  filters: DashboardFilterDef[];
+  datasetSchema: DatasetSchemaColumn[];
+  allRows: DashboardRow[];
+  values: FilterValues;
+  onChange: (next: FilterValues) => void;
+};
+
+const DashboardFilters = ({ filters, datasetSchema, allRows, values, onChange }: Props) => {
+  const controls = useMemo(() => {
+    if (!filters.length) {
+      return null;
+    }
+    return filters.map((def) => {
+      const id = String(def.id || def.field).trim();
+      const field = String(def.field || '').trim();
+      const label = String(def.label || field).trim() || field;
+      const ftype = inferFieldType(def, datasetSchema);
+      const current = values[id];
+
+      if (ftype === 'categorical') {
+        const options = distinctFieldValues(allRows, field);
+        const selected = Array.isArray(current) ? current.map(String) : current ? [String(current)] : [];
+        return (
+          <label key={id} className="flex min-w-[200px] flex-col gap-1 text-xs text-slate-600">
+            <span className="font-semibold text-slate-800">{label}</span>
+            <select
+              multiple
+              className="min-h-[96px] rounded-md border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900"
+              value={selected}
+              onChange={(e) => {
+                const nextSel = Array.from(e.target.selectedOptions, (o) => o.value);
+                onChange({ ...values, [id]: nextSel });
+              }}
+            >
+              {options.map((opt) => (
+                <option key={opt} value={opt}>
+                  {opt}
+                </option>
+              ))}
+            </select>
+          </label>
+        );
+      }
+
+      if (ftype === 'date') {
+        const payload =
+          current && typeof current === 'object' && !Array.isArray(current)
+            ? (current as Record<string, unknown>)
+            : {};
+        const start = typeof payload.start === 'string' ? payload.start : '';
+        const end = typeof payload.end === 'string' ? payload.end : '';
+        return (
+          <div key={id} className="flex min-w-[220px] flex-col gap-1 text-xs text-slate-600">
+            <span className="font-semibold text-slate-800">{label}</span>
+            <div className="flex flex-wrap gap-2">
+              <input
+                type="date"
+                className="rounded-md border border-slate-300 px-2 py-1 text-sm"
+                value={start.slice(0, 10)}
+                onChange={(e) =>
+                  onChange({
+                    ...values,
+                    [id]: { ...payload, start: e.target.value ? `${e.target.value}T00:00:00` : '' },
+                  })
+                }
+              />
+              <input
+                type="date"
+                className="rounded-md border border-slate-300 px-2 py-1 text-sm"
+                value={end.slice(0, 10)}
+                onChange={(e) =>
+                  onChange({
+                    ...values,
+                    [id]: { ...payload, end: e.target.value ? `${e.target.value}T23:59:59` : '' },
+                  })
+                }
+              />
+            </div>
+          </div>
+        );
+      }
+
+      const payload =
+        current && typeof current === 'object' && !Array.isArray(current)
+          ? (current as Record<string, unknown>)
+          : {};
+      const min = payload.min !== undefined && payload.min !== '' ? String(payload.min) : '';
+      const max = payload.max !== undefined && payload.max !== '' ? String(payload.max) : '';
+      return (
+        <div key={id} className="flex min-w-[200px] flex-col gap-1 text-xs text-slate-600">
+          <span className="font-semibold text-slate-800">{label}</span>
+          <div className="flex flex-wrap gap-2">
+            <input
+              type="number"
+              placeholder="Min"
+              className="w-28 rounded-md border border-slate-300 px-2 py-1 text-sm"
+              value={min}
+              onChange={(e) =>
+                onChange({
+                  ...values,
+                  [id]: { ...payload, min: e.target.value === '' ? '' : Number(e.target.value) },
+                })
+              }
+            />
+            <input
+              type="number"
+              placeholder="Max"
+              className="w-28 rounded-md border border-slate-300 px-2 py-1 text-sm"
+              value={max}
+              onChange={(e) =>
+                onChange({
+                  ...values,
+                  [id]: { ...payload, max: e.target.value === '' ? '' : Number(e.target.value) },
+                })
+              }
+            />
+          </div>
+        </div>
+      );
+    });
+  }, [allRows, datasetSchema, filters, values]);
+
+  if (!filters.length) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-3">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <span className="text-sm font-semibold text-slate-800">Filters</span>
+        <button
+          type="button"
+          className="text-xs font-medium text-slate-600 underline decoration-slate-400 underline-offset-2 hover:text-slate-900"
+          onClick={() => onChange({})}
+        >
+          Reset filters
+        </button>
+      </div>
+      <div className="flex flex-wrap gap-4">{controls}</div>
+    </div>
+  );
+};
+
+export default DashboardFilters;

--- a/frontend/src/constants/workspace.ts
+++ b/frontend/src/constants/workspace.ts
@@ -19,7 +19,7 @@ export const SLASH_COMMANDS = [
   },
 ] as const;
 
-export const SYSTEM_DIR_NAMES = new Set(['__macosx', 'skills']);
+export const SYSTEM_DIR_NAMES = new Set(['__macosx', 'skills', 'charts', 'data_cache']);
 export const SYSTEM_FILE_NAMES = new Set(['thumbs.db', 'desktop.ini']);
 
 export const MIN_CANVAS_ZOOM = 0.6;

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -21,6 +21,7 @@ import {
   deleteFolder,
   deleteFile,
   getFileContent,
+  getWorkspaceFilePreview,
   renameFile,
   getRagStatuses,
   resolveFileContextRefs,
@@ -65,6 +66,7 @@ import type {
   ConversationMessage,
   ToolEvent,
   ToolOutputFile,
+  DashboardArtifactInfo,
   ConversationMessageMetadata,
   InterruptAction,
   InterruptAnswersByQuestionId,
@@ -80,6 +82,7 @@ import WorkspaceShareDialog from '../components/WorkspaceShareDialog';
 import type { UIBlock } from '../components/UIBlockRenderer';
 import ExpandableSidebar from '../components/ExpandableSidebar';
 import WorkspaceFileTree from '../components/WorkspaceFileTree';
+import DashboardCanvas, { downloadDashboardHtmlExport } from '../components/dashboard/DashboardCanvas';
 import AgentChatPane from '../components/chat/AgentChatPane';
 import { buildApprovalDraftContent, buildApprovalReview } from '../components/chat/approvalReview';
 import type { RenderableInterruptAction } from '../components/chat/interruptActions';
@@ -399,11 +402,49 @@ const hydrateWorkspace = (workspace: Omit<Workspace, 'lastUsed'> & { lastUsed?: 
   lastUsed: workspace.lastUsed ?? formatWorkspaceLastUsed(workspace.updatedAt),
 });
 
-const normalizeWorkspaceRelativePath = (value?: string): string =>
+const normalizeWorkspaceRelativePath = (value?: string | null): string =>
   String(value || '')
     .replace(/\\/g, '/')
     .replace(/^\/+/, '')
     .trim();
+
+const getDashboardManifestPath = (dashboardPath?: string | null) => {
+  const normalized = normalizeWorkspaceRelativePath(dashboardPath);
+  return normalized ? `${normalized}/dashboard.meta.json` : '';
+};
+
+const getDashboardPackagePathFromManifestPath = (manifestPath?: string | null) => {
+  const normalized = normalizeWorkspaceRelativePath(manifestPath);
+  if (!normalized.endsWith('/dashboard.meta.json')) {
+    return '';
+  }
+  return normalized.slice(0, -'/dashboard.meta.json'.length);
+};
+
+const resolveDashboardPackagePath = (
+  files: WorkspaceFile[],
+  dashboardPath?: string | null,
+) => {
+  const normalized = normalizeWorkspaceRelativePath(dashboardPath);
+  if (!normalized) {
+    return '';
+  }
+  const exactManifestPath = getDashboardManifestPath(normalized);
+  if (files.some((file) => normalizeWorkspaceRelativePath(file.path || file.name) === exactManifestPath)) {
+    return normalized;
+  }
+  const descendantPackagePaths = new Set(
+    files
+      .map((file) => normalizeWorkspaceRelativePath(file.path || file.name))
+      .filter((path) => path.startsWith(`${normalized}/`) && path.endsWith('/dashboard.meta.json'))
+      .map((path) => getDashboardPackagePathFromManifestPath(path))
+      .filter(Boolean),
+  );
+  if (descendantPackagePaths.size === 1) {
+    return Array.from(descendantPackagePaths)[0];
+  }
+  return normalized;
+};
 
 const isDraftWorkspaceFile = (file?: WorkspaceFile | null): boolean =>
   Boolean(file && typeof file.id === 'string' && String(file.id).startsWith('draft:'));
@@ -506,7 +547,9 @@ export default function WorkspacePage() {
   const [files, setFiles] = useState<WorkspaceFile[]>([]);
   const [selectedFile, setSelectedFile] = useState<WorkspaceFile | null>(null);
   const [selectedFileDetails, setSelectedFileDetails] = useState<WorkspaceFile | null>(null);
+  const [selectedDashboardPath, setSelectedDashboardPath] = useState<string | null>(null);
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
+  const [dashboardArtifactsByPath, setDashboardArtifactsByPath] = useState<Record<string, DashboardArtifactInfo>>({});
   const [fileContent, setFileContent] = useState('');
   const [conversationMessages, setConversationMessages] = useState<Record<string, ConversationMessage[]>>({});
   const [chatMessage, setChatMessage] = useState('');
@@ -1288,8 +1331,22 @@ export default function WorkspacePage() {
   const messageBubbleMaxWidth = isAgentPaneFullScreen ? '100%' : '720px';
   const isDarkMode = colorMode === 'dark';
 
-  const activeFile = selectedFileDetails || selectedFile;
+  const activeFile = selectedDashboardPath ? null : (selectedFileDetails || selectedFile);
   const activeFileName = activeFile?.name ?? '';
+  const activeDashboardPath = normalizeWorkspaceRelativePath(selectedDashboardPath || activeFile?.path || activeFile?.name);
+  const isDashboardCanvas = Boolean(selectedDashboardPath);
+  const activeDashboardArtifact = activeDashboardPath ? dashboardArtifactsByPath[activeDashboardPath] : undefined;
+  const activeDashboardDisplayName = activeDashboardPath
+    ? (activeDashboardArtifact?.title || activeDashboardPath.split('/').filter(Boolean).pop() || 'Dashboard')
+    : '';
+  const resolvedDashboardFolder = useMemo(
+    () =>
+      selectedDashboardPath
+        ? resolveDashboardPackagePath(files, selectedDashboardPath)
+          || normalizeWorkspaceRelativePath(selectedDashboardPath)
+        : '',
+    [files, selectedDashboardPath],
+  );
   const normalizedFileName = activeFileName.toLowerCase();
   const isMarkdownFile = !!activeFile && MARKDOWN_FILE_EXTENSIONS.some((ext) => normalizedFileName.endsWith(ext));
   const isHtmlFile = !!activeFile && HTML_FILE_EXTENSIONS.some((ext) => normalizedFileName.endsWith(ext));
@@ -1310,7 +1367,7 @@ export default function WorkspacePage() {
       },
     ];
   }, [activeFile, fileContent]);
-  const canvasTitle = selectedFile ? selectedFile.name : 'Editor';
+  const canvasTitle = activeDashboardPath ? activeDashboardDisplayName : selectedFile ? selectedFile.name : 'Editor';
   const canZoomOutCanvas = canvasZoom > MIN_CANVAS_ZOOM;
   const canZoomInCanvas = canvasZoom < MAX_CANVAS_ZOOM;
   const handleCanvasZoomIn = useCallback(() => {
@@ -1679,7 +1736,7 @@ export default function WorkspacePage() {
     setConversationStreaming({});
   }, []);
 
-  const handleStopStreaming = () => {
+  const handleStopStreaming = async () => {
     stopRequestedRef.current = true;
     const activeRun = getActiveRunForConversation(activeConversationId);
     if (activeRun) {
@@ -1707,6 +1764,17 @@ export default function WorkspacePage() {
           };
         }),
       );
+      await persistAgentProgress(
+        { ...activeRun, status: 'cancelled' },
+        'cancelled',
+        {
+          metadataOverride: {
+            pendingInterrupt: undefined,
+          },
+        },
+      ).catch((error) => {
+        console.error('Failed to persist cancelled run state', error);
+      });
       removeActiveRun(activeRun.runId);
       resumeInFlightRef.current.delete(activeRun.runId);
       resumeAttemptedRef.current.add(activeRun.runId);
@@ -1740,6 +1808,91 @@ export default function WorkspacePage() {
       console.error('Failed to load files for workspace', error);
     }
   }, []);
+
+  const upsertDashboardPlaceholder = useCallback((artifact: DashboardArtifactInfo) => {
+    const normalizedPath = normalizeWorkspaceRelativePath(artifact.dashboardPath);
+    if (!normalizedPath || !selectedWorkspace) {
+      return;
+    }
+    if (artifact.workspaceId && artifact.workspaceId !== selectedWorkspace.id) {
+      return;
+    }
+    const draftId = `draft:${normalizedPath}/dashboard.meta.json`;
+    const manifestPath = getDashboardManifestPath(normalizedPath);
+    const placeholder: WorkspaceFile = {
+      id: draftId,
+      name: manifestPath,
+      path: manifestPath,
+      workspaceId: selectedWorkspace.id,
+      storageType: 'local',
+      mimeType: 'application/json',
+      content: '',
+    };
+    setFiles((prev) => {
+      if (prev.some((file) => normalizeWorkspaceRelativePath(file.path || file.name) === manifestPath)) {
+        return prev;
+      }
+      return [placeholder, ...prev];
+    });
+    setSelectedDashboardPath((prev) => prev || normalizedPath);
+    setSelectedFile(null);
+    setSelectedFileDetails(null);
+    setFileContent('');
+  }, [selectedWorkspace]);
+
+  const mergeDashboardArtifact = useCallback((artifact: DashboardArtifactInfo) => {
+    const normalizedPath = normalizeWorkspaceRelativePath(artifact.dashboardPath);
+    if (!normalizedPath) {
+      return;
+    }
+    if (artifact.workspaceId && selectedWorkspace && artifact.workspaceId !== selectedWorkspace.id) {
+      return;
+    }
+    const next: DashboardArtifactInfo = { ...artifact, dashboardPath: normalizedPath };
+    setDashboardArtifactsByPath((prev) => ({
+      ...prev,
+      [normalizedPath]: next,
+    }));
+    if (next.status === 'generating' || next.status === 'ready') {
+      upsertDashboardPlaceholder(next);
+    }
+    if (next.status === 'ready' && (!selectedDashboardPath || selectedDashboardPath === normalizedPath)) {
+      setSelectedDashboardPath(normalizedPath);
+      setSelectedFile(null);
+      setSelectedFileDetails(null);
+      setFileContent('');
+    }
+  }, [selectedDashboardPath, selectedWorkspace, upsertDashboardPlaceholder]);
+
+  const handleDownloadDashboardHtmlExport = useCallback(async () => {
+    if (!selectedWorkspace || !selectedDashboardPath) {
+      return;
+    }
+    const folder =
+      resolveDashboardPackagePath(files, selectedDashboardPath)
+      || normalizeWorkspaceRelativePath(selectedDashboardPath);
+    if (!folder) {
+      return;
+    }
+    try {
+      await downloadDashboardHtmlExport(selectedWorkspace.id, folder);
+    } catch (error) {
+      console.error('Failed to download dashboard HTML export', error);
+    }
+  }, [files, selectedDashboardPath, selectedWorkspace]);
+
+  const handleDashboardFolderSelect = useCallback((dashboardPath: string) => {
+    const normalizedPath = resolveDashboardPackagePath(files, dashboardPath);
+    if (!normalizedPath) {
+      return;
+    }
+    setSelectedDashboardPath(normalizedPath);
+    setSelectedFile(null);
+    setSelectedFileDetails(null);
+    setFileContent('');
+    setIsEditMode(false);
+    setCanvasZoom(1);
+  }, [files]);
 
   const fetchRagStatusForFiles = useCallback(async () => {
     if (!selectedWorkspace) {
@@ -2845,6 +2998,12 @@ export default function WorkspacePage() {
     fileContentRequestIdRef.current = requestId;
     const isCurrentRequest = () => fileContentRequestIdRef.current === requestId;
 
+    if (selectedDashboardPath) {
+      setFileContent('');
+      setSelectedFileDetails(null);
+      lastAutoSavedContentRef.current = '';
+      return;
+    }
     if (selectedFile && selectedWorkspace) {
       if (isDraftWorkspaceFile(selectedFile)) {
         if (!isCurrentRequest()) return;
@@ -2878,7 +3037,48 @@ export default function WorkspacePage() {
 
   useEffect(() => {
     fetchFileContent();
-  }, [selectedFile, selectedWorkspace]);
+  }, [selectedDashboardPath, selectedFile, selectedWorkspace]);
+
+  useEffect(() => {
+    if (!selectedWorkspace || !selectedDashboardPath) {
+      return;
+    }
+    const dashboardPath = resolveDashboardPackagePath(files, selectedDashboardPath);
+    if (dashboardPath && dashboardPath !== selectedDashboardPath) {
+      setSelectedDashboardPath(dashboardPath);
+    }
+  }, [files, selectedDashboardPath, selectedWorkspace]);
+
+  useEffect(() => {
+    setDashboardArtifactsByPath({});
+    setSelectedDashboardPath(null);
+  }, [selectedWorkspace?.id]);
+
+  useEffect(() => {
+    if (selectedFile) {
+      setSelectedDashboardPath(null);
+    }
+  }, [selectedFile]);
+
+  useEffect(() => {
+    if (!selectedFile || !String(selectedFile.id).startsWith('draft:')) {
+      return;
+    }
+    const selectedPath = normalizeWorkspaceRelativePath(selectedFile.path || selectedFile.name);
+    if (!selectedPath) {
+      return;
+    }
+    const persistedFile = files.find(
+      (file) =>
+        !String(file.id).startsWith('draft:') &&
+        normalizeWorkspaceRelativePath(file.path || file.name) === selectedPath,
+    );
+    if (!persistedFile) {
+      return;
+    }
+    setSelectedFile(persistedFile);
+    setSelectedFileDetails(null);
+  }, [files, selectedFile]);
 
   useEffect(() => {
     const name = selectedFile?.name ?? '';
@@ -3960,6 +4160,9 @@ export default function WorkspacePage() {
 
     if (chunk.type === 'tool_end') {
       updateMessageMetadataAtIndex(conversationId, agentMessageIndex, markStreamingState);
+      if (chunk.dashboardArtifact) {
+        mergeDashboardArtifact(chunk.dashboardArtifact);
+      }
       appendToolEnd(conversationId, agentMessageIndex, chunk);
       const streamLabel = chunk.name || 'tool';
       const streamRaw = chunk.content?.trim();
@@ -3993,6 +4196,11 @@ export default function WorkspacePage() {
               ? translatedErr.trim()
               : `${getFriendlyToolName(errLabel)} hit a snag—details are in the activity log.`,
       );
+      return;
+    }
+
+    if (chunk.type === 'dashboard_artifact') {
+      mergeDashboardArtifact(chunk.dashboardArtifact);
       return;
     }
 
@@ -4949,6 +5157,17 @@ export default function WorkspacePage() {
                 resumeInFlightRef.current.delete(activeRun.runId);
               });
           } else {
+            void persistAgentProgress(
+              { ...activeRun, status: status.status },
+              status.status,
+              {
+                metadataOverride: {
+                  pendingInterrupt: undefined,
+                },
+              },
+            ).catch((error) => {
+              console.error('Failed to persist settled run state', error);
+            });
             resumeInFlightRef.current.delete(activeRun.runId);
             const staleMessage = findAgentMessageForRun(
               activeRun.conversationId,
@@ -4988,6 +5207,17 @@ export default function WorkspacePage() {
         .catch((error) => {
           console.error('Failed to resume run status', error);
           resumeInFlightRef.current.delete(activeRun.runId);
+          void persistAgentProgress(
+            { ...activeRun, status: 'failed' },
+            'failed',
+            {
+              metadataOverride: {
+                pendingInterrupt: undefined,
+              },
+            },
+          ).catch((persistError) => {
+            console.error('Failed to persist stale run failure state', persistError);
+          });
           const staleMessage = findAgentMessageForRun(
             activeRun.conversationId,
             activeRun.placeholderId,
@@ -5014,6 +5244,7 @@ export default function WorkspacePage() {
     findAgentMessageForRun,
     getActiveRunForConversation,
     isAgentMessageEmpty,
+    persistAgentProgress,
     removeActiveRun,
     setConversationAttention,
     syncRunStateToConversation,
@@ -6363,8 +6594,10 @@ export default function WorkspacePage() {
                         files={visibleFiles}
                         colorMode={colorMode}
                         selectedFileId={selectedFile?.id || null}
+                        selectedDashboardPath={selectedDashboardPath}
                         selectedFiles={selectedFiles}
                         copiedPublicUrlFileId={copiedPublicUrlFileId}
+                        dashboardArtifactsByPath={dashboardArtifactsByPath}
                         ragStatuses={ragStatuses}
                         isDraftWorkspaceFile={isDraftWorkspaceFile}
                         onSelectFile={(file) => {
@@ -6373,6 +6606,7 @@ export default function WorkspacePage() {
                           setFileContent('');
                           setIsEditMode(shouldForceEditMode(file.name));
                         }}
+                        onSelectFolder={handleDashboardFolderSelect}
                         onToggleFileSelection={handleFileSelect}
                         onCopyPublicUrl={handleCopyFilePublicUrl}
                         onRenameFile={handleRenameFile}
@@ -6541,28 +6775,42 @@ export default function WorkspacePage() {
                         />
                       </Suspense>
                     ) : (
-                      <div className="h-full w-full overflow-y-auto overflow-x-hidden">
-                        <div
-                          className="h-full origin-top-left"
-                          style={{
-                            transform: `scale(${canvasZoom})`,
-                            width: `${100 / canvasZoom}%`,
-                            minHeight: `${100 / canvasZoom}%`,
-                          }}
-                        >
-                          <Suspense fallback={canvasLoadingFallback}>
-                            <UIBlockRenderer
-                              blocks={canvasBlocks}
-                              workspaceId={selectedWorkspace?.id}
-                              className="h-full w-full"
-                              emptyState={
-                                <div className={`text-center ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
-                                  <p>Select a file to view its content</p>
-                                </div>
-                              }
+                      <div className={isDashboardCanvas ? 'flex h-full w-full min-h-0 flex-col overflow-hidden' : 'h-full w-full overflow-y-auto overflow-x-hidden'}>
+                        {isDashboardCanvas ? (
+                          selectedWorkspace && resolvedDashboardFolder ? (
+                            <DashboardCanvas
+                              workspaceId={selectedWorkspace.id}
+                              dashboardPath={resolvedDashboardFolder}
+                              onDownloadHtmlExport={handleDownloadDashboardHtmlExport}
                             />
-                          </Suspense>
-                        </div>
+                          ) : (
+                            <div className="flex h-full items-center justify-center bg-white text-sm text-slate-500">
+                              Opening dashboard…
+                            </div>
+                          )
+                        ) : (
+                          <div
+                            className="h-full origin-top-left"
+                            style={{
+                              transform: `scale(${canvasZoom})`,
+                              width: `${100 / canvasZoom}%`,
+                              minHeight: `${100 / canvasZoom}%`,
+                            }}
+                          >
+                            <Suspense fallback={canvasLoadingFallback}>
+                              <UIBlockRenderer
+                                blocks={canvasBlocks}
+                                workspaceId={selectedWorkspace?.id}
+                                className="h-full w-full"
+                                emptyState={
+                                  <div className={`text-center ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
+                                    <p>Select a file to view its content</p>
+                                  </div>
+                                }
+                              />
+                            </Suspense>
+                          </div>
+                        )}
                       </div>
                     )}
                   </div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,15 @@ import react from '@vitejs/plugin-react-swc'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: false,
+        ws: true,
+      },
+    },
+  },
   css: {
     postcss: './postcss.config.js',
   },

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -237,7 +237,7 @@ services:
       - "3000:3000"
     volumes:
       - workspace_data:/app/workspaces
-      - skills_data:/app/skills
+      - ../skills:/app/skills:ro
       - ../agent/config:/agent/config
 
   agent:
@@ -271,8 +271,8 @@ services:
       - "8001:8001"
     volumes:
       - workspace_data:/app/workspaces
-      - skills_data:/app/skills
-      - skills_data:/skills
+      - ../skills:/app/skills:ro
+      - ../skills:/skills:ro
       - ../agent/config:/agent/config
 
   frontend:
@@ -296,4 +296,3 @@ volumes:
   clickhouse_data:
   clickhouse_logs:
   workspace_data:
-  skills_data:

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     "./types": "./src/types.ts",
-    "./services/agentStream": "./src/services/agentStream.ts"
+    "./services/agentStream": "./src/services/agentStream.ts",
+    "./dashboard": "./src/dashboard/index.ts"
   }
 }

--- a/packages/shared/src/dashboard/aggregate.ts
+++ b/packages/shared/src/dashboard/aggregate.ts
@@ -1,0 +1,107 @@
+import type { ChartRuntimeDef, DashboardRow } from './types';
+
+function normText(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  return String(value);
+}
+
+function parseNumericValue(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+type AggBucket = {
+  x: unknown;
+  series: unknown;
+  count: number;
+  sum: number;
+  min: number | null;
+  max: number | null;
+  values: number[];
+  numeratorSum: number;
+  denominatorSum: number;
+};
+
+export function aggregateChartRows(rows: DashboardRow[], chartDef: ChartRuntimeDef): { x: unknown; y: number; series: unknown }[] {
+  const dimensionField = normText(chartDef.dimensionField || chartDef.xField);
+  const metricField = normText(chartDef.metricField || chartDef.yField);
+  const numeratorField = normText(chartDef.numeratorField);
+  const denominatorField = normText(chartDef.denominatorField);
+  const seriesField = normText(chartDef.seriesField);
+  const buckets = new Map<string, AggBucket>();
+
+  for (const row of rows) {
+    const xValue = dimensionField ? row[dimensionField] : '__all__';
+    const seriesValue = seriesField ? row[seriesField] : '__single__';
+    const key = `${JSON.stringify(xValue)}::${JSON.stringify(seriesValue)}`;
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = {
+        x: xValue,
+        series: seriesValue,
+        count: 0,
+        sum: 0,
+        min: null,
+        max: null,
+        values: [],
+        numeratorSum: 0,
+        denominatorSum: 0,
+      };
+      buckets.set(key, bucket);
+    }
+    bucket.count += 1;
+    const metricValue = metricField ? parseNumericValue(row[metricField]) : null;
+    const numeratorValue = numeratorField ? parseNumericValue(row[numeratorField]) : null;
+    const denominatorValue = denominatorField ? parseNumericValue(row[denominatorField]) : null;
+    if (metricValue !== null) {
+      bucket.sum += metricValue;
+      bucket.min = bucket.min === null ? metricValue : Math.min(bucket.min, metricValue);
+      bucket.max = bucket.max === null ? metricValue : Math.max(bucket.max, metricValue);
+      bucket.values.push(metricValue);
+    }
+    if (numeratorValue !== null) bucket.numeratorSum += numeratorValue;
+    if (denominatorValue !== null) bucket.denominatorSum += denominatorValue;
+  }
+
+  const aggregation = normText(chartDef.aggregation || 'count').toLowerCase();
+  const points: { x: unknown; y: number; series: unknown }[] = [];
+  for (const bucket of buckets.values()) {
+    let yValue: number;
+    if (aggregation === 'sum') {
+      yValue = bucket.sum;
+    } else if (aggregation === 'avg' || aggregation === 'mean') {
+      yValue = bucket.values.length ? bucket.sum / bucket.values.length : 0;
+    } else if (aggregation === 'min') {
+      yValue = bucket.min === null ? 0 : bucket.min;
+    } else if (aggregation === 'max') {
+      yValue = bucket.max === null ? 0 : bucket.max;
+    } else if (aggregation === 'nunique' || aggregation === 'count_distinct') {
+      yValue = new Set(bucket.values).size;
+    } else if (aggregation === 'ratio' || aggregation === 'rate') {
+      yValue = bucket.denominatorSum ? bucket.numeratorSum / bucket.denominatorSum : 0;
+    } else {
+      yValue = bucket.count;
+    }
+    points.push({ x: bucket.x, y: yValue, series: bucket.series });
+  }
+
+  const sortBy = normText(chartDef.sortBy || 'y').toLowerCase();
+  const sortDirection = normText(chartDef.sortDirection || 'desc').toLowerCase();
+  points.sort((a, b) => {
+    let cmp: number;
+    if (sortBy === 'x') {
+      const ax = a.x;
+      const bx = b.x;
+      if (typeof ax === 'number' && typeof bx === 'number') cmp = ax - bx;
+      else cmp = normText(ax).localeCompare(normText(bx), undefined, { numeric: true });
+    } else {
+      cmp = (Number(a.y) || 0) - (Number(b.y) || 0);
+    }
+    return sortDirection === 'asc' ? cmp : -cmp;
+  });
+
+  const limitRaw = chartDef.limit ?? 0;
+  const limit = Math.max(0, Number(limitRaw) || 0);
+  return limit ? points.slice(0, limit) : points;
+}

--- a/packages/shared/src/dashboard/filters.ts
+++ b/packages/shared/src/dashboard/filters.ts
@@ -1,0 +1,127 @@
+import type { DashboardFilterDef, DashboardRow, DatasetSchemaColumn, FilterValues } from './types';
+
+function normText(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  return String(value);
+}
+
+function schemaTypeMap(schema: DatasetSchemaColumn[]): Record<string, string> {
+  const m: Record<string, string> = {};
+  for (const col of schema) {
+    const name = normText(col.name).trim();
+    if (name) m[name] = normText(col.type).toLowerCase();
+  }
+  return m;
+}
+
+export function inferFieldType(filterDef: DashboardFilterDef, datasetSchema: DatasetSchemaColumn[]): string {
+  const declared = normText(filterDef.type).toLowerCase();
+  if (declared === 'numeric' || declared === 'date' || declared === 'datetime') {
+    return declared === 'datetime' ? 'date' : declared;
+  }
+  const field = normText(filterDef.field).trim();
+  const raw = schemaTypeMap(datasetSchema)[field] || '';
+  if (raw.includes('date') || raw.includes('time')) return 'date';
+  if (/(int|float|double|decimal|real|numeric)/.test(raw)) return 'numeric';
+  return 'categorical';
+}
+
+function parseDateValue(value: unknown): Date | null {
+  if (value === null || value === undefined || value === '') return null;
+  const d = new Date(String(value).replace('Z', '+00:00'));
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function parseNumericValue(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function normalizeComparable(value: unknown, fieldType: string): number | string | null {
+  if (fieldType === 'date') {
+    const d = parseDateValue(value);
+    return d ? d.getTime() / 1000 : null;
+  }
+  if (fieldType === 'numeric') {
+    return parseNumericValue(value);
+  }
+  return normText(value);
+}
+
+function rowMatchesFilter(
+  row: DashboardRow,
+  filterDef: DashboardFilterDef,
+  filterValue: unknown,
+  datasetSchema: DatasetSchemaColumn[],
+): boolean {
+  const field = normText(filterDef.field).trim();
+  const fieldType = inferFieldType(filterDef, datasetSchema);
+  const rowValue = row[field];
+
+  if (fieldType === 'categorical') {
+    const values = Array.isArray(filterValue)
+      ? filterValue.map((v) => normText(v))
+      : filterValue === null || filterValue === undefined || filterValue === ''
+        ? []
+        : [normText(filterValue)];
+    if (values.length === 0) return true;
+    const set = new Set(values);
+    return set.has(normText(rowValue));
+  }
+
+  if (fieldType === 'date') {
+    const rowTime = normalizeComparable(rowValue, 'date');
+    if (rowTime === null) return false;
+    const payload =
+      filterValue && typeof filterValue === 'object' && !Array.isArray(filterValue)
+        ? (filterValue as Record<string, unknown>)
+        : {};
+    const start = parseDateValue(payload.start);
+    const end = parseDateValue(payload.end);
+    const t = rowTime as number;
+    if (start && t < start.getTime() / 1000) return false;
+    if (end && t > end.getTime() / 1000) return false;
+    return true;
+  }
+
+  const numericValue = normalizeComparable(rowValue, 'numeric') as number | null;
+  if (numericValue === null) return false;
+  const payload =
+    filterValue && typeof filterValue === 'object' && !Array.isArray(filterValue)
+      ? (filterValue as Record<string, unknown>)
+      : {};
+  const min = parseNumericValue(payload.min);
+  const max = parseNumericValue(payload.max);
+  if (min !== null && numericValue < min) return false;
+  if (max !== null && numericValue > max) return false;
+  return true;
+}
+
+export function applyDashboardFilters(
+  rows: DashboardRow[],
+  filters: DashboardFilterDef[],
+  filterValues: FilterValues,
+  datasetSchema: DatasetSchemaColumn[],
+): DashboardRow[] {
+  if (!rows.length || !filters.length) return rows;
+  return rows.filter((row) =>
+    filters.every((def) =>
+      rowMatchesFilter(row, def, filterValues[normText(def.id).trim() || def.field], datasetSchema),
+    ),
+  );
+}
+
+export function distinctFieldValues(rows: DashboardRow[], field: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const row of rows) {
+    const v = row[field];
+    if (v === null || v === undefined || v === '') continue;
+    const s = String(v);
+    if (seen.has(s)) continue;
+    seen.add(s);
+    out.push(s);
+  }
+  return out.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+}

--- a/packages/shared/src/dashboard/index.ts
+++ b/packages/shared/src/dashboard/index.ts
@@ -1,0 +1,10 @@
+export type {
+  ChartRuntimeDef,
+  DashboardFilterDef,
+  DashboardRow,
+  DatasetSchemaColumn,
+  FilterValues,
+} from './types';
+export { applyDashboardFilters, inferFieldType, distinctFieldValues } from './filters';
+export { aggregateChartRows } from './aggregate';
+export { buildPlotlyPayload } from './plotly';

--- a/packages/shared/src/dashboard/plotly.ts
+++ b/packages/shared/src/dashboard/plotly.ts
@@ -1,0 +1,117 @@
+import { aggregateChartRows } from './aggregate';
+import type { ChartRuntimeDef, DashboardRow } from './types';
+
+function normText(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  return String(value);
+}
+
+export function buildPlotlyPayload(rows: DashboardRow[], chartDef: ChartRuntimeDef): {
+  data: Record<string, unknown>[];
+  layout: Record<string, unknown>;
+  config: Record<string, unknown>;
+} {
+  const grouped = aggregateChartRows(rows, chartDef);
+  const chartType = normText(chartDef.chartType || 'bar').toLowerCase();
+  const dimensionField = normText(chartDef.dimensionField || chartDef.xField);
+  const metricField = normText(chartDef.metricField || chartDef.yField || chartDef.aggregation);
+  const labels = {
+    x: normText(chartDef.labels?.x || chartDef.xTitle),
+    y: normText(chartDef.labels?.y || chartDef.yTitle),
+    title: normText(chartDef.labels?.title || chartDef.title),
+  };
+  const seriesValues = grouped.map((p) => p.series);
+  const uniqueSeries = [...new Map(seriesValues.map((s) => [JSON.stringify(s), s])).values()];
+
+  const traces: Record<string, unknown>[] = [];
+  for (const seriesKey of uniqueSeries.length ? uniqueSeries : ['__single__']) {
+    const points = grouped.filter((item) => item.series === seriesKey);
+    const traceName =
+      seriesKey === '__single__' ? labels.title || normText(chartDef.title) : normText(seriesKey);
+
+    if (chartType === 'pie') {
+      traces.push({
+        type: 'pie',
+        name: labels.title || normText(chartDef.title),
+        labels: points.map((p) => p.x),
+        values: points.map((p) => p.y),
+        hole: 0.48,
+      });
+      break;
+    }
+
+    let trace: Record<string, unknown> = {
+      type: chartType === 'line' || chartType === 'area' ? 'scatter' : chartType,
+      name: traceName,
+      x: points.map((p) => p.x),
+      y: points.map((p) => p.y),
+    };
+
+    if (chartType === 'line' || chartType === 'area') {
+      trace.mode = normText(chartDef.mode || 'lines+markers');
+      if (chartType === 'area') trace.fill = 'tozeroy';
+    }
+    if (chartType === 'scatter') {
+      trace.mode = normText(chartDef.mode || 'markers');
+    }
+    if (chartType === 'bar' && normText(chartDef.orientation).toLowerCase() === 'h') {
+      trace = {
+        ...trace,
+        type: 'bar',
+        orientation: 'h',
+        x: points.map((p) => p.y),
+        y: points.map((p) => p.x),
+      };
+    }
+    traces.push(trace);
+  }
+
+  const valueFormat = normText(chartDef.format).toLowerCase();
+  let tickformat: string | undefined;
+  if (valueFormat === 'percent' || valueFormat === 'percentage' || valueFormat === 'pct') {
+    tickformat = '.1%';
+  } else if (valueFormat === 'currency' || valueFormat === 'usd') {
+    tickformat = '$,.0f';
+  }
+
+  const layoutSpan = normText(chartDef.layoutSpan || 'half').toLowerCase();
+  const isPie = chartType === 'pie';
+  const isHorizontalBar = chartType === 'bar' && normText(chartDef.orientation).toLowerCase() === 'h';
+
+  const layout: Record<string, unknown> = {
+    title: '',
+    template: 'plotly_white',
+    paper_bgcolor: 'rgba(0,0,0,0)',
+    plot_bgcolor: 'rgba(0,0,0,0)',
+    margin: { t: 18, r: 24, b: 56, l: 56 },
+    height: layoutSpan === 'wide' ? 430 : 360,
+    font: { family: 'Avenir Next, Segoe UI, sans-serif', color: '#0f172a' },
+    legend: { orientation: 'h', y: -0.18, font: { size: 11 } },
+  };
+
+  if (!isPie) {
+    layout.xaxis = {
+      title:
+        labels.x ||
+        (isHorizontalBar ? metricField : dimensionField),
+      gridcolor: '#e2e8f0',
+      tickfont: { size: 12, color: '#475569' },
+      titlefont: { size: 12, color: '#475569' },
+    };
+    layout.yaxis = {
+      title:
+        labels.y ||
+        (isHorizontalBar ? dimensionField : metricField),
+      gridcolor: '#e2e8f0',
+      tickfont: { size: 12, color: '#475569' },
+      titlefont: { size: 12, color: '#475569' },
+      ...(tickformat ? { tickformat } : {}),
+    };
+  }
+
+  return {
+    data: traces,
+    layout,
+    config: { displayModeBar: false, responsive: true },
+  };
+}

--- a/packages/shared/src/dashboard/types.ts
+++ b/packages/shared/src/dashboard/types.ts
@@ -1,0 +1,39 @@
+export type DashboardRow = Record<string, unknown>;
+
+export type DatasetSchemaColumn = { name: string; type: string };
+
+export type DashboardFilterDef = {
+  id: string;
+  field: string;
+  type: string;
+  label?: string;
+  multi?: boolean;
+};
+
+/** Executable chart instructions emitted by the agent (dashboard.spec.json chartRuntimeDefs). */
+export type ChartRuntimeDef = {
+  chartId?: string;
+  chartIndex?: number;
+  chartType?: string;
+  dimensionField?: string;
+  metricField?: string;
+  numeratorField?: string;
+  denominatorField?: string;
+  xField?: string;
+  yField?: string;
+  seriesField?: string;
+  aggregation?: string;
+  orientation?: string;
+  sortBy?: string;
+  sortDirection?: string;
+  limit?: number;
+  mode?: string;
+  xTitle?: string;
+  yTitle?: string;
+  title?: string;
+  format?: string;
+  layoutSpan?: string;
+  labels?: { x?: string; y?: string; title?: string };
+};
+
+export type FilterValues = Record<string, unknown>;

--- a/packages/shared/src/services/agentStream.ts
+++ b/packages/shared/src/services/agentStream.ts
@@ -1,3 +1,5 @@
+import type { DashboardArtifactInfo } from '../types';
+
 export type AgentStreamChunk =
   | { type: 'token' | 'chunk'; content?: string; role?: string }
   | { type: 'thought'; content?: string; role?: string }
@@ -11,8 +13,15 @@ export type AgentStreamChunk =
       prePlanSearchUsed?: number;
     }
   | { type: 'tool_start'; content?: string; name?: string }
-  | { type: 'tool_end'; content?: string; name?: string; outputFiles?: Array<{ path: string; mimeType?: string | null; size?: number }> }
+  | {
+      type: 'tool_end';
+      content?: string;
+      name?: string;
+      outputFiles?: Array<{ path: string; mimeType?: string | null; size?: number }>;
+      dashboardArtifact?: DashboardArtifactInfo;
+    }
   | { type: 'tool_error'; content?: string; name?: string }
+  | { type: 'dashboard_artifact'; dashboardArtifact: DashboardArtifactInfo }
   | {
       type: 'interrupt';
       interruptId?: string;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -97,6 +97,15 @@ export interface ToolOutputFile {
   size?: number;
 }
 
+/** Stream event + durable dashboard package; no TTL or live URL. */
+export interface DashboardArtifactInfo {
+  dashboardPath: string;
+  workspaceId?: string;
+  dashboardId?: string;
+  title?: string;
+  status: 'generating' | 'ready' | 'error';
+}
+
 export interface InterruptChoice {
   id: string;
   label: string;

--- a/skills/data/SKILL.md
+++ b/skills/data/SKILL.md
@@ -3,13 +3,12 @@ name: data
 description: >
   Data analysis skill hub. Routes to the right specialist subskill depending on the
   request — exploration, query writing, end-to-end analysis, visualization, validation,
-  interactive dashboard assembly, or recurring snapshot refresh.
+  dashboard planning plus assembly, or recurring snapshot refresh.
 tools:
   - data_agent_tools
   - get_table_schema
   - run_sql_query
   - materialize_bigquery_to_parquet
-  - generate_chart_config
   - generate_summary
   - generate_dashboard
 mcp_servers:
@@ -45,11 +44,14 @@ Choose the right data connector for the source:
   system of record and DuckDB over workspace snapshots as the local serving layer.
 - **Local files (CSV / Parquet in the workspace)** — use `data_agent_tools`.
   Available tools: `get_table_schema`, `run_sql_query`,
-  `materialize_bigquery_to_parquet`, `generate_chart_config`, `generate_summary`,
+  `materialize_bigquery_to_parquet`, `generate_summary`,
   `generate_dashboard`.
 - **Recurring dashboards / canned reports** — use `data/refresh` to publish a stable
   snapshot such as `datasets/<slug>/latest.parquet`, optionally mirror it to CSV, and
   regenerate a stable HTML artifact in `dashboards/` or `reports/`.
+- **Dashboard creation** — `data/dashboard` is review-first. It should inspect the tagged
+  dataset/report context, propose a dashboard plan, wait for approval, then generate the
+  dashboard package.
 - **Do not attempt cross-source SQL joins in v1.** Orchestrate at the workflow level
   (query each source separately; combine in Python / summary prose).
 
@@ -62,3 +64,6 @@ Choose the right data connector for the source:
 - One `generate_summary` OR one `generate_dashboard` per run.
 - Reports and dashboards only include artifacts from the **current run** — never
   from prior runs.
+- Dashboard requests should prefer a tagged dataset artifact as the source of truth and
+  avoid fresh warehouse rediscovery unless the tagged inputs are unusable.
+- In `data/dashboard`, prefer structured chart bindings over `generate_chart_config` on the main path.

--- a/skills/data/dashboard/SKILL.md
+++ b/skills/data/dashboard/SKILL.md
@@ -1,22 +1,32 @@
 ---
 name: data/dashboard
 description: >
-  Assemble all charts and query results from the current analysis run into a single
-  self-contained interactive HTML dashboard artifact.
+  Plan, review, and then assemble a stakeholder-ready dashboard package from the
+  current analysis run, with a live dashboard session plus snapshot fallback.
+requires_hitl_plan: true
 tools:
   - data_agent_tools
   - get_table_schema
   - run_sql_query
   - materialize_bigquery_to_parquet
-  - generate_chart_config
   - generate_summary
   - generate_dashboard
+  - request_plan_approval
+  - request_clarification
 ---
 
-# data/dashboard — Build an Interactive HTML Dashboard
+# data/dashboard — Plan and Build a Dashboard Package
 
-Produce one portable, self-contained HTML file that embeds all charts and queries
-from the current run. No external dependencies — everything inlined.
+This skill is review-first and low-variance. Before any dashboard package is generated, you must:
+1. inspect the tagged dataset/report context
+2. draft a concrete dashboard plan
+3. call `request_plan_approval`
+4. wait for approval or edits
+5. only then call `generate_dashboard`
+
+Produce one workspace-native dashboard package that can power:
+- a live dashboard session in the canvas
+- a snapshot fallback/export for sharing
 
 This skill is not a generic file bundler. Treat it as a presentation step:
 - Curate the strongest visuals from the current run.
@@ -31,7 +41,7 @@ charts into a single file.
 
 ## Prerequisites (enforced in code)
 - At least one SQL query must have been executed in this run.
-- At least one chart must have been generated in this run.
+- Prefer at least one usable chart or one reusable dataset already prepared in this run.
 - `generate_dashboard` can only be called **once per run**.
 
 ## Connector scope
@@ -99,12 +109,21 @@ If the report is large, extract only the minimum needed story elements:
 - chart titles or section headings
 - 2-4 key takeaways
 
-### 1. Ensure analysis is complete
-- All SQL queries for the dashboard should already be done.
-- All charts (`generate_chart_config`) should already be generated.
-- Do not start fresh analysis here unless a clearly missing visualization prevents a usable
-  dashboard. If the run only contains weak or redundant charts, first generate better charts
-  before calling `generate_dashboard`.
+### 1. Keep analysis bounded
+For tagged local parquet/csv dashboards, prefer a deterministic prep path over open-ended exploration.
+
+- Before approval:
+  - at most **1 schema inspection**
+  - at most **1 lightweight preview query**
+  - no aggregate analysis
+  - no chart generation
+- After approval:
+  - use a bounded chart-prep bundle for KPI summary, time trend, top country/device/category breakdowns, and optional driver table
+  - prefer one reusable aggregate pass over repeated dimension-specific queries
+  - produce **3-5 approved chart bindings max**
+
+Do not rediscover upstream tables or rerun exploratory profiling when the tagged local dataset is already sufficient.
+Do not use `generate_chart_config` on the happy path for `data/dashboard`; pass structured chart bindings directly to `generate_dashboard`.
 
 ### 2. Curate before assembling
 Before generating the dashboard, review the current run and be selective.
@@ -114,7 +133,7 @@ Before generating the dashboard, review the current run and be selective.
   "Top Categories" unless the title is rewritten to state the insight.
 - Do not include charts that merely restate the same ranking with a different dimension
   unless the contrast matters.
-- If a chart is visually weak, re-generate it first with better encoding and labeling.
+- If a chart is visually weak, revise the structured binding and labels before package generation.
 
 Use these chart-quality rules:
 - Match chart type to question:
@@ -129,8 +148,8 @@ Use these chart-quality rules:
   - Long category labels without horizontal orientation or truncation.
   - Chart titles that describe the dimension but not the takeaway.
 
-### 3. Plan the dashboard like an executive artifact
-Decide:
+### 3. Draft the dashboard plan before any generation
+Decide and write down:
 - **Dashboard title**: clear, stakeholder-facing heading.
 - **Description**: one paragraph explaining what this dashboard shows and why it matters.
 - **Section titles**: one heading per included chart. Write insight-led titles, not file names.
@@ -140,11 +159,48 @@ Decide:
   2. Main drivers and breakdowns
   3. Supporting detail or appendix
 
+Your plan must also include:
+- **Audience**: who this dashboard is for
+- **Business question**: the one question this dashboard must answer
+- **Decision questions**: 1-3 concrete decisions the dashboard should support
+- **Source of truth**: the tagged dataset path or canonical dataset artifact
+- **KPIs**: exact definitions, including weighted-rate logic where applicable
+- **Chart list**: 3-6 proposed visuals with purpose and chart type
+- **Layout template**: choose a constrained executive layout and freeze the chart lineup
+- **Risks / gaps**: anything that could make the dashboard misleading or low-value
+- **Fallback note**: whether the dashboard will be truly filter-aware or mostly snapshot/static
+
 The final dashboard should feel like:
 - An executive summary at the top
 - A curated set of visuals in the middle
 - Visible filter controls near the top of the page
 - Raw SQL and verbose technical detail demoted to an appendix
+
+### 3.1 Request plan approval (required)
+Before calling `generate_dashboard`, call `request_plan_approval`.
+
+Use:
+- `plan_title`: the proposed dashboard title
+- `plan_summary` or `plan_summary_markdown`: concise dashboard brief with:
+  - audience
+  - business question
+  - dataset source
+  - KPI definitions
+  - proposed chart set
+  - filter strategy
+  - narrative order
+  - known risks
+- `execution_checklist`: the concrete build steps you will take after approval
+- `plan_file_path`: `dashboard_plan.md`
+- `status_label`: `Review Dashboard Plan`
+- `risky_actions`: mention any risk of weak proxy metrics, static-only charts, or missing fields
+
+If the reviewer chooses:
+- `approve`: continue to generation
+- `edit`: revise the dashboard plan and call `request_plan_approval` again
+- `reject`: stop and do not generate the dashboard
+
+Do not call `generate_dashboard` before approval.
 
 ### 4. Write titles and copy that explain the insight
 Good section titles:
@@ -157,47 +213,58 @@ Weak section titles to avoid:
 - "Top Categories"
 - "Browser/Device Segmentation"
 
-### 5. Generate the dashboard
+### 5. Generate the dashboard package
 Call `generate_dashboard` with:
 - `title`: the dashboard heading.
 - `description`: the context paragraph.
+- `audience`: the primary audience for the dashboard.
+- `business_question`: the core business question.
+- `decision_questions`: 1-3 concrete questions/decisions the dashboard supports.
+- `layout_template`: the approved executive layout template.
+- `headline_takeaway`: optional hero takeaway.
+- `insights`: 2-4 concise executive takeaways.
+- `known_risks`: key caveats or proxy-metric risks.
+- `data_quality_notes`: normalization and data quality notes.
 - `section_titles`: ordered list of polished section headings, one per chart. Do not pass
   raw file names or generic placeholders.
-- `kpis` (optional): explicit KPI cards for the hero area.
+- `metric_cards` (optional): 2-3 explicit KPI cards for the hero area.
 - `dashboard_dataset_path` (optional but required for true shared data filters): a canonical
   Parquet/CSV/JSON dataset materialized for this run.
 - `filter_schema` (optional): structured filter definitions describing field, label, type,
   options, presets, and applicability.
 - `chart_bindings` (optional): per-chart bindings that map charts to dataset fields and
-  aggregations so they can re-render from filtered rows.
+  aggregations so both the live runtime and snapshot can render from the same spec.
+  Include `question_answered`, `why_it_matters`, and layout metadata on the main path.
 - `sections` (optional): named chart groups with `chart_indexes` to control narrative flow.
 - `chart_tags` (optional): tags aligned to chart order so controls can filter charts by theme
   or audience.
 
 The tool will:
-- Embed all charts produced in this run (Plotly JSON → interactive, PNG → static).
-- Embed all queries with their row counts in a technical appendix.
-- Write a single self-contained HTML file to `dashboards/<title>.html`.
-- Emit a `tool_artifacts` event so the frontend surfaces the file.
+- Build a dashboard package under `dashboards/<slug>/`.
+- Write:
+  - `dashboard.meta.json`
+  - `dashboard.spec.json`
+  - `dashboard.snapshot.html`
+- Register a live dashboard session when possible.
+- Emit workspace artifacts so the frontend surfaces the dashboard folder as one object.
 - Only include artifacts from the **current run** — prior-run charts are excluded.
 
 ### 6. Report to user
 After `generate_dashboard` returns:
-- Tell the user the dashboard path so they know where to open it.
+- Tell the user the dashboard folder path so they know what to open.
 - Summarize the story the dashboard tells, not just the file count.
 - Mention what was curated in or left out if that affected quality.
 - Mention any charts that could not be embedded (logged as warnings).
 
 ## Dashboard format
-The HTML output:
+The resulting dashboard package:
 - Should feel polished, editorial, and browser-ready.
 - Should use a light theme by default unless the user asked for dark mode.
 - Should present charts as cards with consistent spacing, hierarchy, and labeling.
-- Must include filter controls that update the view without reloading the page.
+- Must include filter controls when the dashboard is truly dataset-backed.
 - Should place technical SQL details in a lower-priority appendix, not at the top.
-- Plotly charts render interactively (pan, zoom, hover).
-- PNG charts are embedded as base64 (no external file dependencies).
-- No CDN dependency except `cdn.plot.ly` for Plotly runtime.
+- Should make it clear when the snapshot is read-only versus live/filter-aware.
+- Uses a shared Streamlit live runtime plus `dashboard.snapshot.html` fallback from the same `dashboard.spec.json`.
 
 ## Filter expectations
 Filtering is required for dashboards.
@@ -214,28 +281,16 @@ Filtering is required for dashboards.
   - provide `filter_schema` and `chart_bindings`
   - only charts with valid bindings should claim to be filter-aware
 - If the run only contains finished chart artifacts and no reusable underlying dataset:
-  - the dashboard may still be generated, but those charts should be treated as static appendix
-    content rather than pretending to support shared data filtering
+  - the dashboard may still be generated, but those charts should be treated as snapshot/static
+    appendix content rather than pretending to support shared data filtering
   - tell the user that richer cross-filtering requires embedding a canonical dataset or
     pre-aggregated tables instead of only chart outputs
 
-## Quality bar
-The generated dashboard is not acceptable if it looks like:
-- a raw notebook export
-- a query log with charts attached
-- generic default Plotly output with no visual system
-- a wall of similarly styled bar charts without narrative progression
-
-It is acceptable when:
-- the first screen communicates the main story quickly
-- the charts are visually distinct, readable, and ordered with intent
-- titles and descriptive copy explain why each visual matters
-- filters are obvious, responsive, and useful
-- technical details are available but visually de-emphasized
-
 ## Guardrails
+- Do not skip the approval checkpoint for this skill unless the workspace is explicitly in trusted mode.
 - Do not call `generate_summary` and `generate_dashboard` in the same run — pick one.
 - Do not blindly include every query and chart just because it exists.
 - Do not expose raw SQL as the main content of the page.
 - Do not accept generic section titles if you can rewrite them.
+- Do not pretend a snapshot-only dashboard is live or filter-aware.
 - The `dashboards/` directory is separate from `charts/` and `reports/`.

--- a/tests/test_agent_main.py
+++ b/tests/test_agent_main.py
@@ -795,6 +795,20 @@ def test_append_tagged_file_guidance_warns_for_html(client_with_stubs):
     assert "Do not read an entire report HTML" in guided
 
 
+def test_build_dashboard_runtime_guidance_prefers_tagged_local_dataset(client_with_stubs):
+    client_with_stubs
+
+    import helpudoc_agent.app as app_module
+
+    guidance = app_module._build_dashboard_runtime_guidance(
+        "Use /skill data/dashboard\n\nTagged files:\n- datasets/cancellations_6m_v2.parquet\n"
+    )
+
+    assert "Tagged local dataset(s): datasets/cancellations_6m_v2.parquet" in guidance
+    assert "Before request_plan_approval" in guidance
+    assert "Generate 3 to 5 approved charts only" in guidance
+
+
 def test_filter_rag_prefetchable_tagged_files_includes_html(client_with_stubs):
     client_with_stubs
 
@@ -894,3 +908,58 @@ def test_chat_stream_prefetches_tagged_html_with_scoped_keywords(client_with_stu
     assert runtime.workspace_state.context["tagged_rag_context"] == "Story chunk"
     assert messages[-1]["type"] == "done"
     assert source_tracker.updated_workspaces == [runtime.workspace_state]
+
+
+def test_skill_contract_endpoint_reports_loaded_dashboard_policy(monkeypatch, tmp_path):
+    module_names = [
+        "agent.main",
+        "helpudoc_agent.app",
+        "helpudoc_agent.graph",
+        "helpudoc_agent.tools_and_schemas",
+    ]
+    saved_modules = {name: sys.modules.pop(name, None) for name in module_names}
+    _install_dependency_stubs()
+
+    graph_stub = ModuleType("helpudoc_agent.graph")
+    graph_stub.AgentRegistry = RegistryStub
+    sys.modules["helpudoc_agent.graph"] = graph_stub
+
+    tools_stub = ModuleType("helpudoc_agent.tools_and_schemas")
+    tools_stub.ToolFactory = ToolFactoryStub
+    tools_stub.GeminiClientManager = GeminiClientManagerStub
+    sys.modules["helpudoc_agent.tools_and_schemas"] = tools_stub
+
+    import helpudoc_agent.app as app_module
+
+    class CustomSettings(SettingsStub):
+        backend = SimpleNamespace(
+            workspace_root=tmp_path / "workspaces",
+            skills_root=CURRENT_DIR / "skills",
+        )
+
+    monkeypatch.setattr(app_module, "load_settings", lambda *_args, **_kwargs: CustomSettings())
+    monkeypatch.setattr(app_module, "SourceTracker", SourceTrackerStub)
+    monkeypatch.setattr(app_module, "GeminiClientManager", GeminiClientManagerStub)
+    monkeypatch.setattr(app_module, "ToolFactory", ToolFactoryStub)
+    monkeypatch.setattr(app_module, "AgentRegistry", RegistryStub)
+    monkeypatch.setattr(app_module, "RagIndexWorker", RagIndexWorkerStub)
+
+    import agent.main as agent_main
+
+    client = TestClient(agent_main.app)
+    try:
+        response = client.get("/skills/data/dashboard/contract")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["skillId"] == "data/dashboard"
+        assert payload["requiresHitlPlan"] is True
+        assert "request_plan_approval" in payload["tools"]
+    finally:
+        client.close()
+        sys.modules.pop("helpudoc_agent.graph", None)
+        sys.modules.pop("helpudoc_agent.tools_and_schemas", None)
+        for name, module in saved_modules.items():
+            if module is not None:
+                sys.modules[name] = module
+            elif name not in ("helpudoc_agent.graph", "helpudoc_agent.tools_and_schemas"):
+                sys.modules.pop(name, None)

--- a/tests/test_data_skill_family.py
+++ b/tests/test_data_skill_family.py
@@ -10,6 +10,8 @@ Covers:
 from __future__ import annotations
 
 import json
+import threading
+import time
 import textwrap
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -573,6 +575,59 @@ class TestQueryBudgetEnforcement:
         assert mgr.session.query_history[0].sql == "SELECT 1 AS a"
         assert mgr.session.query_history[1].sql == "SELECT 2 AS b"
 
+    def test_run_query_serializes_shared_duckdb_connection(self, tmp_path: Path) -> None:
+        from agent.helpudoc_agent.data_agent_tools import DuckDBManager
+        from unittest.mock import MagicMock
+
+        ws = MagicMock()
+        ws.root_path = tmp_path
+        ws.context = {}
+        mgr = DuckDBManager(ws)
+        mgr.session.schema_inspected = True
+
+        state = {
+            "active": 0,
+            "max_active": 0,
+        }
+        state_lock = threading.Lock()
+
+        class FakeResult:
+            def df(self) -> pd.DataFrame:
+                return pd.DataFrame({"value": [1]})
+
+        class FakeConnection:
+            def execute(self, query: str) -> FakeResult:
+                with state_lock:
+                    state["active"] += 1
+                    state["max_active"] = max(state["max_active"], state["active"])
+                time.sleep(0.05)
+                with state_lock:
+                    state["active"] -= 1
+                return FakeResult()
+
+        mgr.con = FakeConnection()
+
+        errors: list[Exception] = []
+
+        def _run(sql: str) -> None:
+            try:
+                mgr.run_query(sql)
+            except Exception as exc:  # pragma: no cover - regression guard
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=_run, args=("SELECT 1 AS value",)),
+            threading.Thread(target=_run, args=("SELECT 2 AS value",)),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=2)
+
+        assert not errors
+        assert all(not thread.is_alive() for thread in threads)
+        assert state["max_active"] == 1
+
 
 class TestChartBudgetEnforcement:
     """Chart count is capped at MAX_CHART_COUNT."""
@@ -679,6 +734,221 @@ class TestRunScopedHistory:
         assert "charts/old_chart.plotly.json" not in run_chart_paths
 
 
+class TestStrictDashboardMode:
+    def _write_dashboard_dataset(self, tmp_path: Path) -> None:
+        datasets_dir = tmp_path / "datasets"
+        datasets_dir.mkdir(exist_ok=True)
+        pd.DataFrame(
+            {
+                "country": ["US", "US", "CA", "CA"],
+                "device_type": ["Mobile", "Desktop", "Mobile", "Desktop"],
+                "browser": ["Chrome", "Safari", "Chrome", "Firefox"],
+                "cancelled_orders": [10, 5, 7, 3],
+                "total_orders": [100, 50, 70, 30],
+            }
+        ).to_csv(datasets_dir / "cancellations_6m_v2.csv", index=False)
+
+    def test_dashboard_preapproval_blocks_aggregate_queries(self, tmp_path: Path) -> None:
+        from agent.helpudoc_agent.data_agent_tools import build_data_agent_tools
+
+        self._write_dashboard_dataset(tmp_path)
+        workspace = _build_workspace(tmp_path)
+        tools = {tool.name: tool for tool in build_data_agent_tools(workspace)}
+        workspace.context.update(
+            {
+                "active_skill": "data/dashboard",
+                "plan_approved": False,
+                "dashboard_mode": {
+                    "strictLocalDatasets": True,
+                    "taggedDatasetPaths": ["datasets/cancellations_6m_v2.csv"],
+                },
+            }
+        )
+
+        tools["get_table_schema"].invoke({"table_names": []})
+        result = tools["run_sql_query"].invoke(
+            {"sql_query": "SELECT country, COUNT(*) AS total_orders FROM cancellations_6m_v2 GROUP BY country"}
+        )
+
+        assert "Dashboard planning mode is active" in result
+        assert "Before approval" in result
+
+    def test_dashboard_preapproval_allows_single_preview_query(self, tmp_path: Path) -> None:
+        from agent.helpudoc_agent.data_agent_tools import build_data_agent_tools
+
+        self._write_dashboard_dataset(tmp_path)
+        workspace = _build_workspace(tmp_path)
+        tools = {tool.name: tool for tool in build_data_agent_tools(workspace)}
+        workspace.context.update(
+            {
+                "active_skill": "data/dashboard",
+                "plan_approved": False,
+                "dashboard_mode": {
+                    "strictLocalDatasets": True,
+                    "taggedDatasetPaths": ["datasets/cancellations_6m_v2.csv"],
+                },
+            }
+        )
+
+        tools["get_table_schema"].invoke({"table_names": []})
+        first = tools["run_sql_query"].invoke({"sql_query": "SELECT * FROM cancellations_6m_v2 LIMIT 5"})
+        second = tools["run_sql_query"].invoke({"sql_query": "SELECT * FROM cancellations_6m_v2 LIMIT 5"})
+
+        assert "Result shape:" in first
+        assert "preview query is allowed before approval" in second
+
+    def test_dashboard_duplicate_dimension_pass_is_blocked_after_approval(self, tmp_path: Path) -> None:
+        from agent.helpudoc_agent.data_agent_tools import build_data_agent_tools
+
+        self._write_dashboard_dataset(tmp_path)
+        workspace = _build_workspace(tmp_path)
+        tools = {tool.name: tool for tool in build_data_agent_tools(workspace)}
+        workspace.context.update(
+            {
+                "active_skill": "data/dashboard",
+                "plan_approved": True,
+                "dashboard_mode": {
+                    "strictLocalDatasets": True,
+                    "taggedDatasetPaths": ["datasets/cancellations_6m_v2.csv"],
+                },
+            }
+        )
+
+        tools["get_table_schema"].invoke({"table_names": []})
+        first = tools["run_sql_query"].invoke(
+            {"sql_query": "SELECT country, COUNT(*) AS total_orders FROM cancellations_6m_v2 GROUP BY country"}
+        )
+        second = tools["run_sql_query"].invoke(
+            {"sql_query": "SELECT country, SUM(cancelled_orders) AS cancelled_orders FROM cancellations_6m_v2 GROUP BY country"}
+        )
+
+        assert "Result shape:" in first
+        assert "Duplicate dashboard dimension pass blocked" in second
+
+    def test_dashboard_mode_blocks_chart_code_generation_happy_path(self, tmp_path: Path) -> None:
+        from agent.helpudoc_agent.data_agent_tools import build_data_agent_tools
+
+        self._write_dashboard_dataset(tmp_path)
+        workspace = _build_workspace(tmp_path)
+        tools = {tool.name: tool for tool in build_data_agent_tools(workspace)}
+        workspace.context.update(
+            {
+                "active_skill": "data/dashboard",
+                "plan_approved": True,
+                "dashboard_mode": {
+                    "strictLocalDatasets": True,
+                    "taggedDatasetPaths": ["datasets/cancellations_6m_v2.csv"],
+                },
+            }
+        )
+
+        tools["get_table_schema"].invoke({"table_names": []})
+        tools["run_sql_query"].invoke({"sql_query": "SELECT country, COUNT(*) AS cancellations FROM cancellations_6m_v2 GROUP BY country"})
+        result = tools["generate_chart_config"].invoke(
+            {
+                "chart_title": "Should_Be_Spec_Driven",
+                "python_code": "chart_config = {'data': [], 'layout': {}}",
+            }
+        )
+
+        assert "structured chart specs" in result
+
+    def test_dashboard_mode_requires_three_chart_bindings_before_package(self, tmp_path: Path) -> None:
+        from agent.helpudoc_agent.data_agent_tools import build_data_agent_tools
+
+        self._write_dashboard_dataset(tmp_path)
+        workspace = _build_workspace(tmp_path)
+        tools = {tool.name: tool for tool in build_data_agent_tools(workspace)}
+        workspace.context.update(
+            {
+                "active_skill": "data/dashboard",
+                "plan_approved": True,
+                "dashboard_mode": {
+                    "strictLocalDatasets": True,
+                    "taggedDatasetPaths": ["datasets/cancellations_6m_v2.csv"],
+                },
+            }
+        )
+
+        tools["get_table_schema"].invoke({"table_names": []})
+        tools["run_sql_query"].invoke({"sql_query": "SELECT 42 AS val"})
+
+        result = tools["generate_dashboard"].invoke(
+            {
+                "title": "Too Sparse",
+                "description": "Not enough charts yet.",
+                "dashboard_dataset_path": "datasets/cancellations_6m_v2.csv",
+                "chart_bindings": [
+                    {
+                        "chart_index": 1,
+                        "chart_type": "bar",
+                        "x_field": "country",
+                        "aggregation": "count",
+                        "title": "Only one approved chart",
+                    }
+                ],
+            }
+        )
+        assert "pass 3 to 5 approved chart bindings" in result
+
+    def test_dashboard_mode_requires_executive_spec_fields(self, tmp_path: Path) -> None:
+        from agent.helpudoc_agent.data_agent_tools import build_data_agent_tools
+
+        self._write_dashboard_dataset(tmp_path)
+        workspace = _build_workspace(tmp_path)
+        tools = {tool.name: tool for tool in build_data_agent_tools(workspace)}
+        workspace.context.update(
+            {
+                "active_skill": "data/dashboard",
+                "plan_approved": True,
+                "dashboard_mode": {
+                    "strictLocalDatasets": True,
+                    "taggedDatasetPaths": ["datasets/cancellations_6m_v2.csv"],
+                },
+            }
+        )
+
+        tools["get_table_schema"].invoke({"table_names": []})
+        tools["run_sql_query"].invoke({"sql_query": "SELECT 42 AS val"})
+        result = tools["generate_dashboard"].invoke(
+            {
+                "title": "Executive Dashboard",
+                "description": "Missing executive fields should be rejected.",
+                "dashboard_dataset_path": "datasets/cancellations_6m_v2.csv",
+                "chart_bindings": [
+                    {
+                        "chart_index": 1,
+                        "chart_type": "line",
+                        "dimension_field": "country",
+                        "aggregation": "count",
+                        "title": "Cancellation risk is highest in a few countries",
+                        "question_answered": "Where is risk concentrated?",
+                        "why_it_matters": "Country variance helps prioritize interventions.",
+                    },
+                    {
+                        "chart_index": 2,
+                        "chart_type": "bar",
+                        "dimension_field": "browser",
+                        "aggregation": "count",
+                        "title": "Browser friction concentrates cancellation pressure",
+                        "question_answered": "Which browser segments underperform?",
+                        "why_it_matters": "Browser-level friction may indicate UX or checkout issues.",
+                    },
+                    {
+                        "chart_index": 3,
+                        "chart_type": "bar",
+                        "dimension_field": "device_type",
+                        "aggregation": "count",
+                        "title": "Mobile journeys create a disproportionate share of cancellations",
+                        "question_answered": "Which device journeys create the most risk?",
+                        "why_it_matters": "Device context guides operational fixes.",
+                    },
+                ],
+            }
+        )
+        assert "audience is required" in result.lower()
+
+
 class TestDashboardTool:
     """generate_dashboard produces a single self-contained HTML artifact."""
 
@@ -713,9 +983,121 @@ class TestDashboardTool:
         })
         dashboards_dir = tmp_path / "dashboards"
         assert dashboards_dir.exists(), "dashboards/ dir should be created"
-        html_files = list(dashboards_dir.glob("*.html"))
-        assert len(html_files) == 1, f"Expected 1 dashboard HTML, got {html_files}"
-        assert "Dashboard saved to" in result or "dashboards/" in result
+        snapshot_path = dashboards_dir / "My_Dashboard" / "dashboard.snapshot.html"
+        spec_path = dashboards_dir / "My_Dashboard" / "dashboard.spec.json"
+        meta_path = dashboards_dir / "My_Dashboard" / "dashboard.meta.json"
+        assert snapshot_path.exists()
+        assert spec_path.exists()
+        assert meta_path.exists()
+        assert "Dashboard package saved to" in result or "dashboards/" in result
+
+    def test_strict_dashboard_writes_spec_v2_and_native_metadata(self, tmp_path: Path) -> None:
+        from agent.helpudoc_agent.data_agent_tools import build_data_agent_tools
+
+        datasets_dir = tmp_path / "datasets"
+        datasets_dir.mkdir(parents=True, exist_ok=True)
+        pd.DataFrame(
+            {
+                "week": ["2026-W01", "2026-W02", "2026-W03"],
+                "country": ["US", "CA", "US"],
+                "browser": ["Chrome", "Safari", "Chrome"],
+                "device_type": ["Mobile", "Desktop", "Mobile"],
+                "cancelled_orders": [10, 5, 11],
+                "total_orders": [100, 60, 110],
+            }
+        ).to_csv(datasets_dir / "cancellations.csv", index=False)
+
+        workspace = _build_workspace(tmp_path)
+        workspace.context.update(
+            {
+                "active_skill": "data/dashboard",
+                "plan_approved": True,
+                "dashboard_mode": {
+                    "strictLocalDatasets": True,
+                    "taggedDatasetPaths": ["datasets/cancellations.csv"],
+                },
+            }
+        )
+        tools = {tool.name: tool for tool in build_data_agent_tools(workspace)}
+        tools["get_table_schema"].invoke({"table_names": []})
+        tools["run_sql_query"].invoke({"sql_query": "SELECT 1 AS val"})
+        result = tools["generate_dashboard"].invoke(
+            {
+                "title": "Cancellation Drivers",
+                "description": "Executive dashboard for cancellation drivers.",
+                "audience": "Ops leadership",
+                "business_question": "Which segments drive the highest cancellation risk?",
+                "decision_questions": [
+                    "Where is cancellation risk rising over time?",
+                    "Which customer segments deserve intervention first?",
+                ],
+                "layout_template": "executive_driver_dashboard",
+                "headline_takeaway": "Cancellation risk is concentrated in a few segments.",
+                "insights": [
+                    "Weekly cancellation volume is rising.",
+                    "Browser and country concentration suggest prioritized fixes.",
+                ],
+                "known_risks": ["Dataset is a six-month snapshot."],
+                "data_quality_notes": ["Cancellation rate is weighted from totals, not average-of-averages."],
+                "metric_cards": [
+                    {"label": "Cancellation Rate", "value": "15.1%", "meta": "Weighted across all orders"},
+                    {"label": "Cancelled Orders", "value": "5,155", "meta": "Last 6 months"},
+                    {"label": "Highest-Risk Segment", "value": "Chrome / Mobile", "meta": "Largest contributor"},
+                ],
+                "dashboard_dataset_path": "datasets/cancellations.csv",
+                "chart_bindings": [
+                    {
+                        "chart_index": 1,
+                        "chart_type": "line",
+                        "dimension_field": "week",
+                        "metric_field": "cancelled_orders",
+                        "aggregation": "sum",
+                        "title": "Cancellation pressure is rising week over week",
+                        "question_answered": "Is cancellation volume rising over time?",
+                        "why_it_matters": "Leadership needs to know whether risk is improving or worsening.",
+                        "layout_span": "wide",
+                    },
+                    {
+                        "chart_index": 2,
+                        "chart_type": "bar",
+                        "dimension_field": "country",
+                        "metric_field": "cancelled_orders",
+                        "aggregation": "sum",
+                        "orientation": "h",
+                        "title": "A small group of countries drives the bulk of cancellations",
+                        "question_answered": "Which geographies contribute most to cancellations?",
+                        "why_it_matters": "Geographic concentration highlights where remediation should start.",
+                    },
+                    {
+                        "chart_index": 3,
+                        "chart_type": "bar",
+                        "dimension_field": "browser",
+                        "metric_field": "cancelled_orders",
+                        "aggregation": "sum",
+                        "title": "Browser friction appears concentrated in a few user journeys",
+                        "question_answered": "Which browser contexts need the most attention?",
+                        "why_it_matters": "Browser-level issues may map to UX or checkout defects.",
+                    },
+                ],
+            }
+        )
+
+        assert "Dashboard package saved to" in result
+        spec_path = tmp_path / "dashboards" / "Cancellation_Drivers" / "dashboard.spec.json"
+        meta_path = tmp_path / "dashboards" / "Cancellation_Drivers" / "dashboard.meta.json"
+        spec = json.loads(spec_path.read_text(encoding="utf-8"))
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert spec["version"] == 2
+        assert spec["runtimeKind"] == "native"
+        assert spec["dataset"].get("previewPath", "").endswith("data/dashboard.rows.json")
+        assert spec["dataset"].get("rowCount", 0) > 0
+        assert meta.get("runtimeKind") == "native"
+        assert spec["audience"] == "Ops leadership"
+        assert spec["businessQuestion"]
+        assert spec["decisionQuestions"]
+        assert spec["hero"]["headlineTakeaway"]
+        assert spec["layout"]["template"] == "executive_driver_dashboard"
+        assert meta["specVersion"] == 2
 
     def test_dashboard_html_is_self_contained(self, tmp_path: Path) -> None:
         tools = self._run_analysis_and_chart(tmp_path)
@@ -724,15 +1106,14 @@ class TestDashboardTool:
             "description": "No external deps.",
             "section_titles": [],
         })
-        html_files = list((tmp_path / "dashboards").glob("*.html"))
-        content = html_files[0].read_text(encoding="utf-8")
+        content = (tmp_path / "dashboards" / "Self_Contained" / "dashboard.snapshot.html").read_text(encoding="utf-8")
         # Should embed Plotly CDN and the chart spec inline
         assert "plotly" in content.lower()
         assert "<!doctype html>" in content.lower()
         # Should include query block  
         assert "42" in content  # the SELECT 42 result
-        assert "Quick Pulse" in content
-        assert "Charts Embedded" in content
+        assert "Executive Snapshot" in content
+        assert "Charts" in content
 
     def test_dashboard_accepts_section_titles(self, tmp_path: Path) -> None:
         tools = self._run_analysis_and_chart(tmp_path)
@@ -741,8 +1122,7 @@ class TestDashboardTool:
             "description": "Uses custom section headings.",
             "section_titles": ["Insight-Led Title"],
         })
-        html_files = list((tmp_path / "dashboards").glob("*.html"))
-        content = html_files[0].read_text(encoding="utf-8")
+        content = (tmp_path / "dashboards" / "Structured_Dashboard" / "dashboard.snapshot.html").read_text(encoding="utf-8")
         assert "Insight-Led Title" in content
 
     def test_dashboard_requires_at_least_one_query(self, tmp_path: Path) -> None:
@@ -855,8 +1235,7 @@ class TestDashboardTool:
             }
         )
 
-        html_files = list((tmp_path / "dashboards").glob("*.html"))
-        content = html_files[0].read_text(encoding="utf-8")
+        content = (tmp_path / "dashboards" / "Order_Cancellation_Dashboard" / "dashboard.snapshot.html").read_text(encoding="utf-8")
         assert "Shared data filters" in content
         assert "dashboard-filter-controls" in content
         assert "filter-panel-summary" in content
@@ -889,8 +1268,7 @@ class TestDashboardTool:
                 "dashboard_dataset_path": "datasets/orders.csv",
             }
         )
-        html_files = list((tmp_path / "dashboards").glob("*.html"))
-        content = html_files[0].read_text(encoding="utf-8")
+        content = (tmp_path / "dashboards" / "No_Filters_Dashboard" / "dashboard.snapshot.html").read_text(encoding="utf-8")
         assert "Shared data filters" not in content
 
     def test_dashboard_serializes_date_filter_dataset_values(self, tmp_path: Path) -> None:
@@ -940,7 +1318,7 @@ class TestDashboardTool:
                 ],
             }
         )
-        assert "Dashboard saved to:" in result
+        assert "Dashboard package saved to:" in result
 
     def test_dashboard_failure_does_not_consume_single_dashboard_budget(self, tmp_path: Path, monkeypatch) -> None:
         tools = _tools_for_workspace(tmp_path)
@@ -985,7 +1363,7 @@ class TestDashboardTool:
                 "section_titles": [],
             }
         )
-        assert "Dashboard saved to:" in second
+        assert "Dashboard package saved to:" in second
 
     def test_generate_chart_config_persists_plotly_json_only_by_default(self, tmp_path: Path) -> None:
         tools = _tools_for_workspace(tmp_path)
@@ -1309,7 +1687,7 @@ class TestStableArtifactOutputs:
             }
         )
 
-        dashboard_path = tmp_path / "dashboards" / "orders.html"
+        dashboard_path = tmp_path / "dashboards" / "orders" / "dashboard.snapshot.html"
         content = dashboard_path.read_text(encoding="utf-8")
         assert dashboard_path.exists()
         assert "Second description" in content

--- a/tests/test_hitl_plan_approval_config.py
+++ b/tests/test_hitl_plan_approval_config.py
@@ -48,3 +48,11 @@ def test_research_skill_declares_its_own_artifact_contract() -> None:
         "/final-research-report.md",
         "pattern:/0[1-9]_*.md",
     ]
+
+
+def test_dashboard_skill_requires_hitl_plan() -> None:
+    skills = {skill.skill_id: skill for skill in load_skills(Path("skills"))}
+    dashboard = skills["data/dashboard"]
+
+    assert dashboard.policy.requires_hitl_plan is True
+    assert "request_plan_approval" in dashboard.tools


### PR DESCRIPTION
## Summary
- Replace the Streamlit-backed dashboard runtime with a native HelpUDoc dashboard package flow.
- Generate durable dashboard artifacts (`dashboard.meta.json`, `dashboard.spec.json`, `dashboard.snapshot.html`, and preview rows) and emit `dashboard_artifact` events instead of in-memory sessions.
- Add a shared TypeScript dashboard engine plus native `DashboardCanvas` / `DashboardFilters` components to render filterable Plotly dashboards inside the workspace canvas.
- Remove the Streamlit/proxy/session plumbing and update the workspace file tree, docs, and packaging to match the new artifact model.

## Testing
- `npx tsc --noEmit` for the frontend passed.
- `npm test` for the backend passed.
- Updated agent and dashboard tests to cover the native artifact contract and dashboard package generation.
- `graphify update .` was run after the backend edit.