### PR TITLE
[codex] Rework GKE deploy CI and runtime asset seeding

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,10 @@
 # Local/runtime data (never needed for image builds)
 .minio-data
 .postgres-data
+.redis-data
+backend/workspaces
+agent/outputs
+graphify-out
 rag_storage
 
 # Python caches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master, main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend-test:
+    name: Backend tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci --legacy-peer-deps
+      - run: npm test
+
+  frontend:
+    name: Frontend lint and build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+
+  python-agent:
+    name: Python agent smoke and core tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: agent/requirements.txt
+      - name: Install agent dependencies
+        run: pip install -r agent/requirements.txt pytest
+      - name: Run agent tests
+        run: |
+          python -m pytest \
+            tests/test_agent_import_smoke.py \
+            tests/test_agent_configuration.py \
+            tests/test_mcp_binding.py \
+            tests/test_tool_factory.py
+
+  docker-backend:
+    name: Docker build (backend, no push)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - run: docker buildx build -f backend/Dockerfile.gke .
+
+  docker-frontend:
+    name: Docker build (frontend, no push)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - run: |
+          docker buildx build -f frontend/Dockerfile.gke \
+            --build-arg VITE_GOOGLE_CLIENT_ID=dummy \
+            --build-arg VITE_AUTH_MODE=hybrid \
+            .
+
+  docker-agent:
+    name: Docker build (agent, no push)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - run: docker buildx build -f agent/Dockerfile.gke --build-arg "GIT_COMMIT=${{ github.sha }}" .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Path filter
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      agent: ${{ steps.filter.outputs.agent }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'infra/gke/**'
+              - '.github/workflows/ci.yml'
+            frontend:
+              - 'frontend/**'
+              - 'packages/shared/**'
+              - '.github/workflows/ci.yml'
+            agent:
+              - 'agent/**'
+              - 'skills/**'
+              - 'tests/test_agent_*.py'
+              - '.github/workflows/ci.yml'
+
   backend-test:
     name: Backend tests
+    needs: [changes]
+    if: >
+      (github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'))
+      || needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -28,6 +61,10 @@ jobs:
 
   frontend:
     name: Frontend lint and build
+    needs: [changes]
+    if: >
+      (github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'))
+      || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -45,6 +82,10 @@ jobs:
 
   python-agent:
     name: Python agent smoke and core tests
+    needs: [changes]
+    if: >
+      (github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'))
+      || needs.changes.outputs.agent == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -64,30 +105,106 @@ jobs:
             tests/test_tool_factory.py
 
   docker-backend:
-    name: Docker build (backend, no push)
+    name: Docker build validation (backend)
+    needs: [changes]
+    if: >
+      (github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'))
+      || needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
-      - run: docker buildx build -f backend/Dockerfile.gke .
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/Dockerfile.gke
+          push: false
+          tags: helpudoc-backend:ci-${{ github.sha }}
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,scope=backend,mode=max
 
   docker-frontend:
-    name: Docker build (frontend, no push)
+    name: Docker build validation (frontend)
+    needs: [changes]
+    if: >
+      (github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'))
+      || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
-      - run: |
-          docker buildx build -f frontend/Dockerfile.gke \
-            --build-arg VITE_GOOGLE_CLIENT_ID=dummy \
-            --build-arg VITE_AUTH_MODE=hybrid \
-            .
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: frontend/Dockerfile.gke
+          push: false
+          tags: helpudoc-frontend:ci-${{ github.sha }}
+          build-args: |
+            VITE_GOOGLE_CLIENT_ID=dummy
+            VITE_AUTH_MODE=hybrid
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,scope=frontend,mode=max
 
   docker-agent:
-    name: Docker build (agent, no push)
+    name: Docker build validation (agent)
+    needs: [changes]
+    # Heavy image: validate on default-branch pushes only (avoids pip + full Docker agent
+    # install on every PR that touches agent/). PRs still get python-agent when agent paths change.
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
-      - run: docker buildx build -f agent/Dockerfile.gke --build-arg "GIT_COMMIT=${{ github.sha }}" .
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: agent/Dockerfile.gke
+          push: false
+          load: true
+          tags: helpudoc-agent:ci-smoke
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+          cache-from: type=gha,scope=agent
+          cache-to: type=gha,scope=agent,mode=max
+      - name: Smoke import inside loaded image
+        run: docker run --rm helpudoc-agent:ci-smoke python /app/agent/scripts/smoke_import.py
+
+  ci-gate:
+    name: CI status
+    needs:
+      - changes
+      - backend-test
+      - frontend
+      - python-agent
+      - docker-backend
+      - docker-frontend
+      - docker-agent
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any executed job failed
+        run: |
+          set -euo pipefail
+          fail=0
+          for name_result in \
+            "backend-test:${{ needs.backend-test.result }}" \
+            "frontend:${{ needs.frontend.result }}" \
+            "python-agent:${{ needs.python-agent.result }}" \
+            "docker-backend:${{ needs.docker-backend.result }}" \
+            "docker-frontend:${{ needs.docker-frontend.result }}" \
+            "docker-agent:${{ needs.docker-agent.result }}"; do
+            name="${name_result%%:*}"
+            result="${name_result#*:}"
+            case "$result" in
+              failure|cancelled)
+                echo "::error::Job $name ended with $result"
+                fail=1
+                ;;
+              success|skipped) ;;
+              *)
+                echo "::warning::Job $name unexpected result: $result"
+                ;;
+            esac
+          done
+          exit "$fail"

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -255,6 +255,12 @@ jobs:
   deploy:
     name: Deploy to GKE
     needs: [guard, build-backend, build-frontend, build-agent]
+    if: >
+      always()
+      && needs.guard.result == 'success'
+      && (needs.build-backend.result == 'success' || needs.build-backend.result == 'skipped')
+      && (needs.build-frontend.result == 'success' || needs.build-frontend.result == 'skipped')
+      && (needs.build-agent.result == 'success' || needs.build-agent.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -6,6 +6,35 @@ concurrency:
 
 on:
   workflow_dispatch:
+    inputs:
+      build_backend:
+        description: Build and push backend image
+        type: boolean
+        default: true
+      build_frontend:
+        description: Build and push frontend image
+        type: boolean
+        default: true
+      build_agent:
+        description: Build and push agent image
+        type: boolean
+        default: true
+      deploy_infra:
+        description: Apply manifests, RBAC checks, ConfigMap/Langfuse bootstrap (use sparingly)
+        type: boolean
+        default: false
+      sync_runtime_assets:
+        description: Legacy kubectl exec sync of skills/config to PVCs (prefer init-container seeding)
+        type: boolean
+        default: false
+      environment:
+        description: Optional label for operators (echo only; does not switch GitHub Environments)
+        type: string
+        default: ""
+      image_tag_suffix:
+        description: Optional suffix appended to commit SHA for image tags (e.g. -hotfix1)
+        type: string
+        default: ""
 
 env:
   PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
@@ -20,30 +49,31 @@ env:
   USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
 
 jobs:
-  build-images:
-    name: Build and Push ${{ matrix.component }} Image
+  guard:
+    name: Validate workflow inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require at least one component build
+        run: |
+          set -euo pipefail
+          if [[ "${{ inputs.build_backend }}" != "true" && "${{ inputs.build_frontend }}" != "true" && "${{ inputs.build_agent }}" != "true" ]]; then
+            echo "Select at least one of build_backend, build_frontend, or build_agent." >&2
+            exit 1
+          fi
+      - name: Echo operator environment label
+        if: ${{ inputs.environment != '' }}
+        run: 'echo "environment=${{ inputs.environment }}"'
+
+  build-backend:
+    name: Build and push backend
+    needs: [guard]
+    if: ${{ inputs.build_backend }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - component: backend
-            dockerfile: backend/Dockerfile.gke
-            image: helpudoc-backend
-          - component: frontend
-            dockerfile: frontend/Dockerfile.gke
-            image: helpudoc-frontend
-          - component: agent
-            dockerfile: agent/Dockerfile.gke
-            image: helpudoc-agent
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
+      - uses: actions/checkout@v4
       - name: Select Google auth mode
         id: auth_mode
         env:
@@ -52,87 +82,186 @@ jobs:
           CREDENTIALS_JSON: ${{ secrets.GCP_CREDENTIALS_JSON }}
         run: |
           set -euo pipefail
-
           has_wif=false
           has_json=false
-
-          if [[ -n "${WIF_PROVIDER}" && -n "${WIF_SERVICE_ACCOUNT}" ]]; then
-            has_wif=true
-          fi
-
-          if [[ -n "${CREDENTIALS_JSON}" ]]; then
-            has_json=true
-          fi
-
+          if [[ -n "${WIF_PROVIDER}" && -n "${WIF_SERVICE_ACCOUNT}" ]]; then has_wif=true; fi
+          if [[ -n "${CREDENTIALS_JSON}" ]]; then has_json=true; fi
           if [[ "${has_wif}" == "true" && "${has_json}" == "true" ]]; then
-            echo "Configure only one auth method: WIF (GCP_WORKLOAD_PROVIDER + GCP_SERVICE_ACCOUNT) OR GCP_CREDENTIALS_JSON." >&2
+            echo "Configure only one auth method: WIF OR GCP_CREDENTIALS_JSON." >&2
             exit 1
           fi
-
-          if [[ "${has_wif}" == "true" ]]; then
-            echo "mode=wif" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          if [[ "${has_json}" == "true" ]]; then
-            echo "mode=json" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          echo "Missing GCP auth secrets. Set either GCP_WORKLOAD_PROVIDER + GCP_SERVICE_ACCOUNT, or GCP_CREDENTIALS_JSON." >&2
+          if [[ "${has_wif}" == "true" ]]; then echo "mode=wif" >> "${GITHUB_OUTPUT}"; exit 0; fi
+          if [[ "${has_json}" == "true" ]]; then echo "mode=json" >> "${GITHUB_OUTPUT}"; exit 0; fi
+          echo "Missing GCP auth secrets." >&2
           exit 1
-
       - name: Authenticate to Google Cloud (Workload Identity)
         if: ${{ steps.auth_mode.outputs.mode == 'wif' }}
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-
       - name: Authenticate to Google Cloud (Service Account Key)
         if: ${{ steps.auth_mode.outputs.mode == 'json' }}
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
-
-      - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v2
-
+      - uses: google-github-actions/setup-gcloud@v2
+      - uses: docker/setup-buildx-action@v3
       - name: Configure Docker Auth
-        run: |
-          set -euo pipefail
-          gcloud auth configure-docker gcr.io --quiet
-
-      - name: Build and Push Image
+        run: gcloud auth configure-docker gcr.io --quiet
+      - name: Build and push backend
         env:
-          IMAGE_TAG: ${{ github.sha }}
-          COMPONENT: ${{ matrix.component }}
-          DOCKERFILE: ${{ matrix.dockerfile }}
-          IMAGE: ${{ matrix.image }}
+          IMAGE_TAG: ${{ format('{0}{1}', github.sha, inputs.image_tag_suffix) }}
         run: |
           set -euo pipefail
+          CACHE_REF="gcr.io/${PROJECT_ID}/helpudoc-buildcache-backend:buildcache"
+          docker buildx build \
+            -f backend/Dockerfile.gke \
+            --cache-from "type=registry,ref=${CACHE_REF}" \
+            --cache-to "type=registry,ref=${CACHE_REF},mode=max" \
+            -t "gcr.io/${PROJECT_ID}/helpudoc-backend:${IMAGE_TAG}" \
+            --push \
+            .
 
-          docker_args=()
-          if [[ "${COMPONENT}" == "frontend" ]]; then
-            docker_args+=(
-              --build-arg "VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID}"
-              --build-arg "VITE_AUTH_MODE=hybrid"
-            )
+  build-frontend:
+    name: Build and push frontend
+    needs: [guard]
+    if: ${{ inputs.build_frontend }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Google auth mode
+        id: auth_mode
+        env:
+          WIF_PROVIDER: ${{ secrets.GCP_WORKLOAD_PROVIDER }}
+          WIF_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          CREDENTIALS_JSON: ${{ secrets.GCP_CREDENTIALS_JSON }}
+        run: |
+          set -euo pipefail
+          has_wif=false
+          has_json=false
+          if [[ -n "${WIF_PROVIDER}" && -n "${WIF_SERVICE_ACCOUNT}" ]]; then has_wif=true; fi
+          if [[ -n "${CREDENTIALS_JSON}" ]]; then has_json=true; fi
+          if [[ "${has_wif}" == "true" && "${has_json}" == "true" ]]; then
+            echo "Configure only one auth method: WIF OR GCP_CREDENTIALS_JSON." >&2
+            exit 1
           fi
+          if [[ "${has_wif}" == "true" ]]; then echo "mode=wif" >> "${GITHUB_OUTPUT}"; exit 0; fi
+          if [[ "${has_json}" == "true" ]]; then echo "mode=json" >> "${GITHUB_OUTPUT}"; exit 0; fi
+          echo "Missing GCP auth secrets." >&2
+          exit 1
+      - name: Authenticate to Google Cloud (Workload Identity)
+        if: ${{ steps.auth_mode.outputs.mode == 'wif' }}
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - name: Authenticate to Google Cloud (Service Account Key)
+        if: ${{ steps.auth_mode.outputs.mode == 'json' }}
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
+      - uses: google-github-actions/setup-gcloud@v2
+      - uses: docker/setup-buildx-action@v3
+      - name: Configure Docker Auth
+        run: gcloud auth configure-docker gcr.io --quiet
+      - name: Build and push frontend
+        env:
+          IMAGE_TAG: ${{ format('{0}{1}', github.sha, inputs.image_tag_suffix) }}
+        run: |
+          set -euo pipefail
+          CACHE_REF="gcr.io/${PROJECT_ID}/helpudoc-buildcache-frontend:buildcache"
+          docker buildx build \
+            -f frontend/Dockerfile.gke \
+            --build-arg "VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID}" \
+            --build-arg "VITE_AUTH_MODE=hybrid" \
+            --cache-from "type=registry,ref=${CACHE_REF}" \
+            --cache-to "type=registry,ref=${CACHE_REF},mode=max" \
+            -t "gcr.io/${PROJECT_ID}/helpudoc-frontend:${IMAGE_TAG}" \
+            --push \
+            .
 
-          docker build -f "${DOCKERFILE}" "${docker_args[@]}" -t "gcr.io/${PROJECT_ID}/${IMAGE}:${IMAGE_TAG}" .
-          docker push "gcr.io/${PROJECT_ID}/${IMAGE}:${IMAGE_TAG}"
+  build-agent:
+    name: Build and push agent
+    needs: [guard]
+    if: ${{ inputs.build_agent }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Google auth mode
+        id: auth_mode
+        env:
+          WIF_PROVIDER: ${{ secrets.GCP_WORKLOAD_PROVIDER }}
+          WIF_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          CREDENTIALS_JSON: ${{ secrets.GCP_CREDENTIALS_JSON }}
+        run: |
+          set -euo pipefail
+          has_wif=false
+          has_json=false
+          if [[ -n "${WIF_PROVIDER}" && -n "${WIF_SERVICE_ACCOUNT}" ]]; then has_wif=true; fi
+          if [[ -n "${CREDENTIALS_JSON}" ]]; then has_json=true; fi
+          if [[ "${has_wif}" == "true" && "${has_json}" == "true" ]]; then
+            echo "Configure only one auth method: WIF OR GCP_CREDENTIALS_JSON." >&2
+            exit 1
+          fi
+          if [[ "${has_wif}" == "true" ]]; then echo "mode=wif" >> "${GITHUB_OUTPUT}"; exit 0; fi
+          if [[ "${has_json}" == "true" ]]; then echo "mode=json" >> "${GITHUB_OUTPUT}"; exit 0; fi
+          echo "Missing GCP auth secrets." >&2
+          exit 1
+      - name: Authenticate to Google Cloud (Workload Identity)
+        if: ${{ steps.auth_mode.outputs.mode == 'wif' }}
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - name: Authenticate to Google Cloud (Service Account Key)
+        if: ${{ steps.auth_mode.outputs.mode == 'json' }}
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
+      - uses: google-github-actions/setup-gcloud@v2
+      - uses: docker/setup-buildx-action@v3
+      - name: Configure Docker Auth
+        run: gcloud auth configure-docker gcr.io --quiet
+      - name: Build and push agent
+        env:
+          IMAGE_TAG: ${{ format('{0}{1}', github.sha, inputs.image_tag_suffix) }}
+        run: |
+          set -euo pipefail
+          CACHE_REF="gcr.io/${PROJECT_ID}/helpudoc-buildcache-agent:buildcache"
+          docker buildx build \
+            -f agent/Dockerfile.gke \
+            --build-arg "GIT_COMMIT=${IMAGE_TAG}" \
+            --cache-from "type=registry,ref=${CACHE_REF}" \
+            --cache-to "type=registry,ref=${CACHE_REF},mode=max" \
+            -t "gcr.io/${PROJECT_ID}/helpudoc-agent:${IMAGE_TAG}" \
+            --push \
+            .
+      - name: Agent image smoke import
+        env:
+          IMAGE_TAG: ${{ format('{0}{1}', github.sha, inputs.image_tag_suffix) }}
+        run: |
+          set -euo pipefail
+          docker pull "gcr.io/${PROJECT_ID}/helpudoc-agent:${IMAGE_TAG}"
+          docker run --rm "gcr.io/${PROJECT_ID}/helpudoc-agent:${IMAGE_TAG}" \
+            python /app/agent/scripts/smoke_import.py
 
   deploy:
-    needs: build-images
+    name: Deploy to GKE
+    needs: [guard, build-backend, build-frontend, build-agent]
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Select Google auth mode
         id: auth_mode
@@ -142,34 +271,17 @@ jobs:
           CREDENTIALS_JSON: ${{ secrets.GCP_CREDENTIALS_JSON }}
         run: |
           set -euo pipefail
-
           has_wif=false
           has_json=false
-
-          if [[ -n "${WIF_PROVIDER}" && -n "${WIF_SERVICE_ACCOUNT}" ]]; then
-            has_wif=true
-          fi
-
-          if [[ -n "${CREDENTIALS_JSON}" ]]; then
-            has_json=true
-          fi
-
+          if [[ -n "${WIF_PROVIDER}" && -n "${WIF_SERVICE_ACCOUNT}" ]]; then has_wif=true; fi
+          if [[ -n "${CREDENTIALS_JSON}" ]]; then has_json=true; fi
           if [[ "${has_wif}" == "true" && "${has_json}" == "true" ]]; then
-            echo "Configure only one auth method: WIF (GCP_WORKLOAD_PROVIDER + GCP_SERVICE_ACCOUNT) OR GCP_CREDENTIALS_JSON." >&2
+            echo "Configure only one auth method: WIF OR GCP_CREDENTIALS_JSON." >&2
             exit 1
           fi
-
-          if [[ "${has_wif}" == "true" ]]; then
-            echo "mode=wif" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          if [[ "${has_json}" == "true" ]]; then
-            echo "mode=json" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          echo "Missing GCP auth secrets. Set either GCP_WORKLOAD_PROVIDER + GCP_SERVICE_ACCOUNT, or GCP_CREDENTIALS_JSON." >&2
+          if [[ "${has_wif}" == "true" ]]; then echo "mode=wif" >> "${GITHUB_OUTPUT}"; exit 0; fi
+          if [[ "${has_json}" == "true" ]]; then echo "mode=json" >> "${GITHUB_OUTPUT}"; exit 0; fi
+          echo "Missing GCP auth secrets." >&2
           exit 1
 
       - name: Authenticate to Google Cloud (Workload Identity)
@@ -185,8 +297,7 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
 
-      - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           install_components: gke-gcloud-auth-plugin
 
@@ -202,10 +313,19 @@ jobs:
           set -euo pipefail
           gcloud container clusters get-credentials "${GKE_CLUSTER}" --location "${GKE_LOCATION}" --project "${PROJECT_ID}"
 
-      - name: Verify Kubernetes RBAC apply permissions
+      - name: Ensure helpudoc-config exists (app deploys only)
+        if: ${{ !inputs.deploy_infra }}
         run: |
           set -euo pipefail
+          if ! kubectl -n helpudoc get configmap helpudoc-config >/dev/null 2>&1; then
+            echo "helpudoc-config is missing. Run this workflow once with deploy_infra=true, or create the ConfigMap manually (see docs/deploy.md)." >&2
+            exit 1
+          fi
 
+      - name: Verify Kubernetes RBAC apply permissions
+        if: ${{ inputs.deploy_infra }}
+        run: |
+          set -euo pipefail
           missing=()
           for check in \
             "create roles.rbac.authorization.k8s.io" \
@@ -216,34 +336,32 @@ jobs:
               missing+=("${check}")
             fi
           done
-
           if (( ${#missing[@]} > 0 )); then
             echo "The active deploy identity cannot apply infra/gke/k8s/49-skill-sandbox.yaml." >&2
-            echo "Missing Kubernetes permissions:" >&2
             printf '  - %s\n' "${missing[@]}" >&2
-            echo "" >&2
-            echo "On GKE, grant the deploy service account IAM permissions that cover RBAC objects, such as roles/container.admin, or a custom role including container.roles.* and container.roleBindings.*." >&2
             exit 1
           fi
 
-      - name: Apply Kubernetes manifests (ConfigMap is bootstrap-only; see next step)
+      - name: Apply Kubernetes manifests
+        if: ${{ inputs.deploy_infra }}
         run: |
           set -euo pipefail
           kubectl -n helpudoc delete job helpudoc-minio-setup --ignore-not-found
           kubectl apply -f infra/gke/k8s/
 
       - name: Ensure helpudoc-config exists (first install only)
+        if: ${{ inputs.deploy_infra }}
         run: |
           set -euo pipefail
           if kubectl -n helpudoc get configmap helpudoc-config >/dev/null 2>&1; then
             echo "helpudoc-config already present; not applying demo ConfigMap."
             exit 0
           fi
-          echo "No helpudoc-config: applying infra/gke/bootstrap/20-configmap.demo.yaml (demo defaults)."
-          echo "For production, create the ConfigMap from env/prod/config.env instead (see infra/gke/README.md)."
+          echo "Applying infra/gke/bootstrap/20-configmap.demo.yaml"
           kubectl apply -f infra/gke/bootstrap/20-configmap.demo.yaml
 
       - name: Ensure Langfuse bootstrap config and secrets
+        if: ${{ inputs.deploy_infra }}
         env:
           CLICKHOUSE_PASSWORD_INPUT: ${{ secrets.CLICKHOUSE_PASSWORD }}
           LANGFUSE_NEXTAUTH_SECRET_INPUT: ${{ secrets.LANGFUSE_NEXTAUTH_SECRET }}
@@ -254,10 +372,8 @@ jobs:
           LANGFUSE_INIT_USER_PASSWORD_INPUT: ${{ secrets.LANGFUSE_INIT_USER_PASSWORD }}
         run: |
           set -euo pipefail
-
           kubectl -n helpudoc get configmap helpudoc-config >/dev/null
           kubectl -n helpudoc get secret helpudoc-secrets >/dev/null
-
           ensure_cm_key() {
             local key="$1"
             local value="$2"
@@ -267,7 +383,6 @@ jobs:
             kubectl -n helpudoc patch configmap helpudoc-config --type merge -p \
               "$(jq -n --arg key "${key}" --arg value "${value}" '{data:{($key):$value}}')"
           }
-
           ensure_secret_key() {
             local key="$1"
             local value="$2"
@@ -277,7 +392,6 @@ jobs:
             kubectl -n helpudoc patch secret helpudoc-secrets --type merge -p \
               "$(jq -n --arg key "${key}" --arg value "${value}" '{stringData:{($key):$value}}')"
           }
-
           ensure_cm_key LANGFUSE_NEXTAUTH_URL "https://langfuse.lc-demo.com"
           ensure_cm_key LANGFUSE_BASE_URL "http://langfuse-web"
           ensure_cm_key LANGFUSE_TRACING_ENABLED "true"
@@ -287,7 +401,6 @@ jobs:
           ensure_cm_key LANGFUSE_INIT_PROJECT_NAME "gke"
           ensure_cm_key LANGFUSE_INIT_USER_EMAIL "admin@local.com"
           ensure_cm_key LANGFUSE_INIT_USER_NAME "admin"
-
           clickhouse_secret="${CLICKHOUSE_PASSWORD_INPUT:-}"
           if [[ -z "${clickhouse_secret}" ]]; then
             clickhouse_secret="$(openssl rand -hex 24)"
@@ -301,6 +414,7 @@ jobs:
           ensure_secret_key LANGFUSE_INIT_USER_PASSWORD "${LANGFUSE_INIT_USER_PASSWORD_INPUT:-$(openssl rand -base64 24)}"
 
       - name: Bootstrap Langfuse database and wait for Langfuse
+        if: ${{ inputs.deploy_infra }}
         run: |
           set -euo pipefail
           chmod +x infra/gke/scripts/bootstrap-langfuse-db.sh
@@ -309,13 +423,11 @@ jobs:
       - name: Sync OAuth Config and Secrets
         run: |
           set -euo pipefail
-
           test -n "${GOOGLE_OAUTH_CLIENT_ID}"
           test -n "${GOOGLE_OAUTH_CLIENT_SECRET}"
           test -n "${GOOGLE_OAUTH_REDIRECT_URI}"
           test -n "${GOOGLE_OAUTH_POST_LOGIN_REDIRECT}"
           test -n "${OAUTH_TOKEN_ENCRYPTION_KEY}"
-
           kubectl -n helpudoc patch configmap helpudoc-config --type merge -p "$(jq -n \
             --arg auth_mode "hybrid" \
             --arg cid "${GOOGLE_OAUTH_CLIENT_ID}" \
@@ -324,32 +436,57 @@ jobs:
             --arg scopes "openid email profile https://www.googleapis.com/auth/bigquery https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/spreadsheets.readonly" \
             --arg domain ".lc-demo.com" \
             '{data:{AUTH_MODE:$auth_mode,GOOGLE_OAUTH_CLIENT_ID:$cid,GOOGLE_OAUTH_REDIRECT_URI:$redir,GOOGLE_OAUTH_POST_LOGIN_REDIRECT:$post,GOOGLE_OAUTH_SCOPES:$scopes,SESSION_COOKIE_DOMAIN:$domain}}')"
-
           kubectl -n helpudoc patch secret helpudoc-secrets --type merge -p "$(jq -n \
             --arg client_secret "${GOOGLE_OAUTH_CLIENT_SECRET}" \
             --arg enc_key "${OAUTH_TOKEN_ENCRYPTION_KEY}" \
             '{stringData:{GOOGLE_OAUTH_CLIENT_SECRET:$client_secret,OAUTH_TOKEN_ENCRYPTION_KEY:$enc_key}}')"
 
-      - name: Update Images
+      - name: Update workload images
         env:
-          IMAGE_TAG: ${{ github.sha }}
+          IMAGE_TAG: ${{ format('{0}{1}', github.sha, inputs.image_tag_suffix) }}
         run: |
           set -euo pipefail
-          kubectl -n helpudoc set image deployment/helpudoc-app \
-            backend="gcr.io/${PROJECT_ID}/helpudoc-backend:${IMAGE_TAG}" \
-            agent="gcr.io/${PROJECT_ID}/helpudoc-agent:${IMAGE_TAG}"
-          kubectl -n helpudoc set image deployment/helpudoc-frontend \
-            frontend="gcr.io/${PROJECT_ID}/helpudoc-frontend:${IMAGE_TAG}"
-          kubectl -n helpudoc set image cronjob/helpudoc-daily-reflection \
-            reflection-job="gcr.io/${PROJECT_ID}/helpudoc-backend:${IMAGE_TAG}"
+          TAG="${IMAGE_TAG}"
+          BACKEND_IMG="gcr.io/${PROJECT_ID}/helpudoc-backend:${TAG}"
+          FRONTEND_IMG="gcr.io/${PROJECT_ID}/helpudoc-frontend:${TAG}"
+          AGENT_IMG="gcr.io/${PROJECT_ID}/helpudoc-agent:${TAG}"
 
-      - name: Wait for Rollout
+          APP_ARGS=()
+          if [[ "${{ inputs.build_backend }}" == "true" ]]; then
+            APP_ARGS+=("backend=${BACKEND_IMG}")
+          fi
+          if [[ "${{ inputs.build_agent }}" == "true" ]]; then
+            APP_ARGS+=("agent=${AGENT_IMG}")
+          fi
+          if (( ${#APP_ARGS[@]} > 0 )); then
+            kubectl -n helpudoc set image deployment/helpudoc-app "${APP_ARGS[@]}"
+          fi
+
+          if [[ "${{ inputs.build_agent }}" == "true" ]]; then
+            kubectl -n helpudoc patch deployment helpudoc-app --type=json -p "$(jq -n \
+              --arg img "${AGENT_IMG}" \
+              '[{"op":"replace","path":"/spec/template/spec/initContainers/0/image","value":$img},
+                {"op":"replace","path":"/spec/template/spec/initContainers/1/image","value":$img}]')"
+          fi
+
+          if [[ "${{ inputs.build_frontend }}" == "true" ]]; then
+            kubectl -n helpudoc set image deployment/helpudoc-frontend \
+              frontend="${FRONTEND_IMG}"
+          fi
+
+          if [[ "${{ inputs.build_backend }}" == "true" ]]; then
+            kubectl -n helpudoc set image cronjob/helpudoc-daily-reflection \
+              reflection-job="${BACKEND_IMG}"
+          fi
+
+      - name: Wait for rollout
         run: |
           set -euo pipefail
           kubectl -n helpudoc rollout status deployment/helpudoc-app --timeout=20m
           kubectl -n helpudoc rollout status deployment/helpudoc-frontend --timeout=10m
 
-      - name: Sync Skills PVC
+      - name: Legacy sync Skills PVC (kubectl exec)
+        if: ${{ inputs.sync_runtime_assets }}
         run: |
           set -euo pipefail
           APP_POD="$(kubectl -n helpudoc get pods -l app=helpudoc-app -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.phase}{"\n"}{end}' | awk '$2 == "Running" {print $1; exit}')"
@@ -358,10 +495,24 @@ jobs:
           tar -C skills -cf - . | kubectl -n helpudoc exec -i "${APP_POD}" -c backend -- sh -lc "tar -xf - -C /app/skills"
           kubectl -n helpudoc exec "${APP_POD}" -c backend -- sh -lc "test -f /app/skills/research/SKILL.md"
 
-      - name: Sync Agent Config PVC
+      - name: Legacy sync Agent Config PVC (kubectl exec)
+        if: ${{ inputs.sync_runtime_assets }}
         run: |
           set -euo pipefail
           APP_POD="$(kubectl -n helpudoc get pods -l app=helpudoc-app -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.phase}{"\n"}{end}' | awk '$2 == "Running" {print $1; exit}')"
           test -n "${APP_POD}"
           kubectl -n helpudoc exec "${APP_POD}" -c backend -- sh -lc "mkdir -p /agent/config"
           kubectl -n helpudoc exec -i "${APP_POD}" -c backend -- sh -lc "cat > /agent/config/runtime.yaml" < agent/config/runtime.yaml
+
+      - name: Post-deploy smoke (in-cluster HTTP)
+        run: |
+          set -euo pipefail
+          POD="helpudoc-smoke-${{ github.run_id }}-${{ github.run_attempt }}"
+          kubectl -n helpudoc run "${POD}" --rm --restart=Never --image=curlimages/curl:8.5.0 -- \
+            sh -ec 'curl -fsS "http://backend.helpudoc.svc.cluster.local:3000/api/health"; curl -fsS "http://helpudoc-frontend.helpudoc.svc.cluster.local/" >/dev/null'
+
+      - name: Post-deploy smoke (agent sidecar)
+        run: |
+          set -euo pipefail
+          kubectl -n helpudoc exec deploy/helpudoc-app -c agent -- \
+            python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8001/health').read()"

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 FROM python:3.12-slim
 WORKDIR /app
 
@@ -20,9 +21,10 @@ RUN apt-get update \
 
 # Install deps before copying the rest so the layer caches across code changes.
 COPY agent/requirements.txt /app/agent/requirements.txt
-RUN PIP_INDEX_URL="${PYTORCH_CPU_INDEX_URL}" \
+RUN --mount=type=cache,target=/root/.cache/pip \
+  PIP_INDEX_URL="${PYTORCH_CPU_INDEX_URL}" \
   PIP_EXTRA_INDEX_URL="${PYPI_INDEX_URL}" \
-  pip install --no-cache-dir -r /app/agent/requirements.txt
+  pip install -r /app/agent/requirements.txt
 
 COPY agent/ /app/agent/
 COPY skills/ /app/skills/

--- a/agent/Dockerfile.gke
+++ b/agent/Dockerfile.gke
@@ -1,9 +1,11 @@
+# syntax=docker/dockerfile:1.7
 FROM python:3.12-slim
 
 WORKDIR /app/agent
 
 ARG PYTORCH_CPU_INDEX_URL=https://download.pytorch.org/whl/cpu
 ARG PYPI_INDEX_URL=https://pypi.org/simple
+ARG GIT_COMMIT=unknown
 
 # System libs required by mineru/opencv (paper2slides parser)
 RUN apt-get update \
@@ -23,9 +25,10 @@ RUN apt-get update \
 # Copy dependency manifest first so `pip install` layer caches across code/skills changes.
 COPY agent/requirements.txt /app/agent/requirements.txt
 
-RUN PIP_INDEX_URL="${PYTORCH_CPU_INDEX_URL}" \
+RUN --mount=type=cache,target=/root/.cache/pip \
+  PIP_INDEX_URL="${PYTORCH_CPU_INDEX_URL}" \
   PIP_EXTRA_INDEX_URL="${PYPI_INDEX_URL}" \
-  pip install --no-cache-dir -r /app/agent/requirements.txt
+  pip install -r /app/agent/requirements.txt
 
 ARG GCP_COST_MCP_VERSION=v0.8.0
 RUN curl -fsSL -o /usr/local/bin/gcp-cost-mcp-server \
@@ -35,8 +38,13 @@ RUN curl -fsSL -o /usr/local/bin/gcp-cost-mcp-server \
 COPY agent/scripts/gcp-cost-mcp-wrapper.sh /usr/local/bin/gcp-cost-mcp-wrapper
 RUN chmod +x /usr/local/bin/gcp-cost-mcp-wrapper
 
-# Copy agent code and shared skills into the image so list_skills works in GKE.
+# Copy agent code and skills. Bundled source paths are used by GKE initContainers to seed PVCs.
 COPY agent/ /app/agent/
+COPY skills/ /app/skills-source/
+RUN mkdir -p /app/agent-config-source \
+  && cp /app/agent/config/runtime.yaml /app/agent-config-source/runtime.yaml \
+  && printf '%s\n' "${GIT_COMMIT}" > /app/skills-source/.HELPUDOC_SOURCE_REVISION \
+  && cp /app/skills-source/.HELPUDOC_SOURCE_REVISION /app/agent-config-source/.HELPUDOC_SOURCE_REVISION
 COPY skills/ /app/skills/
 
 EXPOSE 8001

--- a/agent/helpudoc_agent/app.py
+++ b/agent/helpudoc_agent/app.py
@@ -1129,6 +1129,15 @@ def create_app() -> FastAPI:
     app = FastAPI(title="DeepAgents Service", version="0.2.0")
     rag_worker = RagIndexWorker(settings.backend.workspace_root)
 
+    @app.get("/health")
+    async def health() -> dict[str, object]:
+        """Lightweight liveness/readiness probe for orchestrators and deploy smoke tests."""
+        return {
+            "status": "ok",
+            "service": "helpudoc-agent",
+            "dependencies": dependency_diag,
+        }
+
     @app.on_event("startup")
     async def _startup() -> None:
         try:

--- a/backend/Dockerfile.gke
+++ b/backend/Dockerfile.gke
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 FROM node:20-bookworm-slim AS base
 
 WORKDIR /app
@@ -6,8 +7,8 @@ WORKDIR /app
 COPY backend/package*.json ./
 COPY backend/tsconfig.json ./
 
-# Install all dependencies
-RUN npm ci --legacy-peer-deps
+RUN --mount=type=cache,target=/root/.npm \
+  npm ci --legacy-peer-deps
 
 # Copy the rest of the backend source code
 COPY backend/src ./src

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -50,6 +50,10 @@ function resolveSaveUninitialized(): boolean {
 }
 
 async function startServer() {
+  app.get('/api/health', (_req, res) => {
+    res.status(200).json({ status: 'ok', service: 'helpudoc-backend' });
+  });
+
   logWorkspaceRootDiagnostic('backend');
   const databaseService = new DatabaseService();
   await databaseService.initialize();

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -6,6 +6,19 @@ For local development and one-time cluster setup, start with `docs/deploy.md`.
 
 ## Overview
 
+### Pull request CI (`ci.yml`)
+
+On every pull request and push to `master` / `main`, `.github/workflows/ci.yml` runs (jobs run in parallel):
+
+- **Backend tests** — `cd backend && npm test`
+- **Frontend** — `cd frontend && npm run lint && npm run build`
+- **Python agent** — installs `agent/requirements.txt` plus `pytest`, then runs `tests/test_agent_import_smoke.py`, `tests/test_agent_configuration.py`, `tests/test_mcp_binding.py`, and `tests/test_tool_factory.py`
+- **Docker smoke builds (no push)** — `docker buildx build` for `backend/Dockerfile.gke`, `frontend/Dockerfile.gke` (with dummy `VITE_GOOGLE_CLIENT_ID`), and `agent/Dockerfile.gke` (long-running; 120 minute job timeout)
+
+**Secret scanning:** `.github/workflows/secret-scan.yml` still runs on its own triggers (`push` / `pull_request`). It is not folded into `ci.yml`; keep it as a separate required check if your branch protection rules need it.
+
+### Manual deploy: `deploy-gke.yml`
+
 The primary deploy pipelines are GitHub workflows:
 - `.github/workflows/deploy-gke.yml` (full stack)
 - `.github/workflows/deploy-frontend-gke.yml` (frontend only)
@@ -13,13 +26,31 @@ The primary deploy pipelines are GitHub workflows:
 - `.github/workflows/deploy-agent-gke.yml` (agent only)
 - `.github/workflows/deploy-langfuse-gke.yml` (ClickHouse + Langfuse only: storage, manifests, Postgres `langfuse` DB bootstrap, rollout health)
 
-Each workflow:
-1. Authenticates to GCP (WIF or JSON key).
-2. Builds and pushes service images to `gcr.io/$PROJECT_ID/*` tagged by commit SHA.
-3. Gets cluster credentials and deploys via `kubectl`.
-4. Waits for rollout status.
+**Deploy Full Stack to GKE** (`.github/workflows/deploy-gke.yml`) is manual-only and supports component toggles, registry Buildx cache, infra gating, and post-rollout smoke checks.
 
-**Langfuse (ClickHouse + Langfuse):** Use **`Deploy Langfuse to GKE`** when you need observability infra without rebuilding app images. It applies `30-storage.yaml`, `44-clickhouse.yaml`, and `45-langfuse.yaml`, validates required `helpudoc-config` / `helpudoc-secrets` keys, runs `infra/gke/scripts/bootstrap-langfuse-db.sh --wait-rollout`, and waits for Langfuse web/worker rollouts. **`deploy-gke.yml`** applies `infra/gke/k8s/` (no ConfigMap in that directory; the demo `helpudoc-config` lives in `infra/gke/bootstrap/20-configmap.demo.yaml` and is applied **only** when `helpudoc-config` is missing), then runs the Langfuse bootstrap script, then merges OAuth keys from GitHub secrets—so routine full-stack deploys do not overwrite production `LANGFUSE_*` or Postgres settings. **Backend** and **agent** workflows only touch `50-app.yaml` and OAuth patches (backend). Populate Langfuse keys from `env/prod/config.env.example` and `env/prod/secrets.env.example` before running the Langfuse workflow (`infra/gke/README.md` for DNS and ingress).
+When you run **Deploy Full Stack to GKE**, configure these `workflow_dispatch` inputs:
+
+| Input | Default | Purpose |
+| --- | ---: | --- |
+| `build_backend` | true | Build/push `helpudoc-backend` and patch the backend + reflection CronJob images when true. |
+| `build_frontend` | true | Build/push `helpudoc-frontend` and patch the frontend deployment when true. |
+| `build_agent` | true | Build/push `helpudoc-agent`, patch the agent container, align init-container seed images, and run the image smoke import after push. |
+| `deploy_infra` | false | When true: RBAC preflight, `kubectl apply -f infra/gke/k8s/`, first-time demo ConfigMap bootstrap, Langfuse key patching + DB bootstrap/wait. When false: skips manifest/bootstrap work (cluster must already have `helpudoc-config`). |
+| `sync_runtime_assets` | false | Legacy `kubectl exec` sync of `skills/` and `agent/config/runtime.yaml` into PVCs. Prefer init-container seeding (see `docs/deploy.md`); leave false unless you need the old bridge. |
+| `environment` | empty | Echo-only label for operators (does not switch GitHub Environment protection rules). |
+| `image_tag_suffix` | empty | Appended to `github.sha` for all image tags in that run (for example `-hotfix1`). |
+
+At least one of `build_backend`, `build_frontend`, or `build_agent` must be true.
+
+**Buildx registry cache:** each image build uses `docker buildx build` with `--cache-from` / `--cache-to` pointing at `gcr.io/$PROJECT_ID/helpudoc-buildcache-{backend,frontend,agent}:buildcache` so repeated builds reuse layers.
+
+**Post-deploy smoke checks** (always after rollout wait): an ephemeral `curlimages/curl` pod hits `http://backend.helpudoc.svc.cluster.local:3000/api/health` and fetches the frontend service root; the workflow then runs `python -c 'urllib.request.urlopen("http://127.0.0.1:8001/health")...'` inside the `agent` container of `deployment/helpudoc-app`.
+
+The smaller **Deploy Frontend / Backend / Agent to GKE** workflows still build one image at a time and patch the matching deployment. Prefer **`deploy-gke.yml`** when you want Buildx cache, component toggles, and smoke checks in one place.
+
+**Langfuse-only:** **`Deploy Langfuse to GKE`** applies `30-storage.yaml`, `44-clickhouse.yaml`, and `45-langfuse.yaml`, validates required `helpudoc-config` / `helpudoc-secrets` keys, runs `infra/gke/scripts/bootstrap-langfuse-db.sh --wait-rollout`, and waits for Langfuse web/worker rollouts.
+
+In **`deploy-gke.yml`**, when **`deploy_infra` is true**, the workflow applies `infra/gke/k8s/`, creates the demo `helpudoc-config` only if it is missing (`infra/gke/bootstrap/20-configmap.demo.yaml`), runs Langfuse key patching + DB bootstrap, then merges OAuth keys from GitHub secrets. When **`deploy_infra` is false**, none of that runs: the cluster must already have `helpudoc-config` and the workloads you expect (run an infra deploy first on a brand-new cluster). Routine app deploys should keep **`deploy_infra` false** so image tags and rollouts are the only mutations.
 
 ## One Command Deploy (Manual)
 
@@ -81,8 +112,8 @@ Run one of these in GitHub Actions:
 GKE storage is defined in `infra/gke/k8s/30-storage.yaml` (includes `clickhouse-pvc` for Langfuse).
 
 Key mounts used by the app:
-- `skills-pvc` mounted at `/app/skills` (backend reads this via `SKILLS_ROOT`).
-- `agent-config-pvc` mounted at `/agent/config` (backend reads runtime config via `AGENT_CONFIG_PATH=/agent/config/runtime.yaml`).
+- `skills-pvc` mounted at `/app/skills` (backend reads this via `SKILLS_ROOT`). On pod start, init containers may copy bundled skills from the agent image into an **empty** PVC once; see `docs/deploy.md`.
+- `agent-config-pvc` mounted at `/agent/config` (backend reads runtime config via `AGENT_CONFIG_PATH=/agent/config/runtime.yaml`). Init containers may copy bundled `runtime.yaml` from the agent image when the PVC file is missing.
 - `workspace-pvc` mounted at `/app/workspaces` (user data; deploy sync does not modify this path).
 
 If the settings pages are broken in a new cluster, confirm these PVCs exist and are mounted into the `helpudoc-app` deployment.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -8,12 +8,22 @@ For local development and one-time cluster setup, start with `docs/deploy.md`.
 
 ### Pull request CI (`ci.yml`)
 
-On every pull request and push to `master` / `main`, `.github/workflows/ci.yml` runs (jobs run in parallel):
+On every pull request and push to `master` / `main`, `.github/workflows/ci.yml` runs.
+
+**When jobs run**
+
+- A **`changes`** job uses [`dorny/paths-filter`](https://github.com/dorny/paths-filter) so unrelated PRs skip stacks they did not touch (for example, a frontend-only PR skips backend tests and backend Docker validation).
+- On **push to `master` or `main`** (including after a PR merge), **all** test and Docker validation jobs run so the default branch always gets a full pass.
+- **Agent Docker** runs on **default-branch pushes only** (with `load: true` and `docker run … smoke_import.py`) so PRs that touch `agent/` are not charged twice for heavy dependencies (once for `pip install -r agent/requirements.txt` in **python-agent**, again inside a full image build). Merge to main still proves the image builds and that imports succeed inside the container.
+
+**Jobs (parallel where enabled)**
 
 - **Backend tests** — `cd backend && npm test`
 - **Frontend** — `cd frontend && npm run lint && npm run build`
 - **Python agent** — installs `agent/requirements.txt` plus `pytest`, then runs `tests/test_agent_import_smoke.py`, `tests/test_agent_configuration.py`, `tests/test_mcp_binding.py`, and `tests/test_tool_factory.py`
-- **Docker smoke builds (no push)** — `docker buildx build` for `backend/Dockerfile.gke`, `frontend/Dockerfile.gke` (with dummy `VITE_GOOGLE_CLIENT_ID`), and `agent/Dockerfile.gke` (long-running; 120 minute job timeout)
+- **Docker build validation (no push)** — `docker/build-push-action@v6` with GitHub Actions cache (`cache-from` / `cache-to` `type=gha`, separate scope per image). These verify Dockerfile syntax, base image pulls, installs, and copy steps; they do **not** push, vulnerability-scan, or deploy. Backend/frontend builds do not load the image into the runner. The agent job on main **loads** the image and runs `python /app/agent/scripts/smoke_import.py` inside the container.
+
+**Branch protection:** require the **`CI status`** (`ci-gate`) job so one check reflects the whole workflow (skipped jobs count as success for the gate).
 
 **Secret scanning:** `.github/workflows/secret-scan.yml` still runs on its own triggers (`push` / `pull_request`). It is not folded into `ci.yml`; keep it as a separate required check if your branch protection rules need it.
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -57,21 +57,24 @@ gcloud container clusters get-credentials "$CLUSTER" --zone "$GKE_LOCATION" --pr
 
 ### 4.2 Recommended full-stack deploy (GitHub Actions)
 
-The primary full-stack deploy path is the manual **Deploy Full Stack to GKE**
-GitHub Actions workflow in `.github/workflows/deploy-gke.yml`.
+The primary full-stack deploy path is the manual **Deploy Full Stack to GKE** workflow in `.github/workflows/deploy-gke.yml`.
 
-What it does:
-- builds and pushes `helpudoc-backend`, `helpudoc-frontend`, and
-  `helpudoc-agent` in parallel jobs
-- tags all three app images with the same Git commit SHA
-- applies `infra/gke/k8s/`
-- creates the demo `helpudoc-config` only if the ConfigMap is missing
-- ensures Langfuse bootstrap config/secrets, then runs
-  `infra/gke/scripts/bootstrap-langfuse-db.sh --wait-rollout`
-- patches OAuth config/secrets from GitHub repository secrets
-- updates the backend, agent, and frontend deployment images to the commit SHA
-- waits for app/frontend rollouts
-- syncs `skills/` and `agent/config/runtime.yaml` into their PVC-backed mounts
+**App deploy (default)** — leave **`deploy_infra`** false and **`sync_runtime_assets`** false:
+
+- Builds and pushes only the images you select (`build_backend`, `build_frontend`, `build_agent`; all default true) using **Docker Buildx** with **registry layer cache** (`gcr.io/$PROJECT_ID/helpudoc-buildcache-*`).
+- Tags selected images with `github.sha` plus optional **`image_tag_suffix`**.
+- Requires an existing `helpudoc-config` ConfigMap (bootstrap the cluster once before relying on app-only deploys).
+- Patches deployment images only for components you built; when the agent image changes, it also patches the **init-container** images used for runtime asset seeding.
+- Merges OAuth keys from GitHub repository secrets (same as before).
+- Waits for `helpudoc-app` and `helpudoc-frontend` rollouts, then runs **post-deploy smoke checks** against `GET /api/health` on the backend service, a GET on the frontend service, and `GET /health` on the agent container (`127.0.0.1:8001`).
+
+**Infra / bootstrap deploy** — set **`deploy_infra`** true (use sparingly):
+
+- Runs the Kubernetes RBAC preflight, `kubectl apply -f infra/gke/k8s/`, first-time demo `helpudoc-config` if missing, Langfuse secret/config patching, Langfuse DB bootstrap + rollout wait, then continues with OAuth + image rollout as in an app deploy.
+
+**Runtime assets (skills + agent config on PVCs):** the `helpudoc-app` pod includes **init containers** (`seed-skills`, `seed-agent-config`) that copy from image paths **`/app/skills-source`** and **`/app/agent-config-source/runtime.yaml`** into the PVC mounts **only when the target paths are empty**, so normal pod restarts do not wipe admin edits. Each image carries `.HELPUDOC_SOURCE_REVISION` (build tag / commit) beside the bundled tree; after a successful seed, the same filename may appear under the PVC for operators to diff **image revision** versus **live PVC** content (`kubectl exec` into the backend container and `cat /app/skills/.HELPUDOC_IMAGE_SOURCE_REVISION` or `/agent/config/.HELPUDOC_IMAGE_SOURCE_REVISION`).
+
+**Legacy PVC sync:** if you temporarily need the old `kubectl exec` tar/rsync behaviour, set **`sync_runtime_assets`** true. It is destructive for `/app/skills` when enabled; prefer init seeding for new clusters.
 
 Required GitHub secrets:
 - `GCP_PROJECT_ID`
@@ -92,11 +95,11 @@ Required GitHub secrets:
 
 Notes:
 - The deploy is manual-only (`workflow_dispatch`), not automatic on every push.
-- The build jobs do not talk to the cluster; the deploy job does all
-  `kubectl` work after the three image pushes succeed.
+- PR validation runs `.github/workflows/ci.yml` on pushes and pull requests to `master` / `main`.
+- The build jobs do not talk to the cluster; the deploy job does all `kubectl` work after selected image pushes succeed.
 - The checked-in manifests still reference `:latest`; the workflow patches the
   running `helpudoc-app` and `helpudoc-frontend` deployments to the commit SHA
-  after applying manifests.
+  after rollout (and patches init-container agent images when the agent image is rebuilt).
 - `infra/gke/k8s/52-daily-reflection-cron.yaml` also exists in the manifest
   directory. It currently uses the checked-in backend image reference when
   manifests are applied; update it manually if the CronJob must run a specific

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -95,7 +95,7 @@ Required GitHub secrets:
 
 Notes:
 - The deploy is manual-only (`workflow_dispatch`), not automatic on every push.
-- PR validation runs `.github/workflows/ci.yml` on pushes and pull requests to `master` / `main`.
+- PR validation runs `.github/workflows/ci.yml` on pushes and pull requests to `master` / `main` (path-filtered on PRs; full matrix on merge to `master` / `main`; see `docs/ci-cd.md`).
 - The build jobs do not talk to the cluster; the deploy job does all `kubectl` work after selected image pushes succeed.
 - The checked-in manifests still reference `:latest`; the workflow patches the
   running `helpudoc-app` and `helpudoc-frontend` deployments to the commit SHA

--- a/docs/repo-cicd-restructure-plan.md
+++ b/docs/repo-cicd-restructure-plan.md
@@ -1,0 +1,909 @@
+# HelpUDoc CI/CD and Repository Restructure Plan
+
+Generated: 2026-05-10
+
+**Branch `ci-cicd-pr1-3`:** PR 1–3 items below are implemented in-repo (workflows, Dockerfiles, `50-app.yaml`, health routes, docs). One PR 3 checklist item remains open: exposing image-vs-PVC revision in the settings UI (revision marker files and `kubectl` inspection are documented in `docs/deploy.md`).
+
+## Executive View
+
+The CI/CD work and the repository cleanup should be treated as one program, but not one giant refactor. The fastest path is:
+
+1. Make deploys cheaper and more predictable with Buildx cache, component toggles, and an infra toggle.
+2. Create clear runtime ownership boundaries before moving code: web backend, agent API, document parsing, report/dashboard rendering, shared contracts, and infrastructure.
+3. Refactor high-gravity files behind compatibility shims so tests and deploys keep working while names and directories improve.
+4. Split the agent image only after dependency ownership is visible in code and requirements files.
+
+My opinion: start with the CI/CD quick wins and env/config consolidation, then do code movement in thin slices. The repo has several big files that are doing real product work, so a rename-only cleanup would feel satisfying for a day and painful for a month. The best cleanup is boundary-first: make each service and feature own a small, obvious set of files.
+
+## Current Evidence
+
+From `graphify-out/GRAPH_REPORT.md`, the core graph "god nodes" are:
+
+| Node | Source file | Meaning for restructure |
+| --- | --- | --- |
+| `WorkspaceState` | `agent/helpudoc_agent/state.py` | Agent runtime state is a central boundary and should stay stable during moves. |
+| `SourceTracker` | `agent/helpudoc_agent/utils.py` | Citation/source tracking is shared agent infrastructure, not a random util. |
+| `Settings`, `ToolConfig` | `agent/helpudoc_agent/configuration.py` | Runtime config is too central to leave as one mixed loader/model/env module. |
+| `WorkspaceRagStore`, `RagConfig` | `agent/helpudoc_agent/rag_indexer.py` | RAG indexing is a service boundary and likely future worker image. |
+| `DoclingParser` | `agent/paper2slides/raganything/parser.py` | Heavy parser code is shared by RAG and Paper2Slides, so it should not live under a Paper2Slides-only name. |
+| `SkillPolicy` | `agent/helpudoc_agent/skills_registry.py` | Skills are platform config/runtime policy, not only prompt assets. |
+| `DuckDBManager` | `agent/helpudoc_agent/data_agent_tools.py` | Data/dashboard tooling is a feature package and should be broken out. |
+| `ToolFactory` | `agent/helpudoc_agent/tools_and_schemas.py` | Tool registration is central and should be modularized before adding more tools. |
+
+Large files worth splitting:
+
+| File | Approx lines | Current concern |
+| --- | ---: | --- |
+| `frontend/src/pages/WorkspacePage.tsx` | 7117 | Many unrelated workflows in one route component. |
+| `agent/helpudoc_agent/app.py` | 3010 | FastAPI routes, schemas, lifecycle, RAG, Paper2Slides, streaming, and auth in one file. |
+| `agent/helpudoc_agent/data_agent_tools.py` | 2852 | DuckDB, state, charts, dashboards, report generation, and tool factory together. |
+| `frontend/src/components/chat/ChatMessageBubble.tsx` | 1968 | Message rendering, tool rendering, markdown, interrupts, and artifact previews together. |
+| `agent/helpudoc_agent/tools_and_schemas.py` | 1849 | Tool registry plus many concrete tool implementations. |
+| `backend/src/api/agent.ts` | 1384 | Agent run routes, slash metadata, Paper2Slides, policy, streaming, and proxy concerns together. |
+| `backend/src/api/settings.ts` | 1266 | Runtime config, skills CRUD, skill builder, GitHub import, and admin settings together. |
+| `backend/src/services/agentRunService.ts` | 1162 | Stream persistence, run lifecycle, resume, interrupts, cancellation, and telemetry together. |
+
+Local workspace size is also noisy even though these files are ignored by git:
+
+| Path | Size observed | Action |
+| --- | ---: | --- |
+| `.venv` | 2.4G | Keep ignored; add cleanup script and developer note. |
+| `agent/.venv` | 2.7G | Keep ignored; prefer one documented Python env. |
+| `frontend/node_modules` | 1.6G | Keep ignored; no action beyond docs. |
+| `backend/workspaces` | 225M | Keep ignored; document runtime data location. |
+| `.redis-data`, `.minio-data`, `.postgres-data` | 359M combined | Keep ignored; cleanup helper. |
+| `agent/outputs` | 86M | Keep ignored; should move under runtime workspace/cache in future. |
+
+## Target Boundaries
+
+### Target Repository Shape
+
+```text
+.github/
+  actions/
+    gcp-auth/
+    docker-buildx/
+  workflows/
+    ci.yml
+    build-images.yml
+    deploy-gke.yml
+    infra-gke.yml
+    deploy-langfuse-gke.yml
+
+agent/
+  Dockerfile.gke
+  Dockerfile.base
+  requirements-api.txt
+  requirements-parser.txt
+  requirements-reporting.txt
+  requirements-runtime.txt
+  requirements.txt
+  helpudoc_agent/
+    api/
+    config/
+    runtime/
+    rag/
+    skills/
+    tools/
+    integrations/
+  document_intelligence/
+    docling/
+    raganything/
+  presentation_pipeline/
+    ...
+
+backend/
+  src/
+    api/
+      agent/
+      settings/
+    config/
+    services/
+      agent-runs/
+      paper2slides/
+      skills/
+      workspaces/
+    integrations/
+
+frontend/
+  src/
+    features/
+      workspace/
+      chat/
+      paper2slides/
+      dashboard/
+      settings/
+    shared/
+    services/
+
+packages/
+  contracts/
+  dashboard-runtime/
+
+infra/
+  gke/
+  env/
+  scripts/
+
+scripts/
+  clean-runtime-artifacts.sh
+  validate-env.*
+```
+
+### Naming Decisions
+
+| Current name | Target name | Why |
+| --- | --- | --- |
+| `agent/helpudoc_agent/graph.py` | `agent/helpudoc_agent/runtime/agent_registry.py` | The file no longer describes a LangGraph graph. It builds/caches DeepAgents/LangChain agents. |
+| `agent/paper2slides/` | `agent/presentation_pipeline/` | The feature now supports more than papers and may generate slides/posters from general docs. |
+| `agent/paper2slides/raganything/` | `agent/document_intelligence/raganything/` | Doc parsing is used by RAG and attachment understanding, not only Paper2Slides. |
+| `packages/shared` | `packages/contracts` plus `packages/dashboard-runtime` | Current package mixes API contracts, stream helpers, and dashboard runtime logic. |
+| `backend/src/api/settings.ts` | `backend/src/api/settings/*` | One file owns too many admin surfaces. |
+| `frontend/src/pages/WorkspacePage.tsx` | `frontend/src/features/workspace/WorkspacePage.tsx` plus hooks/components | The route is a coordinator, not the owner of every workspace workflow. |
+
+## Phase 0 - Prep and Guardrails
+
+Goal: make later refactors safe and reversible.
+
+| File | Change |
+| --- | --- |
+| `docs/repo-cicd-restructure-plan.md` | Keep this plan as the tracking document. |
+| `docs/current-architecture.md` | Update after code movement, especially Langfuse status and any new worker boundaries. |
+| `docs/ci-cd.md` | Update after workflow changes. |
+| `docs/deploy.md` | Update after deploy mode split and skills/config init-container change. |
+| `AGENTS.md` | Keep graphify rule. After code edits, run `graphify update .`. |
+| `.gitignore` | Already ignores runtime data; add comments grouping local runtime dirs if desired. |
+| `.dockerignore` | Already excludes major runtime dirs; add `backend/workspaces`, `agent/outputs`, and `graphify-out` if not already covered. |
+| `scripts/clean-runtime-artifacts.sh` | New optional script to remove ignored local data: `.local-run`, `.pytest_cache`, Python caches, `agent/outputs`, `backend/workspaces`, local Docker volume dirs. Must print paths and require an explicit `--yes`. |
+
+Validation:
+
+- `git status --short` before each refactor.
+- No source movement without tests or import shims.
+- After code-file changes, run `graphify update .`.
+
+## Phase 1 - CI/CD Quick Wins
+
+Goal: fast deploys without changing application architecture.
+
+### Workflow Files
+
+| File | Action |
+| --- | --- |
+| `.github/workflows/deploy-gke.yml` | Add `workflow_dispatch` inputs: `build_backend`, `build_frontend`, `build_agent`, `deploy_infra`, `sync_runtime_assets`, `image_tag_suffix`, and optional `environment`. Default app deploy should build selected components, set images, wait rollout, and run smoke tests. |
+| `.github/workflows/deploy-gke.yml` | Replace `docker build` and `docker push` with `docker buildx build --cache-from type=registry --cache-to type=registry,mode=max --push`. |
+| `.github/workflows/deploy-gke.yml` | Gate RBAC checks, manifest apply, ConfigMap bootstrap, Langfuse secret bootstrap, and Langfuse DB bootstrap behind `inputs.deploy_infra == true`. |
+| `.github/workflows/deploy-gke.yml` | Gate skills/config sync behind `inputs.sync_runtime_assets == true` only as a temporary bridge. Remove this after the init-container/image seeding pattern lands. |
+| `.github/workflows/deploy-agent-gke.yml` | Convert to a thin wrapper around the reusable build/deploy job, or delete after `deploy-gke.yml` supports component toggles. Keep only if operators strongly prefer one-click component workflows. |
+| `.github/workflows/deploy-backend-gke.yml` | Same as above. |
+| `.github/workflows/deploy-frontend-gke.yml` | Same as above. |
+| `.github/workflows/deploy-langfuse-gke.yml` | Keep as infra workflow, but share auth setup with the new composite action. |
+| `.github/workflows/ci.yml` | New PR workflow: backend tests, frontend lint/build, Python tests/smoke imports, no push. |
+| `.github/workflows/build-images.yml` | New reusable workflow for selected image builds. Inputs: component list, tag, push true/false, registry host, cache namespace. |
+| `.github/workflows/infra-gke.yml` | New manual workflow for manifest diff/apply/bootstrap only. It should support `kubectl diff` before apply. |
+| `.github/workflows/secret-scan.yml` | Keep. Optionally make it part of required PR CI. |
+| `.github/actions/gcp-auth/action.yml` | New composite action to remove repeated WIF/JSON auth logic from all workflows. |
+| `.github/actions/docker-buildx/action.yml` | Optional composite action for registry auth plus common buildx flags. |
+
+### Dockerfiles and Requirements
+
+| File | Action |
+| --- | --- |
+| `agent/Dockerfile.gke` | Add `# syntax=docker/dockerfile:1.7` and use `RUN --mount=type=cache,target=/root/.cache/pip pip install ...`. |
+| `agent/Dockerfile.gke` | Stop using `--no-cache-dir` for BuildKit cache layers. The pip cache is mounted, not baked into the final layer. |
+| `agent/Dockerfile` | Apply the same BuildKit pip cache pattern for local image parity. |
+| `backend/Dockerfile.gke` | Add npm cache mount for `npm ci`. Consider compiling TypeScript to `dist` instead of running production with `ts-node`. |
+| `frontend/Dockerfile.gke` | Already uses npm cache. Keep and make sure Buildx registry cache covers this image. |
+| `agent/scripts/smoke_import.py` | Keep as agent image smoke test. Add imports for the parser-worker split only after that split exists. |
+| `tests/test_agent_import_smoke.py` | Keep. This is the repo-level guard that the agent runtime can import. |
+
+### Deployment Smoke Tests
+
+| File | Action |
+| --- | --- |
+| `.github/workflows/deploy-gke.yml` | Add post-rollout smoke checks: backend `/api/health` or equivalent, frontend HTTP GET, agent `/health`, and optional OAuth config sanity. |
+| `backend/src/api/routes.ts` | Add or expose a simple health route if one does not already exist. |
+| `agent/helpudoc_agent/app.py` | Keep or add `/health` and parser dependency diagnostics. Move later to `agent/helpudoc_agent/api/routes/health.py`. |
+| `frontend/nginx.conf` | Ensure frontend health can be checked by fetching `/` or `/index.html`. |
+
+## Phase 2 - Infra Mode Split and Runtime Asset Seeding
+
+Goal: normal deploys mutate only image tags; infra/bootstrap runs only when requested.
+
+| File | Action |
+| --- | --- |
+| `infra/gke/k8s/50-app.yaml` | Add init containers to seed `/app/skills` and `/agent/config` from image-bundled source paths. |
+| `infra/gke/k8s/50-app.yaml` | Add source paths in images, for example `/app/skills-source` and `/app/agent-config-source`, so PVC mounts do not hide the source copy. |
+| `infra/gke/k8s/50-app.yaml` | Patch init-container images in deploy workflow alongside backend/agent images. |
+| `agent/Dockerfile.gke` | Copy `skills/` to `/app/skills-source` instead of only `/app/skills`. Copy `agent/config/runtime.yaml` to `/app/agent-config-source/runtime.yaml`. |
+| `backend/Dockerfile.gke` | If backend remains the settings owner for skills, also copy `skills/` to a source path or rely on the agent init container. Choose one owner. |
+| `.github/workflows/deploy-gke.yml` | Remove `kubectl exec` skills/config sync after init-container seeding is verified. |
+| `infra/gke/k8s/30-storage.yaml` | Keep `skills-pvc` and `agent-config-pvc` only if admin UI needs runtime edits. If config becomes ConfigMap-backed, remove or deprecate `agent-config-pvc` later. |
+| `backend/src/api/settings.ts` | During transition, settings page writes to PVC-backed paths as today. Add a visible version/source field later so operators know when PVC content diverges from image source. |
+| `docs/deploy.md` | Document normal deploy versus infra/bootstrap deploy. |
+| `docs/ci-cd.md` | Document component toggles and when to use `deploy_infra`. |
+
+Important decision:
+
+- If skills are product code, image-bundle them and use init-container copy.
+- If skills are admin-editable runtime content, keep the PVC as the live layer and record the image source version. Do not keep syncing by `kubectl exec`.
+
+## Phase 3 - Environment and Config Unification
+
+Goal: one canonical env inventory, typed loaders per runtime, and fewer duplicated variable defaults.
+
+### New Shared Env Inventory
+
+| File | Action |
+| --- | --- |
+| `infra/env/helpudoc.env.schema.yaml` | New canonical env catalog. For each var: owner service, type, default, secret/non-secret, local/prod required, docs, and deprecated aliases. |
+| `scripts/validate-env.ts` | New validator for backend/frontend/prod env files. |
+| `agent/helpudoc_agent/config/env.py` | New Pydantic env loader for agent-owned variables. |
+| `backend/src/config/env.ts` | New Zod env loader for backend-owned variables. |
+| `frontend/src/config/env.ts` | New typed Vite env adapter for `VITE_*` vars. |
+
+### Existing Env Files
+
+| File | Action |
+| --- | --- |
+| `env/local/dev.env.example` | Align names with schema. Prefer one model name set. Add comments for parser/RAG variables. |
+| `env/local/stack.env.example` | Align with schema and remove drift from `dev.env.example`. |
+| `env/local/paper2slides.env.example` | Either merge into `dev.env.example` under a Paper2Slides section or keep as feature overlay with schema validation. |
+| `env/prod/config.env.example` | Generate or verify from schema. Keep only non-secret config. |
+| `env/prod/secrets.env.example` | Generate or verify from schema. Keep only secrets. |
+| `infra/gke/templates/20-configmap.yaml` | Align with schema names and defaults. |
+| `infra/gke/templates/10-secrets.yaml` | Align with schema names. |
+| `infra/gke/bootstrap/20-configmap.demo.yaml` | Keep as demo bootstrap, but make it obviously non-production. |
+| `agent/config/runtime.yaml` | Move model/tool/MCP config out of ad hoc env duplication. Keep `${...}` references, but document every env var in schema. |
+
+### Code Files to Change
+
+| File | Action |
+| --- | --- |
+| `backend/src/index.ts` | Replace direct `process.env` session parsing with `backend/src/config/env.ts`. |
+| `backend/src/config/workspaceRoot.ts` | Keep path diagnostics, but use env loader as input. |
+| `backend/src/services/databaseService.ts` | Read typed DB config from env module. |
+| `backend/src/services/s3Service.ts` | Read typed S3 config from env module. |
+| `backend/src/services/googleOAuthService.ts` | Read typed OAuth config from env module. |
+| `backend/src/services/langfuseClient.ts` | Read typed Langfuse config from env module. |
+| `backend/src/api/agent.ts` | Replace duplicated path/env helpers with config modules. |
+| `backend/src/api/settings.ts` | Replace duplicated path/env helpers with config modules. |
+| `agent/helpudoc_agent/configuration.py` | Split settings models from env override logic. |
+| `agent/helpudoc_agent/rag_indexer.py` | Move `RagConfig.from_env` into `agent/helpudoc_agent/rag/config.py`. |
+| `agent/helpudoc_agent/rag_worker.py` | Move queue env parsing into `agent/helpudoc_agent/rag/config.py`. |
+| `agent/helpudoc_agent/langfuse_callbacks.py` | Use agent env loader. |
+| `agent/helpudoc_agent/sandbox_runner.py` | Use agent env loader for sandbox settings. |
+| `agent/paper2slides/rag/config.py` | Use shared agent env helpers or the presentation pipeline config module. |
+| `agent/paper2slides/generator/content_planner.py` | Use presentation config object rather than repeated `os.getenv`. |
+| `agent/paper2slides/generator/image_generator.py` | Same. |
+| `agent/paper2slides/core/stages/*.py` | Same. |
+
+## Phase 4 - Agent Runtime Refactor
+
+Goal: split the agent service by responsibility while keeping imports stable.
+
+### Runtime and Config
+
+| Current file | Target file(s) | Action |
+| --- | --- | --- |
+| `agent/helpudoc_agent/graph.py` | `agent/helpudoc_agent/runtime/agent_registry.py` | Move `AgentRegistry`, `_clone_preservable_context`, model selection, tool binding, and middleware construction. |
+| `agent/helpudoc_agent/graph.py` | Compatibility shim | Re-export `AgentRegistry` for one or two releases so tests and imports do not break immediately. |
+| `agent/helpudoc_agent/configuration.py` | `agent/helpudoc_agent/config/models.py` | Move `ModelConfig`, `BackendConfig`, `MCPServerConfig`, `ToolConfig`, `Settings`. |
+| `agent/helpudoc_agent/configuration.py` | `agent/helpudoc_agent/config/loader.py` | Move YAML loading, merge logic, env expansion, and `load_settings`. |
+| `agent/helpudoc_agent/configuration.py` | `agent/helpudoc_agent/config/paths.py` | Move `PACKAGE_ROOT`, `AGENT_ROOT`, `REPO_ROOT`, default paths, workspace diagnostics. |
+| `agent/helpudoc_agent/state.py` | `agent/helpudoc_agent/runtime/state.py` | Move when stable; keep shim at old path. |
+| `agent/helpudoc_agent/memory_store.py` | `agent/helpudoc_agent/runtime/memory_store.py` | Move with registry because it is runtime persistence. |
+
+### FastAPI Surface
+
+| Current file | Target file(s) | Action |
+| --- | --- | --- |
+| `agent/helpudoc_agent/app.py` | `agent/helpudoc_agent/api/app.py` | Keep `create_app` only: load settings, register routes, lifecycle. |
+| `agent/helpudoc_agent/app.py` | `agent/helpudoc_agent/api/schemas.py` | Move Pydantic request/response classes. |
+| `agent/helpudoc_agent/app.py` | `agent/helpudoc_agent/api/lifecycle.py` | Move startup dependency diagnostics, registry construction, RAG worker start/stop. |
+| `agent/helpudoc_agent/app.py` | `agent/helpudoc_agent/api/routes/chat.py` | Move chat, resume, interrupt, and streaming routes. |
+| `agent/helpudoc_agent/app.py` | `agent/helpudoc_agent/api/routes/rag.py` | Move RAG query/status routes and tagged RAG context helpers. |
+| `agent/helpudoc_agent/app.py` | `agent/helpudoc_agent/api/routes/paper2slides.py` | Move Paper2Slides run/export routes. |
+| `agent/helpudoc_agent/app.py` | `agent/helpudoc_agent/api/routes/attachments.py` | Move attachment understanding routes. |
+| `agent/helpudoc_agent/app.py` | `agent/helpudoc_agent/api/routes/health.py` | Move health/diagnostics route. |
+| `agent/main.py` | `agent/helpudoc_agent/api/app.py` import | Keep `main.py` as the uvicorn entrypoint, but import from the new app module. |
+
+### Tools
+
+| Current file | Target file(s) | Action |
+| --- | --- | --- |
+| `agent/helpudoc_agent/tools_and_schemas.py` | `agent/helpudoc_agent/tools/factory.py` | Move `ToolFactory`. |
+| `agent/helpudoc_agent/tools_and_schemas.py` | `agent/helpudoc_agent/tools/gemini.py` | Move `GeminiClientManager` and Gemini-native tools. |
+| `agent/helpudoc_agent/tools_and_schemas.py` | `agent/helpudoc_agent/tools/web_sources.py` | Move `StructuredWebSource`, `StructuredWebAnswer`, source formatting. |
+| `agent/helpudoc_agent/tools_and_schemas.py` | `agent/helpudoc_agent/tools/builtins/*.py` | Split built-in tools: skills, RAG, image URL, BigQuery export, PDF/image, report append. |
+| `agent/helpudoc_agent/tools_and_schemas.py` | Compatibility shim | Re-export old names until tests and imports are migrated. |
+| `agent/helpudoc_agent/tool_guard.py` | `agent/helpudoc_agent/tools/guard.py` | Move after factory split. |
+| `agent/helpudoc_agent/bigquery_export_tools.py` | `agent/helpudoc_agent/tools/bigquery_export.py` | Move to tools package. |
+
+### Skills
+
+| Current file | Target file(s) | Action |
+| --- | --- | --- |
+| `agent/helpudoc_agent/skills_registry.py` | `agent/helpudoc_agent/skills/registry.py` | Move discovery/loading. |
+| `agent/helpudoc_agent/skills_registry.py` | `agent/helpudoc_agent/skills/policy.py` | Move `SkillPolicy` and policy helpers. |
+| `agent/helpudoc_agent/skills_registry.py` | Compatibility shim | Keep old import path during migration. |
+| `skills/**/SKILL.md` | No move in phase 4 | Keep skill content stable until runtime code is moved. |
+
+### RAG and Document Understanding
+
+| Current file | Target file(s) | Action |
+| --- | --- | --- |
+| `agent/helpudoc_agent/rag_indexer.py` | `agent/helpudoc_agent/rag/store.py` | Move `WorkspaceRagStore`. |
+| `agent/helpudoc_agent/rag_indexer.py` | `agent/helpudoc_agent/rag/config.py` | Move `RagConfig`, LightRAG env defaults, queue config. |
+| `agent/helpudoc_agent/rag_indexer.py` | `agent/helpudoc_agent/rag/ingestion.py` | Move file ingestion, delete, safe path handling. |
+| `agent/helpudoc_agent/rag_worker.py` | `agent/helpudoc_agent/rag/worker.py` | Move worker loop. |
+| `agent/helpudoc_agent/rag_indexer.py` | Compatibility shim | Keep old import path. |
+| `agent/helpudoc_agent/rag_worker.py` | Compatibility shim | Keep old import path. |
+
+### Tests to Update
+
+| File | Action |
+| --- | --- |
+| `tests/test_agent_main.py` | Update stubs from `helpudoc_agent.graph` to runtime module, then keep a small shim test. |
+| `tests/test_mcp_binding.py` | Update monkeypatch paths to runtime/tool modules. |
+| `tests/test_tool_factory.py` | Update imports to `helpudoc_agent.tools.factory`. |
+| `tests/test_agent_configuration.py` | Update imports to config package. |
+| `tests/test_mcp_configuration.py` | Update imports to config models/loader. |
+| `tests/test_paper2slides_cache.py` | Leave until presentation package move. |
+
+## Phase 5 - Data Tools and Dashboard Runtime
+
+Goal: make the data/dashboard feature understandable and reduce duplicated JS/Python dashboard logic.
+
+| Current file | Target file(s) | Action |
+| --- | --- | --- |
+| `agent/helpudoc_agent/data_agent_tools.py` | `agent/helpudoc_agent/tools/data/state.py` | Move `DataAgentSessionState`, query/chart/materialization records. |
+| `agent/helpudoc_agent/data_agent_tools.py` | `agent/helpudoc_agent/tools/data/duckdb_manager.py` | Move `DuckDBManager` and workspace file registration. |
+| `agent/helpudoc_agent/data_agent_tools.py` | `agent/helpudoc_agent/tools/data/query_tools.py` | Move schema/query/materialization callable tools. |
+| `agent/helpudoc_agent/data_agent_tools.py` | `agent/helpudoc_agent/tools/data/chart_tools.py` | Move chart config generation and chart output handling. |
+| `agent/helpudoc_agent/data_agent_tools.py` | `agent/helpudoc_agent/tools/data/dashboard_tools.py` | Move dashboard package generation. |
+| `agent/helpudoc_agent/data_agent_tools.py` | `agent/helpudoc_agent/tools/data/factory.py` | Move `build_data_agent_tools`. |
+| `agent/helpudoc_agent/data_report_renderers.py` | `agent/helpudoc_agent/tools/data/renderers/html_summary.py` | Move summary renderer. |
+| `agent/helpudoc_agent/data_report_renderers.py` | `agent/helpudoc_agent/tools/data/renderers/dashboard_snapshot.py` | Move dashboard HTML snapshot renderer. |
+| `packages/shared/src/dashboard/*` | `packages/dashboard-runtime/src/*` | Move frontend dashboard runtime helpers to a dedicated package. |
+| `frontend/src/components/dashboard/DashboardCanvas.tsx` | Update imports | Import from `@helpudoc/dashboard-runtime`. |
+| `frontend/src/components/dashboard/DashboardFilters.tsx` | Update imports | Import from `@helpudoc/dashboard-runtime`. |
+| `agent/helpudoc_agent/data_report_renderers.py` | Future optional | Generate dashboard snapshot from the same spec contract as `packages/dashboard-runtime`; do not duplicate business semantics in two places. |
+| `tests/test_data_skill_family.py` | Update imports and add tests for data tool package boundaries. |
+| `agent/tests/test_data_agent_tools.py` | Split tests by query/chart/dashboard modules. |
+
+## Phase 6 - Shared Packages
+
+Goal: make shared TypeScript code a real package boundary.
+
+| Current file | Target file(s) | Action |
+| --- | --- | --- |
+| `packages/shared/package.json` | `packages/contracts/package.json` | Rename package to `@helpudoc/contracts`. Export types and stream client. |
+| `packages/shared/src/types.ts` | `packages/contracts/src/types.ts` | Move app contracts. Consider splitting into `workspace.ts`, `conversation.ts`, `agent.ts`, `skills.ts`, `memory.ts`, `dashboard.ts`. |
+| `packages/shared/src/services/agentStream.ts` | `packages/contracts/src/agentStream.ts` | Move stream chunk types and reconnect helper. |
+| `packages/shared/src/dashboard/*` | `packages/dashboard-runtime/src/*` | Move dashboard-only runtime code. |
+| `frontend/package.json` | Update dependencies | Replace `@helpudoc/shared` with `@helpudoc/contracts` and `@helpudoc/dashboard-runtime`. |
+| `backend/package.json` | Add dependency | Add `@helpudoc/contracts` via file dependency or npm workspace. |
+| `frontend/src/types.ts` | Update export | Re-export from `@helpudoc/contracts/types`, not relative `../../packages/shared`. |
+| `frontend/src/services/agentApi.ts` | Update import | Import stream helper from `@helpudoc/contracts/agentStream`. |
+| `frontend/src/services/settingsApi.ts` | Update import | Import `AgentStreamChunk` from package export. |
+| `backend/src/services/*.ts` | Update imports | Replace `../../../packages/shared/src/types` with `@helpudoc/contracts/types`. |
+| Root `package.json` | New optional | Add npm workspaces for `frontend`, `backend`, `packages/*` to make local package use less brittle. |
+| Root `package-lock.json` | New optional | Only if npm workspaces are adopted. |
+| `backend/tsconfig.json` | Update paths | Add package path aliases or rely on workspace install. |
+| `frontend/tsconfig.app.json` | Update include | Ensure package types are resolved through dependencies, not source-relative imports. |
+| `frontend/vite.config.ts` | Update optimize/deps if needed | Ensure linked packages compile cleanly. |
+
+## Phase 7 - Backend Structure
+
+Goal: make backend routes and services navigable.
+
+### Agent API
+
+| Current file | Target file(s) | Action |
+| --- | --- | --- |
+| `backend/src/api/agent.ts` | `backend/src/api/agent/index.ts` | Route composition only. |
+| `backend/src/api/agent.ts` | `backend/src/api/agent/runs.ts` | Start/resume/cancel/status/stream endpoints. |
+| `backend/src/api/agent.ts` | `backend/src/api/agent/slash.ts` | Slash metadata and skill policy endpoints. |
+| `backend/src/api/agent.ts` | `backend/src/api/agent/paper2slides.ts` | Paper2Slides job/export endpoints. |
+| `backend/src/api/agent.ts` | `backend/src/api/agent/attachments.ts` | Current-turn multimodal and attachment understanding proxy helpers if they remain in agent routes. |
+| `backend/src/api/agent.ts` | `backend/src/api/agent/policy.ts` | Effective agent policy, MCP delegated auth policy helpers. |
+| `backend/src/api/routes.ts` | Update imports | Import `agentRoutes` from `backend/src/api/agent`. |
+
+### Settings API
+
+| Current file | Target file(s) | Action |
+| --- | --- | --- |
+| `backend/src/api/settings.ts` | `backend/src/api/settings/index.ts` | Route composition only. |
+| `backend/src/api/settings.ts` | `backend/src/api/settings/agentConfig.ts` | Runtime YAML read/write/merge. |
+| `backend/src/api/settings.ts` | `backend/src/api/settings/skills.ts` | Skills CRUD and file content operations. |
+| `backend/src/api/settings.ts` | `backend/src/api/settings/skillBuilder.ts` | Skill builder run/session/context endpoints. |
+| `backend/src/api/settings.ts` | `backend/src/api/settings/githubImport.ts` | GitHub skill import inspect/apply. |
+| `backend/src/api/settings.ts` | `backend/src/services/skills/skillPaths.ts` | Path resolution and allowed-prefix rules. |
+| `backend/src/api/settings.ts` | `backend/src/services/skills/frontmatter.ts` | Frontmatter parse/format helpers. |
+| `backend/src/api/routes.ts` | Update imports | Import settings router directory. |
+
+### Agent Run Service
+
+| Current file | Target file(s) | Action |
+| --- | --- | --- |
+| `backend/src/services/agentRunService.ts` | `backend/src/services/agent-runs/types.ts` | Run status, context, metadata, interrupt types. |
+| `backend/src/services/agentRunService.ts` | `backend/src/services/agent-runs/store.ts` | Redis stream/meta persistence. |
+| `backend/src/services/agentRunService.ts` | `backend/src/services/agent-runs/interrupts.ts` | Interrupt parsing, signatures, resume payload normalization. |
+| `backend/src/services/agentRunService.ts` | `backend/src/services/agent-runs/lifecycle.ts` | Start/resume/cancel orchestration. |
+| `backend/src/services/agentRunService.ts` | Compatibility barrel | Re-export public functions used by API tests during migration. |
+| `backend/tests/agentRunService.test.ts` | Update imports incrementally. |
+| `backend/tests/runTelemetryService.test.ts` | Keep stable unless service API changes. |
+
+### Other Backend Cleanups
+
+| File | Action |
+| --- | --- |
+| `backend/src/services/paper2SlidesService.ts` | Move to `backend/src/services/paper2slides/service.ts`. |
+| `backend/src/services/paper2SlidesJobService.ts` | Move to `backend/src/services/paper2slides/jobService.ts`. |
+| `backend/src/types/paper2slides.ts` | Move to shared contracts if frontend and backend both need the exact same shape. |
+| `backend/src/services/googleDriveService.ts` | Consider `backend/src/integrations/google/driveService.ts`. |
+| `backend/src/services/googleOAuthService.ts` | Consider `backend/src/integrations/google/oauthService.ts`. |
+| `backend/src/services/langfuseClient.ts` | Consider `backend/src/integrations/langfuse/client.ts`. |
+| `backend/src/lib/skillsRegistry.ts` | Move under `backend/src/services/skills/registry.ts`. |
+
+## Phase 8 - Frontend Structure
+
+Goal: make product workflows feature-owned and shrink route components.
+
+### Workspace Page
+
+| Current file | Target file(s) | Action |
+| --- | --- | --- |
+| `frontend/src/pages/WorkspacePage.tsx` | `frontend/src/features/workspace/WorkspacePage.tsx` | Route-level coordinator only. |
+| `frontend/src/pages/WorkspacePage.tsx` | `frontend/src/features/workspace/hooks/useWorkspaceSelection.ts` | Workspace list/create/delete/rename/current selection. |
+| `frontend/src/pages/WorkspacePage.tsx` | `frontend/src/features/workspace/hooks/useWorkspaceFiles.ts` | File tree, file actions, content loading, RAG status. |
+| `frontend/src/pages/WorkspacePage.tsx` | `frontend/src/features/chat/hooks/useAgentRun.ts` | Run start/resume/cancel/status/stream reconnect. |
+| `frontend/src/pages/WorkspacePage.tsx` | `frontend/src/features/chat/hooks/useConversationState.ts` | Conversation load/append/truncate/history state. |
+| `frontend/src/pages/WorkspacePage.tsx` | `frontend/src/features/paper2slides/hooks/usePaper2SlidesJob.ts` | Paper2Slides options, job start, polling, export. |
+| `frontend/src/pages/WorkspacePage.tsx` | `frontend/src/features/dashboard/hooks/useDashboardArtifacts.ts` | Dashboard manifest/path resolution and artifact state. |
+| `frontend/src/pages/WorkspacePage.tsx` | `frontend/src/features/workspace/utils/workspacePaths.ts` | `normalizeWorkspaceRelativePath`, dashboard path helpers. |
+| `frontend/src/pages/WorkspacePage.tsx` | `frontend/src/features/paper2slides/components/PresentationModal.tsx` | Move bottom modal currently in same file. |
+| `frontend/src/pages/WorkspacePage.tsx` | `frontend/src/pages/WorkspacePage.tsx` | Keep as a thin re-export initially to avoid route churn. |
+
+### Chat
+
+| Current file | Target file(s) | Action |
+| --- | --- | --- |
+| `frontend/src/components/chat/ChatMessageBubble.tsx` | `frontend/src/features/chat/components/ChatMessageBubble.tsx` | Keep shell. |
+| `frontend/src/components/chat/ChatMessageBubble.tsx` | `frontend/src/features/chat/components/ToolEventList.tsx` | Move tool rendering. |
+| `frontend/src/components/chat/ChatMessageBubble.tsx` | `frontend/src/features/chat/components/InterruptCard.tsx` | Move approval/clarification UI. |
+| `frontend/src/components/chat/ChatMessageBubble.tsx` | `frontend/src/features/chat/components/ArtifactPreview.tsx` | Move file/dashboard/presentation previews. |
+| `frontend/src/components/chat/approvalReview.ts` | `frontend/src/features/chat/interrupts/approvalReview.ts` | Move with interrupt code. |
+| `frontend/src/components/chat/interruptActions.ts` | `frontend/src/features/chat/interrupts/actions.ts` | Move with interrupt code. |
+| `frontend/src/components/chat/chatTypes.ts` | `frontend/src/features/chat/types.ts` | Move after shared contract cleanup. |
+
+### Files, Dashboard, Settings
+
+| Current file | Target file(s) | Action |
+| --- | --- | --- |
+| `frontend/src/components/FileRenderer.tsx` | `frontend/src/features/files/FileRenderer.tsx` | Keep shell. |
+| `frontend/src/components/FileRenderer.tsx` | `frontend/src/features/files/renderers/MarkdownRenderer.tsx` | Move markdown renderer. |
+| `frontend/src/components/FileRenderer.tsx` | `frontend/src/features/files/renderers/OfficeRenderer.tsx` | Move docx/pptx handling. |
+| `frontend/src/components/FileRenderer.tsx` | `frontend/src/features/files/renderers/DashboardRenderer.tsx` | Move dashboard-specific handling if any. |
+| `frontend/src/components/dashboard/*` | `frontend/src/features/dashboard/components/*` | Move dashboard components. |
+| `frontend/src/components/settings/*` | `frontend/src/features/settings/components/*` | Move settings components. |
+| `frontend/src/services/settingsApi.ts` | Split into `frontend/src/features/settings/api/*.ts` | Separate agent config, skills, skill builder, users, reflections. |
+| `frontend/src/types.ts` | Replace with package export | Re-export from `@helpudoc/contracts`. |
+
+## Phase 9 - Paper2Slides and Parser/Image Split
+
+Goal: isolate heavy document intelligence from the agent API and prepare for separate images.
+
+### Package Movement
+
+| Current file/directory | Target | Action |
+| --- | --- | --- |
+| `agent/paper2slides/` | `agent/presentation_pipeline/` | Move in a dedicated PR after tests pass. Keep `agent/paper2slides` as shim package importing from new package. |
+| `agent/paper2slides/main.py` | `agent/presentation_pipeline/cli.py` | Move CLI implementation. Keep `paper2slides/main.py` shim. |
+| `agent/paper2slides/__main__.py` | Shim | Continue supporting `python -m paper2slides` temporarily. |
+| `agent/paper2slides/core/*` | `agent/presentation_pipeline/core/*` | Move. |
+| `agent/paper2slides/generator/*` | `agent/presentation_pipeline/generation/*` | Move and rename for clarity. |
+| `agent/paper2slides/summary/*` | `agent/presentation_pipeline/summarization/*` | Move. |
+| `agent/paper2slides/prompts/*` | `agent/presentation_pipeline/prompts/*` | Move. |
+| `agent/paper2slides/utils/*` | `agent/presentation_pipeline/utils/*` | Move, then split large files like `slide_assets.py`. |
+| `agent/paper2slides/rag/*` | `agent/presentation_pipeline/rag/*` or shared `document_intelligence/rag` | Decide based on whether it remains presentation-specific. |
+| `agent/paper2slides/raganything/*` | `agent/document_intelligence/raganything/*` | Move because `DoclingParser` is not presentation-only. Keep shim package. |
+| `agent/raganything/*` | Remove or merge | There is a tiny top-level compatibility package. Collapse into the new parser package or keep as a temporary shim. |
+
+### Backend/Frontend Integration
+
+| File | Action |
+| --- | --- |
+| `agent/helpudoc_agent/paper2slides_runner.py` | Rename to `presentation_runner.py`; keep shim. Update command to call new module. |
+| `agent/helpudoc_agent/app.py` | After API split, update routes to import from `presentation_runner.py`. |
+| `backend/src/services/paper2SlidesService.ts` | Keep API naming for product continuity, but move directory to `services/paper2slides`. |
+| `backend/src/services/paper2SlidesJobService.ts` | Same. |
+| `frontend/src/services/paper2SlidesJobApi.ts` | Keep public API names until UI copy changes. |
+| `frontend/src/constants/workspace.ts` | Consider renaming constants from `PAPER2SLIDES_*` to `PRESENTATION_*` only after product copy changes. |
+| `tests/test_paper2slides_cache.py` | Update imports to `presentation_runner`; add shim import test for old name. |
+| `tests/test_paper2slides_frontend_flow.sh` | Update to call the new CLI, then optionally keep a legacy command smoke test. |
+| `agent/paper2slides/tests/test_slide_assets.py` | Move to `agent/presentation_pipeline/tests/`. |
+
+### Dependency Split
+
+| New file | Purpose |
+| --- | --- |
+| `agent/requirements-api.txt` | FastAPI, LangChain/LangGraph/DeepAgents, Google SDK, postgres checkpoint, Redis, Langfuse, lightweight runtime. |
+| `agent/requirements-parser.txt` | Docling, MinerU, LightRAG, PyTorch CPU, torchvision, transformers, pypdf/pymupdf/opencv. |
+| `agent/requirements-reporting.txt` | pandas, duckdb, matplotlib, seaborn, plotly, kaleido, python-pptx. |
+| `agent/requirements-runtime.txt` | Includes api plus selected shared deps for current combined image. |
+| `agent/requirements.txt` | Temporary umbrella including the split files for compatibility. |
+| `agent/Dockerfile.base` | Heavy base image for parser/reporting dependencies. |
+| `agent/Dockerfile.gke` | App image layered on base or installing `requirements-runtime.txt`. |
+| `agent/Dockerfile.parser-worker` | Future parser worker image. |
+| `agent/Dockerfile.report-worker` | Future reporting worker image if dashboards/reports get separate queue. |
+
+## Phase 10 - Service and Image Boundary Split
+
+Goal: reduce agent rebuild weight and isolate heavy workloads.
+
+### Target Services
+
+| Service | Image | Responsibility |
+| --- | --- | --- |
+| Backend API | `helpudoc-backend` | Auth, RBAC, workspace/files, conversations, job orchestration. |
+| Frontend | `helpudoc-frontend` | React UI served by nginx. |
+| Agent API | `helpudoc-agent-api` | Chat orchestration, tools, MCP binding, memory/checkpointing. |
+| Parser worker | `helpudoc-parser-worker` | Docling/MinerU/LightRAG ingestion and attachment understanding. |
+| Report worker | `helpudoc-report-worker` | Data dashboards, reports, PPTX/image-heavy generation if needed. |
+
+### Files
+
+| File | Action |
+| --- | --- |
+| `infra/gke/k8s/50-app.yaml` | Eventually remove parser-heavy env/deps from the agent API container. |
+| `infra/gke/k8s/53-parser-worker.yaml` | New deployment or job worker for RAG/document parsing. |
+| `infra/gke/k8s/54-report-worker.yaml` | Optional future worker if report generation needs isolation. |
+| `backend/src/services/ragQueueService.ts` | Confirm queue payloads are stable enough for parser worker. |
+| `agent/helpudoc_agent/rag/worker.py` | Becomes parser-worker entrypoint. |
+| `agent/parser_worker.py` | New uvicorn-free worker entrypoint or module runner. |
+| `agent/report_worker.py` | Optional future worker entrypoint. |
+| `.github/workflows/build-images.yml` | Add selectable images: `agent-api`, `parser-worker`, `report-worker`. |
+| `docs/current-architecture.md` | Update diagrams after worker split. |
+
+## Phase 11 - Infra and Registry Modernization
+
+Goal: modern GCP registry, cleaner manifests, and safer releases.
+
+| File | Action |
+| --- | --- |
+| `.github/workflows/*.yml` | Support `REGISTRY_HOST` and image repository inputs so `gcr.io` to Artifact Registry is one config change. |
+| `infra/gke/k8s/*.yaml` | Replace hard-coded `gcr.io/my-rd-coe-demo-gen-ai/...` with documented placeholders or Kustomize overlays. |
+| `infra/gke/kustomization.yaml` | New optional Kustomize base for image substitutions. |
+| `infra/gke/overlays/dev/kustomization.yaml` | Optional environment overlay. |
+| `infra/gke/overlays/prod/kustomization.yaml` | Optional environment overlay with prod hosts/resources. |
+| `infra/gke/README.md` | Add Artifact Registry setup and IAM notes. |
+| `docs/ci-cd.md` | Document SHA tags plus environment aliases. |
+| `.github/workflows/deploy-gke.yml` | Optionally push `:staging` or `:prod` aliases after SHA push, but deploy by SHA. |
+
+## Phase 12 - Documentation and Developer Experience
+
+| File | Action |
+| --- | --- |
+| `README.md` | Add concise repo map and link to architecture/deploy docs. |
+| `agent/README.md` | Update package names after agent refactor. |
+| `backend/README.md` | Add backend module map and local commands. |
+| `frontend/README.md` | Add frontend feature directory map. |
+| `docs/current-architecture.md` | Refresh diagrams. Note actual Langfuse instrumentation and worker split status. |
+| `docs/environment.md` | Generate or manually align from env schema. |
+| `docs/ci-cd.md` | Update to new workflows. |
+| `docs/deploy.md` | Update normal deploy vs infra deploy. |
+| `docs/data-skill-migration.md` | Update after data tools move and dashboard runtime package split. |
+| `docs/dashboard-runtime-status.md` | Update after `packages/dashboard-runtime` split. |
+| `docs/paper2slides-cache-bug.md` | Update paths after presentation package move. |
+
+## Recommended Implementation Order
+
+| Step | Work | Priority | Why |
+| ---: | --- | --- | --- |
+| 1 | Add Buildx registry cache and pip/npm cache mounts. | P0 | Immediate CI speed gain. |
+| 2 | Add deploy inputs for component build toggles and `deploy_infra`. | P0 | Avoid rebuilding/deploying everything every run. |
+| 3 | Add CI workflow with tests/builds and no push. | P0 | Creates safety net before refactors. |
+| 4 | Add env schema and typed backend/agent env modules. | P0/P1 | Reduces hidden config drift before service split. |
+| 5 | Replace `kubectl exec` skills/config sync with init-container seeding. | P1 | Makes deployments reproducible by image tag. |
+| 6 | Split `graph.py`, `configuration.py`, and `app.py` with shims. | P1 | Removes agent naming confusion and central file risk. |
+| 7 | Split data tools and dashboard runtime package. | P1 | Cleans up dashboard/data ownership and `packages` ambiguity. |
+| 8 | Split backend `agent.ts`, `settings.ts`, and `agentRunService.ts`. | P1 | Makes API/service ownership readable. |
+| 9 | Split frontend `WorkspacePage.tsx` and `ChatMessageBubble.tsx`. | P1 | Biggest frontend maintainability win. |
+| 10 | Split requirements and create agent base image. | P1 | Prepares for image weight reduction. |
+| 11 | Move parser code out of `paper2slides` and add parser worker image. | P1/P2 | Fixes naming and build-weight root cause. |
+| 12 | Move from `gcr.io` to Artifact Registry and Kustomize overlays. | P2 | Good platform hygiene after pipeline is stable. |
+
+## Validation Matrix
+
+| Area | Commands/checks |
+| --- | --- |
+| Python agent | `python -m pytest tests/test_agent_import_smoke.py tests/test_agent_configuration.py tests/test_mcp_binding.py tests/test_tool_factory.py` |
+| Agent container | `docker buildx build -f agent/Dockerfile.gke --load -t helpudoc-agent:test .` then `docker run --rm helpudoc-agent:test python /app/agent/scripts/smoke_import.py` |
+| Backend | `cd backend && npm test` |
+| Frontend | `cd frontend && npm run lint && npm run build` |
+| Shared packages | `npm install` from workspace root if workspaces are adopted, then frontend/backend type checks. |
+| GKE normal deploy | Build selected component only, `kubectl set image`, rollout wait, smoke tests. |
+| GKE infra deploy | `kubectl diff`, apply manifests, bootstrap Langfuse/config only when requested. |
+| Graph upkeep | After code-file edits: `graphify update .` |
+
+## Compatibility Shim Policy
+
+Use shims for package/file renames that have broad imports:
+
+| Old path | Shim behavior | Removal condition |
+| --- | --- | --- |
+| `helpudoc_agent.graph` | Re-export from `helpudoc_agent.runtime.agent_registry`. | Remove after all tests/imports use new path and one release cycle passes. |
+| `helpudoc_agent.configuration` | Re-export config models and `load_settings`. | Remove after app/tests/docs use `helpudoc_agent.config.*`. |
+| `helpudoc_agent.tools_and_schemas` | Re-export `ToolFactory`, schemas, and managers. | Remove after tool modules are stable. |
+| `helpudoc_agent.data_agent_tools` | Re-export `build_data_agent_tools` and key classes. | Remove after runtime config references new entrypoint. |
+| `paper2slides` package | Re-export/forward to `presentation_pipeline`. | Remove only after CLI, backend, frontend, docs, and tests no longer refer to Paper2Slides as a package name. Product copy can still say Paper2Slides if desired. |
+| `paper2slides.raganything` | Re-export from `document_intelligence.raganything`. | Remove after RAG and presentation pipeline imports are migrated. |
+| `packages/shared` | Keep package alias or publish deprecation package. | Remove after backend/frontend import `@helpudoc/contracts` and `@helpudoc/dashboard-runtime`. |
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Large rename breaks imports across tests and runtime. | Move one boundary at a time and keep shims. |
+| Docker cache does not hit because context changes too often. | Copy dependency manifests before source, use Buildx registry cache, and split requirements. |
+| Skills PVC diverges from image source. | Add version marker during init seeding and surface source/version in settings. |
+| Backend and agent disagree on env defaults. | Typed loaders generated/validated against one env schema. |
+| Parser worker split changes runtime behavior. | First create base image and requirements split, then move queue worker, then remove parser deps from API image. |
+| Frontend refactor causes UI regressions. | Split hooks/components behind existing page route and run Playwright smoke tests. |
+| Shared package rename breaks Vite or ts-node. | Adopt npm workspaces or explicit `file:` dependencies in both frontend and backend. |
+
+## Near-Term PR Breakdown
+
+Use these checklists as the working tracker. Keep items unchecked until the PR is merged and docs/tests have been updated.
+
+### PR 1 - `ci-build-cache`
+
+Buildx cache, pip/npm cache mounts, component toggles, and `deploy_infra`.
+
+- [x] Add `workflow_dispatch` inputs to `.github/workflows/deploy-gke.yml`: `build_backend`, `build_frontend`, `build_agent`, `deploy_infra`, `sync_runtime_assets`, optional `environment`, and optional tag suffix.
+- [x] Replace `docker build` / `docker push` in `.github/workflows/deploy-gke.yml` with `docker buildx build --cache-from ... --cache-to ... --push`.
+- [x] Add Buildx setup and registry-cache naming for backend, frontend, and agent images.
+- [x] Gate backend image build on `inputs.build_backend`.
+- [x] Gate frontend image build on `inputs.build_frontend`.
+- [x] Gate agent image build on `inputs.build_agent`.
+- [x] Update `kubectl set image` logic so only selected components are patched.
+- [x] Gate RBAC verification behind `inputs.deploy_infra`.
+- [x] Gate manifest apply behind `inputs.deploy_infra`.
+- [x] Gate ConfigMap/bootstrap/Langfuse steps behind `inputs.deploy_infra`.
+- [x] Temporarily gate skills/config `kubectl exec` sync behind `inputs.sync_runtime_assets`.
+- [x] Add `# syntax=docker/dockerfile:1.7` to `agent/Dockerfile.gke`.
+- [x] Add BuildKit pip cache mount to `agent/Dockerfile.gke`.
+- [x] Add BuildKit pip cache mount to `agent/Dockerfile`.
+- [x] Add npm cache mount to `backend/Dockerfile.gke`.
+- [x] Run agent image smoke import with `agent/scripts/smoke_import.py`.
+- [x] Update `docs/ci-cd.md` with the new manual deploy inputs.
+- [x] Update `docs/deploy.md` with normal app deploy versus infra deploy guidance.
+
+### PR 2 - `ci-docs-and-smoke`
+
+PR CI, smoke routes/checks, and deployment docs.
+
+- [x] Add `.github/workflows/ci.yml`.
+- [x] Add backend test job running `cd backend && npm test`.
+- [x] Add frontend lint/build job running `cd frontend && npm run lint && npm run build`.
+- [x] Add Python smoke/test job for `tests/test_agent_import_smoke.py` and core agent tests.
+- [x] Add no-push Docker build check for backend image.
+- [x] Add no-push Docker build check for frontend image.
+- [x] Add no-push Docker build check for agent image if CI time is acceptable.
+- [x] Add or expose backend health endpoint under `/api/health`.
+- [x] Add or expose agent runtime health endpoint under `/health`.
+- [x] Add post-deploy backend smoke check in `.github/workflows/deploy-gke.yml`.
+- [x] Add post-deploy frontend smoke check in `.github/workflows/deploy-gke.yml`.
+- [x] Add post-deploy agent smoke check in `.github/workflows/deploy-gke.yml`.
+- [x] Document smoke checks in `docs/ci-cd.md`.
+- [x] Confirm `secret-scan.yml` still runs independently or as part of required checks.
+
+### PR 3 - `runtime-assets-seeding`
+
+Image-bundled skills/config source and init-container copy, replacing `kubectl exec` sync.
+
+- [x] Choose the runtime asset ownership model: image-seeded PVC, ConfigMap, or admin-editable PVC with image source marker.
+- [x] Update `agent/Dockerfile.gke` to copy `skills/` to `/app/skills-source`.
+- [x] Update `agent/Dockerfile.gke` to copy `agent/config/runtime.yaml` to `/app/agent-config-source/runtime.yaml`.
+- [x] Update `backend/Dockerfile.gke` only if backend remains the owner of settings/skills source assets (no change: agent image owns bundled source; init uses agent image).
+- [x] Add init container in `infra/gke/k8s/50-app.yaml` to seed `/app/skills` from source assets.
+- [x] Add init container in `infra/gke/k8s/50-app.yaml` to seed `/agent/config/runtime.yaml` from source assets.
+- [x] Add a version/source marker file for seeded skills.
+- [x] Add a version/source marker file for seeded agent config.
+- [x] Ensure init containers do not overwrite admin-edited runtime assets unless explicitly configured.
+- [x] Patch init-container images in deploy workflow when app image tags change.
+- [x] Remove or disable `kubectl exec` skills sync after seeding is verified.
+- [x] Remove or disable `kubectl exec` agent config sync after seeding is verified.
+- [ ] Update settings API or UI to show image source version versus live PVC version if both exist (deferred; revision markers documented for operators in `docs/deploy.md`).
+- [x] Update `docs/deploy.md` and `docs/ci-cd.md`.
+
+### PR 4 - `env-schema`
+
+Canonical env schema plus backend/agent typed env loaders.
+
+- [ ] Add `infra/env/helpudoc.env.schema.yaml`.
+- [ ] Catalog backend-owned env vars in the schema.
+- [ ] Catalog agent-owned env vars in the schema.
+- [ ] Catalog frontend `VITE_*` vars in the schema.
+- [ ] Mark secrets versus non-secrets.
+- [ ] Mark local required, prod required, and optional vars.
+- [ ] Add deprecated alias notes for variables such as `PARSER` versus `RAGANYTHING_PARSER`.
+- [ ] Add `backend/src/config/env.ts` using Zod or an equivalent typed parser.
+- [ ] Update `backend/src/index.ts` to read session/server config from `backend/src/config/env.ts`.
+- [ ] Update `backend/src/services/databaseService.ts` to read DB config from the env module.
+- [ ] Update `backend/src/services/s3Service.ts` to read S3 config from the env module.
+- [ ] Update `backend/src/services/googleOAuthService.ts` to read OAuth config from the env module.
+- [ ] Add `agent/helpudoc_agent/config/env.py` using Pydantic or dataclasses.
+- [ ] Update `agent/helpudoc_agent/configuration.py` env override logic to use the new env helper.
+- [ ] Update `agent/helpudoc_agent/rag_indexer.py` / future RAG config to use the new env helper.
+- [ ] Update `agent/helpudoc_agent/sandbox_runner.py` to use the new env helper.
+- [ ] Add `frontend/src/config/env.ts` for typed Vite env access.
+- [ ] Add env validation script under `scripts/`.
+- [ ] Validate `env/local/*.env.example` against schema.
+- [ ] Validate `env/prod/*.env.example` against schema.
+- [ ] Update `docs/environment.md`.
+
+### PR 5 - `agent-runtime-rename`
+
+Move `graph.py` to runtime registry with compatibility shim.
+
+- [ ] Create `agent/helpudoc_agent/runtime/__init__.py`.
+- [ ] Move `AgentRegistry` from `agent/helpudoc_agent/graph.py` to `agent/helpudoc_agent/runtime/agent_registry.py`.
+- [ ] Move `_clone_preservable_context` to `agent/helpudoc_agent/runtime/agent_registry.py`.
+- [ ] Keep `agent/helpudoc_agent/graph.py` as a compatibility shim.
+- [ ] Update `agent/helpudoc_agent/app.py` imports to use `helpudoc_agent.runtime.agent_registry`.
+- [ ] Update `tests/test_mcp_binding.py` imports and monkeypatch paths.
+- [ ] Update `tests/test_agent_main.py` stubs and cleanup lists.
+- [ ] Add a small test proving `from helpudoc_agent.graph import AgentRegistry` still works.
+- [ ] Update references in `docs/repo-cicd-restructure-plan.md` if the target path changes.
+- [ ] Run focused Python tests.
+- [ ] Run `graphify update .`.
+
+### PR 6 - `agent-api-split`
+
+Split `agent/helpudoc_agent/app.py` into API modules.
+
+- [ ] Create `agent/helpudoc_agent/api/__init__.py`.
+- [ ] Create `agent/helpudoc_agent/api/app.py` and move `create_app`.
+- [ ] Keep `agent/helpudoc_agent/app.py` as a compatibility shim or thin wrapper.
+- [ ] Move Pydantic request/response models to `agent/helpudoc_agent/api/schemas.py`.
+- [ ] Move startup/shutdown setup to `agent/helpudoc_agent/api/lifecycle.py`.
+- [ ] Move internal analysis/memory routes to `agent/helpudoc_agent/api/routes/internal.py`.
+- [ ] Move RAG query/status routes to `agent/helpudoc_agent/api/routes/rag.py`.
+- [ ] Move Paper2Slides routes to `agent/helpudoc_agent/api/routes/paper2slides.py`.
+- [ ] Move attachment understanding route to `agent/helpudoc_agent/api/routes/attachments.py`.
+- [ ] Move chat/stream/resume/respond/act routes to `agent/helpudoc_agent/api/routes/chat.py`.
+- [ ] Move skill contract route to `agent/helpudoc_agent/api/routes/skills.py`.
+- [ ] Move health/diagnostics route to `agent/helpudoc_agent/api/routes/health.py`.
+- [ ] Update `agent/main.py` to import `create_app` from the new API package.
+- [ ] Update tests that import `helpudoc_agent.app`.
+- [ ] Run focused agent API tests.
+- [ ] Run `graphify update .`.
+
+### PR 7 - `shared-packages-split`
+
+Split `packages/shared` into `contracts` and `dashboard-runtime`.
+
+- [ ] Add `packages/contracts/package.json`.
+- [ ] Move API/domain types from `packages/shared/src/types.ts` to `packages/contracts/src/types.ts`.
+- [ ] Move agent stream helper from `packages/shared/src/services/agentStream.ts` to `packages/contracts/src/agentStream.ts`.
+- [ ] Add package exports for `@helpudoc/contracts/types`.
+- [ ] Add package exports for `@helpudoc/contracts/agentStream`.
+- [ ] Add `packages/dashboard-runtime/package.json`.
+- [ ] Move `packages/shared/src/dashboard/*` to `packages/dashboard-runtime/src/*`.
+- [ ] Add package exports for `@helpudoc/dashboard-runtime`.
+- [ ] Update `frontend/package.json` dependencies.
+- [ ] Update `backend/package.json` dependencies if backend imports contracts directly.
+- [ ] Replace frontend relative imports from `packages/shared`.
+- [ ] Replace backend relative imports from `packages/shared`.
+- [ ] Decide whether to add npm workspaces at the repo root.
+- [ ] Keep `packages/shared` as a compatibility package or remove after all imports are migrated.
+- [ ] Run frontend build.
+- [ ] Run backend tests/type checks.
+
+### PR 8 - `data-tools-split`
+
+Data tools package and renderer split.
+
+- [ ] Create `agent/helpudoc_agent/tools/data/`.
+- [ ] Move `DataAgentSessionState` and record types to `tools/data/state.py`.
+- [ ] Move `DuckDBManager` to `tools/data/duckdb_manager.py`.
+- [ ] Move SQL/schema/materialization tools to `tools/data/query_tools.py`.
+- [ ] Move chart tools to `tools/data/chart_tools.py`.
+- [ ] Move dashboard generation tools to `tools/data/dashboard_tools.py`.
+- [ ] Move `build_data_agent_tools` to `tools/data/factory.py`.
+- [ ] Keep `agent/helpudoc_agent/data_agent_tools.py` as a compatibility shim.
+- [ ] Split `agent/helpudoc_agent/data_report_renderers.py` into data renderer modules.
+- [ ] Update `agent/config/runtime.yaml` entrypoint for `data_agent_tools` when compatibility shim is no longer needed.
+- [ ] Update `tests/test_data_skill_family.py`.
+- [ ] Split or update `agent/tests/test_data_agent_tools.py`.
+- [ ] Run data-tool tests.
+- [ ] Run `graphify update .`.
+
+### PR 9 - `backend-api-split`
+
+Split backend agent/settings routes and agent run service.
+
+- [ ] Create `backend/src/api/agent/index.ts`.
+- [ ] Move agent run endpoints to `backend/src/api/agent/runs.ts`.
+- [ ] Move slash metadata endpoint to `backend/src/api/agent/slash.ts`.
+- [ ] Move Paper2Slides endpoints to `backend/src/api/agent/paper2slides.ts`.
+- [ ] Move presentation endpoint to `backend/src/api/agent/presentation.ts`.
+- [ ] Move effective agent policy helpers to `backend/src/api/agent/policy.ts` or a service module.
+- [ ] Update `backend/src/api/routes.ts` to import the new agent router.
+- [ ] Create `backend/src/api/settings/index.ts`.
+- [ ] Move agent config routes to `backend/src/api/settings/agentConfig.ts`.
+- [ ] Move skills CRUD routes to `backend/src/api/settings/skills.ts`.
+- [ ] Move skill builder routes to `backend/src/api/settings/skillBuilder.ts`.
+- [ ] Move GitHub import routes to `backend/src/api/settings/githubImport.ts`.
+- [ ] Move skill path/frontmatter helpers to `backend/src/services/skills/`.
+- [ ] Split `backend/src/services/agentRunService.ts` into `services/agent-runs/*`.
+- [ ] Keep a compatibility barrel for old `agentRunService` exports.
+- [ ] Update backend tests.
+- [ ] Run `cd backend && npm test`.
+
+### PR 10 - `frontend-workspace-split`
+
+Split workspace route and chat renderers.
+
+- [ ] Create `frontend/src/features/workspace/`.
+- [ ] Move `WorkspacePage` implementation to `frontend/src/features/workspace/WorkspacePage.tsx`.
+- [ ] Keep `frontend/src/pages/WorkspacePage.tsx` as a thin route re-export.
+- [ ] Extract workspace selection logic into `features/workspace/hooks/useWorkspaceSelection.ts`.
+- [ ] Extract file tree/content logic into `features/workspace/hooks/useWorkspaceFiles.ts`.
+- [ ] Extract agent run lifecycle logic into `features/chat/hooks/useAgentRun.ts`.
+- [ ] Extract conversation state logic into `features/chat/hooks/useConversationState.ts`.
+- [ ] Extract Paper2Slides polling/options into `features/paper2slides/hooks/usePaper2SlidesJob.ts`.
+- [ ] Extract dashboard artifact state into `features/dashboard/hooks/useDashboardArtifacts.ts`.
+- [ ] Move `PresentationModal` into `features/paper2slides/components/PresentationModal.tsx`.
+- [ ] Split `ChatMessageBubble.tsx` into message shell, tool events, interrupts, and artifact previews.
+- [ ] Move dashboard components under `features/dashboard/components`.
+- [ ] Move settings components under `features/settings/components`.
+- [ ] Run `cd frontend && npm run lint`.
+- [ ] Run `cd frontend && npm run build`.
+- [ ] Run relevant Playwright smoke tests if available.
+
+### PR 11 - `presentation-parser-split`
+
+Move parser out of Paper2Slides and split requirements.
+
+- [ ] Create `agent/presentation_pipeline/`.
+- [ ] Move Paper2Slides CLI/core/generator/summary/utils modules into `presentation_pipeline`.
+- [ ] Keep `agent/paper2slides` as a compatibility shim package.
+- [ ] Create `agent/document_intelligence/`.
+- [ ] Move `agent/paper2slides/raganything/*` into `agent/document_intelligence/raganything/`.
+- [ ] Keep `paper2slides.raganything` as a compatibility shim.
+- [ ] Update `agent/helpudoc_agent/paper2slides_runner.py` or rename it to `presentation_runner.py`.
+- [ ] Update RAG imports that currently reference `paper2slides.raganything`.
+- [ ] Update tests for new package paths.
+- [ ] Add shim tests for old package paths.
+- [ ] Create `agent/requirements-api.txt`.
+- [ ] Create `agent/requirements-parser.txt`.
+- [ ] Create `agent/requirements-reporting.txt`.
+- [ ] Create `agent/requirements-runtime.txt`.
+- [ ] Keep `agent/requirements.txt` as a temporary umbrella file.
+- [ ] Add `agent/Dockerfile.base`.
+- [ ] Update `agent/Dockerfile.gke` to use the split requirements or base image.
+- [ ] Run Paper2Slides cache/frontend-flow tests.
+- [ ] Run agent import smoke test.
+- [ ] Run `graphify update .`.
+
+### PR 12 - `artifact-registry-and-overlays`
+
+Artifact Registry and Kustomize overlays.
+
+- [ ] Choose Artifact Registry location and repository, for example `asia-southeast1-docker.pkg.dev/${PROJECT_ID}/helpudoc`.
+- [ ] Add registry host/repository variables to GitHub workflows.
+- [ ] Update Docker auth setup for Artifact Registry.
+- [ ] Update image naming in build workflows.
+- [ ] Keep deploy-by-SHA behavior.
+- [ ] Optionally add environment alias tags such as `staging` or `prod`.
+- [ ] Add `infra/gke/kustomization.yaml` or equivalent image substitution strategy.
+- [ ] Add `infra/gke/overlays/dev/kustomization.yaml` if needed.
+- [ ] Add `infra/gke/overlays/prod/kustomization.yaml` if needed.
+- [ ] Remove hard-coded `gcr.io/my-rd-coe-demo-gen-ai/...` image references from manifests or isolate them in overlays.
+- [ ] Update `infra/gke/README.md` with Artifact Registry setup and IAM.
+- [ ] Update `docs/ci-cd.md`.
+- [ ] Update `docs/deploy.md`.

--- a/frontend/src/ProtectedShell.tsx
+++ b/frontend/src/ProtectedShell.tsx
@@ -1,6 +1,6 @@
 import { Suspense, lazy, type FC, type ReactElement } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
-import { useAuth } from './auth/AuthProvider';
+import { useAuth } from './auth/useAuth';
 
 const WorkspacePage = lazy(() => import('./pages/WorkspacePage'));
 const AgentSettingsPage = lazy(() => import('./pages/AgentSettingsPage'));

--- a/frontend/src/auth/AuthProvider.tsx
+++ b/frontend/src/auth/AuthProvider.tsx
@@ -1,19 +1,8 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { getAuthUser, setAuthUser } from './authStore';
 import type { AuthUser } from './authStore';
 import { API_URL, AUTH_MODE, apiFetch } from '../services/apiClient';
-
-interface AuthContextValue {
-  user: AuthUser | null;
-  loading: boolean;
-  googleReady: boolean;
-  googleError: string | null;
-  authMode: 'oidc' | 'headers' | 'hybrid';
-  signInWithGoogle: (returnTo?: string) => Promise<void>;
-  signInWithHeaders: (profile: { name: string; email?: string | null }) => Promise<void>;
-  signOut: () => Promise<void>;
-  refreshSession: () => Promise<void>;
-}
+import { AuthContext, type AuthContextValue } from './authContext';
 
 type AuthMeResponse = {
   authenticated: boolean;
@@ -27,8 +16,6 @@ type AuthMeResponse = {
     isAdmin: boolean;
   } | null;
 };
-
-const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 const normalizeAuthMode = (mode?: string): 'oidc' | 'headers' | 'hybrid' => {
   const normalized = (mode || '').toLowerCase();
@@ -71,7 +58,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [authMode, setAuthMode] = useState<'oidc' | 'headers' | 'hybrid'>(() => normalizeAuthMode(AUTH_MODE));
   const [user, setUser] = useState<AuthUser | null>(() => (authMode === 'oidc' ? null : getAuthUser()));
   const [loading, setLoading] = useState(authMode !== 'headers');
-  const [googleConfigured, setGoogleConfigured] = useState<boolean>(false);
   const [googleError, setGoogleError] = useState<string | null>(null);
 
   const persistUser = useCallback((next: AuthUser | null) => {
@@ -82,7 +68,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const refreshSession = useCallback(async () => {
     if (authMode === 'headers') {
       persistUser(getAuthUser());
-      setGoogleConfigured(false);
       setGoogleError(null);
       setLoading(false);
       return;
@@ -99,7 +84,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const serverMode = normalizeAuthMode(payload.authMode);
       setAuthMode(serverMode);
       const googleIsConfigured = Boolean(payload.googleConfigured);
-      setGoogleConfigured(googleIsConfigured);
       setGoogleError(
         serverMode !== 'headers' && !googleIsConfigured
           ? 'Google sign-in is unavailable (server OAuth is not configured).'
@@ -132,7 +116,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       url.searchParams.set('returnTo', returnTo);
     }
     window.location.assign(url.toString());
-  }, [authMode, googleConfigured]);
+  }, [authMode]);
 
   const signInWithHeaders = useCallback(async (profile: { name: string; email?: string | null }) => {
     persistUser(buildHeaderAuthUser(profile));
@@ -167,15 +151,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     signInWithHeaders,
     signOut,
     refreshSession,
-  }), [authMode, googleConfigured, googleError, loading, refreshSession, signInWithGoogle, signInWithHeaders, signOut, user]);
+  }), [authMode, googleError, loading, refreshSession, signInWithGoogle, signInWithHeaders, signOut, user]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
-
-export function useAuth(): AuthContextValue {
-  const ctx = useContext(AuthContext);
-  if (!ctx) {
-    throw new Error('useAuth must be used within an AuthProvider');
-  }
-  return ctx;
-}

--- a/frontend/src/auth/authContext.ts
+++ b/frontend/src/auth/authContext.ts
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+import type { AuthUser } from './authStore';
+
+export interface AuthContextValue {
+  user: AuthUser | null;
+  loading: boolean;
+  googleReady: boolean;
+  googleError: string | null;
+  authMode: 'oidc' | 'headers' | 'hybrid';
+  signInWithGoogle: (returnTo?: string) => Promise<void>;
+  signInWithHeaders: (profile: { name: string; email?: string | null }) => Promise<void>;
+  signOut: () => Promise<void>;
+  refreshSession: () => Promise<void>;
+}
+
+export const AuthContext = createContext<AuthContextValue | undefined>(undefined);

--- a/frontend/src/auth/useAuth.ts
+++ b/frontend/src/auth/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { AuthContext, type AuthContextValue } from './authContext';
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return ctx;
+}

--- a/frontend/src/components/FileRenderer.tsx
+++ b/frontend/src/components/FileRenderer.tsx
@@ -140,10 +140,10 @@ const CODE_LANGUAGE_BY_EXTENSION: Record<string, string> = {
   '.dockerfile': 'docker',
 };
 let parquetRuntimePromise: Promise<{
-  parquetMetadataAsync: any;
-  parquetReadObjects: any;
-  parquetSchema: any;
-  compressors: any;
+  parquetMetadataAsync: typeof import('hyparquet').parquetMetadataAsync;
+  parquetReadObjects: typeof import('hyparquet').parquetReadObjects;
+  parquetSchema: typeof import('hyparquet').parquetSchema;
+  compressors: import('hyparquet').Compressors;
 }> | null = null;
 
 const loadParquetRuntime = async () => {

--- a/frontend/src/components/chat/AgentChatPane.tsx
+++ b/frontend/src/components/chat/AgentChatPane.tsx
@@ -7,6 +7,7 @@ import type {
   SetStateAction,
   SyntheticEvent,
 } from 'react';
+import type { Components } from 'react-markdown';
 import type {
   AgentPersona,
   ConversationMessage,
@@ -158,7 +159,7 @@ export default function AgentChatPane({
   isPreparingAttachments: boolean;
   personaDisplayName: string;
   messageBubbleMaxWidth: string;
-  markdownComponents: Record<string, any>;
+  markdownComponents: Components;
   expandedToolMessages: Set<ConversationMessage['id']>;
   expandedThinkingMessages: Set<ConversationMessage['id']>;
   copiedMessageId: ConversationMessage['id'] | null;

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -434,7 +434,6 @@ export default function ChatMessageBubble({
   handleInterruptAction,
   enableTrustedPlanMode,
   isStreaming,
-  workspaceId: _workspaceId,
 }: {
   colorMode: 'light' | 'dark';
   message: ConversationMessage;

--- a/frontend/src/components/chat/ChatMessageList.tsx
+++ b/frontend/src/components/chat/ChatMessageList.tsx
@@ -1,5 +1,6 @@
 import { ArrowDown, MessageSquareText } from 'lucide-react';
 import { type Dispatch, type ReactNode, type SetStateAction, useEffect, useMemo, useRef, useState } from 'react';
+import type { Components } from 'react-markdown';
 
 import type {
   ConversationMessage,
@@ -50,7 +51,7 @@ export default function ChatMessageList({
   isStreaming: boolean;
   personaDisplayName: string;
   messageBubbleMaxWidth: string;
-  markdownComponents: Record<string, any>;
+  markdownComponents: Components;
   expandedToolMessages: Set<ConversationMessage['id']>;
   expandedThinkingMessages: Set<ConversationMessage['id']>;
   copiedMessageId: ConversationMessage['id'] | null;

--- a/frontend/src/components/chat/approvalReview.ts
+++ b/frontend/src/components/chat/approvalReview.ts
@@ -103,7 +103,7 @@ const checklistToSteps = (checklist: string): PlanReviewStep[] =>
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean)
-    .map((line) => line.replace(/^[-*]\s+/, '').replace(/^\d+[\.\)]\s+/, '').trim())
+    .map((line) => line.replace(/^[-*]\s+/, '').replace(/^\d+[.)]\s+/, '').trim())
     .filter(Boolean)
     .map((title) => ({
       title,

--- a/frontend/src/components/dashboard/DashboardCanvas.tsx
+++ b/frontend/src/components/dashboard/DashboardCanvas.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import PlotlyChart from '../PlotlyChart';
 import type { PlotlySpec } from '../PlotlyChart';
 import { getWorkspaceFilePreview } from '../../services/fileApi';
-import { apiFetch, buildApiUrl } from '../../services/apiClient';
 import {
   applyDashboardFilters,
   buildPlotlyPayload,
@@ -214,21 +213,3 @@ function inferSchemaFromRows(sample: DashboardRow[]): DatasetSchemaColumn[] {
 }
 
 export default DashboardCanvas;
-
-/** Fetch snapshot HTML as a download (avoids executing HTML in a same-origin iframe). */
-export async function downloadDashboardHtmlExport(workspaceId: string, dashboardPath: string, filename?: string) {
-  const base = normalizePath(dashboardPath);
-  const path = `${base}/dashboard.snapshot.html`;
-  const url = buildApiUrl(`/workspaces/${workspaceId}/files/preview/raw`);
-  url.searchParams.set('path', path);
-  const res = await apiFetch(url.toString());
-  if (!res.ok) {
-    throw new Error('Failed to download HTML export');
-  }
-  const blob = await res.blob();
-  const a = document.createElement('a');
-  a.href = URL.createObjectURL(blob);
-  a.download = filename || 'dashboard.snapshot.html';
-  a.click();
-  URL.revokeObjectURL(a.href);
-}

--- a/frontend/src/components/dashboard/dashboardDownload.ts
+++ b/frontend/src/components/dashboard/dashboardDownload.ts
@@ -1,0 +1,26 @@
+import { apiFetch, buildApiUrl } from '../../services/apiClient';
+
+function normalizePath(value: string): string {
+  return String(value || '')
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .trim();
+}
+
+/** Fetch snapshot HTML as a download, avoiding same-origin iframe execution. */
+export async function downloadDashboardHtmlExport(workspaceId: string, dashboardPath: string, filename?: string) {
+  const base = normalizePath(dashboardPath);
+  const path = `${base}/dashboard.snapshot.html`;
+  const url = buildApiUrl(`/workspaces/${workspaceId}/files/preview/raw`);
+  url.searchParams.set('path', path);
+  const res = await apiFetch(url.toString());
+  if (!res.ok) {
+    throw new Error('Failed to download HTML export');
+  }
+  const blob = await res.blob();
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = filename || 'dashboard.snapshot.html';
+  a.click();
+  URL.revokeObjectURL(a.href);
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { PaletteMode } from '@mui/material';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Sun, Moon } from 'lucide-react';
-import { useAuth } from '../auth/AuthProvider';
+import { useAuth } from '../auth/useAuth';
 import { applyColorModeToDocument, resolveInitialColorMode } from '../colorMode';
 
 interface LocationState {

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -21,7 +21,6 @@ import {
   deleteFolder,
   deleteFile,
   getFileContent,
-  getWorkspaceFilePreview,
   renameFile,
   getRagStatuses,
   resolveFileContextRefs,
@@ -82,14 +81,15 @@ import WorkspaceShareDialog from '../components/WorkspaceShareDialog';
 import type { UIBlock } from '../components/UIBlockRenderer';
 import ExpandableSidebar from '../components/ExpandableSidebar';
 import WorkspaceFileTree from '../components/WorkspaceFileTree';
-import DashboardCanvas, { downloadDashboardHtmlExport } from '../components/dashboard/DashboardCanvas';
+import DashboardCanvas from '../components/dashboard/DashboardCanvas';
+import { downloadDashboardHtmlExport } from '../components/dashboard/dashboardDownload';
 import AgentChatPane from '../components/chat/AgentChatPane';
 import { buildApprovalDraftContent, buildApprovalReview } from '../components/chat/approvalReview';
 import type { RenderableInterruptAction } from '../components/chat/interruptActions';
 import DrivePickerModal from '../components/chat/DrivePickerModal';
 import GoogleDriveIcon from '../components/chat/GoogleDriveIcon';
 import type { ChatComposerAttachment } from '../components/chat/chatTypes';
-import { useAuth } from '../auth/AuthProvider';
+import { useAuth } from '../auth/useAuth';
 import {
   extractToolPathFiles,
   getFriendlyToolName,
@@ -4416,10 +4416,7 @@ export default function WorkspacePage() {
           console.debug('[WorkspacePage] stream finished', { runId, status: finalStatus });
         }
         flushBufferedAgentChunks();
-        if (supersededByNewerStream) {
-          return;
-        }
-        if (finalStatus === 'running' || finalStatus === 'queued') {
+        if (!supersededByNewerStream && (finalStatus === 'running' || finalStatus === 'queued')) {
           const reconnectAttempts = (runInfo.streamReconnectAttempts || 0) + 1;
           if (reconnectAttempts > 5) {
             const failedStatus: AgentRunStatus = 'failed';
@@ -4444,63 +4441,63 @@ export default function WorkspacePage() {
             stopRequestedRef.current = false;
             resumeInFlightRef.current.delete(runId);
             removeActiveRun(runId);
-            return;
+          } else {
+            const resumedRunInfo: ActiveRunInfo = {
+              ...runInfo,
+              status: 'running',
+              lastStreamId,
+              streamReconnectAttempts: reconnectAttempts,
+            };
+            registerActiveRun(resumedRunInfo);
+            setConversationAttention(conversationId, 'running', 'Streaming the latest agent updates...');
+            if (streamAbortMapRef.current.get(conversationId) === controller) {
+              streamAbortMapRef.current.delete(conversationId);
+            }
+            window.setTimeout(() => {
+              const activeRun = activeRunsRef.current[runId];
+              if (!activeRun || activeRun.status !== 'running') {
+                return;
+              }
+              void streamRunForConversation(activeRun, false, activeRun.lastStreamId);
+            }, Math.min(10000, 1000 * reconnectAttempts));
           }
-          const resumedRunInfo: ActiveRunInfo = {
-            ...runInfo,
-            status: 'running',
-            lastStreamId,
-            streamReconnectAttempts: reconnectAttempts,
-          };
-          registerActiveRun(resumedRunInfo);
-          setConversationAttention(conversationId, 'running', 'Streaming the latest agent updates...');
+        } else if (!supersededByNewerStream) {
+          const normalizedFinalStatus = normalizeRunStatus(finalStatus);
+          await syncRunStateToConversation(
+            {
+              ...runInfo,
+              status: normalizedFinalStatus,
+              lastStreamId,
+            },
+            normalizedFinalStatus,
+            normalizedFinalStatus === 'awaiting_approval' ? effectivePendingInterrupt : undefined,
+          );
+          setConversationAttention(
+            conversationId,
+            normalizedFinalStatus,
+            normalizedFinalStatus === 'awaiting_approval'
+              ? effectivePendingInterrupt?.title || effectivePendingInterrupt?.description || 'Waiting for your input.'
+              : normalizedFinalStatus === 'completed'
+                ? 'The latest run completed.'
+                : normalizedFinalStatus === 'cancelled'
+                  ? 'The latest run was stopped.'
+                  : latestRunMeta?.error || 'The latest run failed.',
+          );
+          setStreamingForConversation(conversationId, false);
           if (streamAbortMapRef.current.get(conversationId) === controller) {
             streamAbortMapRef.current.delete(conversationId);
           }
-          window.setTimeout(() => {
-            const activeRun = activeRunsRef.current[runId];
-            if (!activeRun || activeRun.status !== 'running') {
-              return;
+          stopRequestedRef.current = false;
+          resumeInFlightRef.current.delete(runId);
+          if (finalStatus === 'awaiting_approval') {
+            registerActiveRun({ ...runInfo, status: finalStatus, lastStreamId, streamReconnectAttempts: 0 });
+          } else {
+            removeActiveRun(runId);
+            removeActiveRunsForTurn(conversationId, turnId);
+            const workspaceId = selectedWorkspace?.id;
+            if (workspaceId) {
+              loadFilesForWorkspace(workspaceId);
             }
-            void streamRunForConversation(activeRun, false, activeRun.lastStreamId);
-          }, Math.min(10000, 1000 * reconnectAttempts));
-          return;
-        }
-        const normalizedFinalStatus = normalizeRunStatus(finalStatus);
-        await syncRunStateToConversation(
-          {
-            ...runInfo,
-            status: normalizedFinalStatus,
-            lastStreamId,
-          },
-          normalizedFinalStatus,
-          normalizedFinalStatus === 'awaiting_approval' ? effectivePendingInterrupt : undefined,
-        );
-        setConversationAttention(
-          conversationId,
-          normalizedFinalStatus,
-          normalizedFinalStatus === 'awaiting_approval'
-            ? effectivePendingInterrupt?.title || effectivePendingInterrupt?.description || 'Waiting for your input.'
-            : normalizedFinalStatus === 'completed'
-              ? 'The latest run completed.'
-              : normalizedFinalStatus === 'cancelled'
-                ? 'The latest run was stopped.'
-                : latestRunMeta?.error || 'The latest run failed.',
-        );
-        setStreamingForConversation(conversationId, false);
-        if (streamAbortMapRef.current.get(conversationId) === controller) {
-          streamAbortMapRef.current.delete(conversationId);
-        }
-        stopRequestedRef.current = false;
-        resumeInFlightRef.current.delete(runId);
-        if (finalStatus === 'awaiting_approval') {
-          registerActiveRun({ ...runInfo, status: finalStatus, lastStreamId, streamReconnectAttempts: 0 });
-        } else {
-          removeActiveRun(runId);
-          removeActiveRunsForTurn(conversationId, turnId);
-          const workspaceId = selectedWorkspace?.id;
-          if (workspaceId) {
-            loadFilesForWorkspace(workspaceId);
           }
         }
       }

--- a/frontend/src/services/knowledgeApi.ts
+++ b/frontend/src/services/knowledgeApi.ts
@@ -28,8 +28,8 @@ export const createKnowledge = async (
     content?: string;
     fileId?: number;
     sourceUrl?: string;
-    tags?: any;
-    metadata?: Record<string, any>;
+    tags?: unknown;
+    metadata?: Record<string, unknown>;
   },
 ) => {
   const response = await apiFetch(`${API_URL}/workspaces/${workspaceId}/knowledge`, {
@@ -50,8 +50,8 @@ export const updateKnowledge = async (
     content?: string;
     fileId?: number | null;
     sourceUrl?: string;
-    tags?: any;
-    metadata?: Record<string, any>;
+    tags?: unknown;
+    metadata?: Record<string, unknown>;
   }>,
 ) => {
   const response = await apiFetch(`${API_URL}/workspaces/${workspaceId}/knowledge/${knowledgeId}`, {

--- a/infra/gke/k8s/50-app.yaml
+++ b/infra/gke/k8s/50-app.yaml
@@ -16,6 +16,51 @@ spec:
         app: helpudoc-app
     spec:
       serviceAccountName: helpudoc-agent
+      initContainers:
+        # Copy image-bundled skills/config into PVCs only when the mount is empty,
+        # so admin edits on the PVC are preserved across restarts.
+        - name: seed-skills
+          image: gcr.io/my-rd-coe-demo-gen-ai/helpudoc-agent:latest
+          imagePullPolicy: Always
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              if [ -f /pvc-skills/research/SKILL.md ]; then
+                echo "seed-skills: PVC already has skills; skipping."
+                exit 0
+              fi
+              echo "seed-skills: copying from image to PVC..."
+              mkdir -p /pvc-skills
+              cp -a /app/skills-source/. /pvc-skills/
+              if [ -f /app/skills-source/.HELPUDOC_SOURCE_REVISION ]; then
+                cp /app/skills-source/.HELPUDOC_SOURCE_REVISION /pvc-skills/.HELPUDOC_IMAGE_SOURCE_REVISION || true
+              fi
+          volumeMounts:
+            - name: skills-data
+              mountPath: /pvc-skills
+        - name: seed-agent-config
+          image: gcr.io/my-rd-coe-demo-gen-ai/helpudoc-agent:latest
+          imagePullPolicy: Always
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              if [ -f /pvc-agent-config/runtime.yaml ]; then
+                echo "seed-agent-config: PVC already has runtime.yaml; skipping."
+                exit 0
+              fi
+              echo "seed-agent-config: copying runtime.yaml from image to PVC..."
+              mkdir -p /pvc-agent-config
+              cp /app/agent-config-source/runtime.yaml /pvc-agent-config/runtime.yaml
+              if [ -f /app/agent-config-source/.HELPUDOC_SOURCE_REVISION ]; then
+                cp /app/agent-config-source/.HELPUDOC_SOURCE_REVISION /pvc-agent-config/.HELPUDOC_IMAGE_SOURCE_REVISION || true
+              fi
+          volumeMounts:
+            - name: agent-config-data
+              mountPath: /pvc-agent-config
       containers:
         - name: backend
           image: gcr.io/my-rd-coe-demo-gen-ai/helpudoc-backend:latest


### PR DESCRIPTION
## Summary

This PR bundles the first three CI/CD restructuring slices from `docs/repo-cicd-restructure-plan.md`:

- Reworks the GKE deploy workflow around explicit build/deploy inputs, Buildx registry caching, gated infra steps, conditional image updates, and opt-in legacy runtime asset sync.
- Adds PR CI coverage for backend tests, frontend lint/build, selected Python pytest coverage, and no-push Docker image builds.
- Seeds runtime skills and agent config from the agent image through init containers, preserving existing PVC/admin edits and recording source revision files.

## Operational notes

- The first rollout of the new init containers needs `deploy_infra: true` once, or a direct apply of `infra/gke/k8s/50-app.yaml`, so the Deployment includes the init containers before app-only image patching.
- App-only deploys now require an existing `helpudoc-config`; otherwise the workflow fails fast with a clear error.
- Runtime asset PVC/image revision comparison remains documented via `.HELPUDOC_IMAGE_SOURCE_REVISION` and `.HELPUDOC_SOURCE_REVISION`; the settings API/UI follow-up remains the only open PR3 checklist item.

## Validation

- Confirmed local branch tip: `759d214` (`ci: PR1–3 deploy workflow, CI, init seeding, health probes`).
- Ran `git diff --check origin/master...HEAD` successfully.
- Confirmed `graphify update .` was already run after code edits per handoff.