### PR TITLE
docs: clarify PR12 deploy surface readiness

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -58,11 +58,32 @@ At least one of `build_backend`, `build_frontend`, or `build_agent` must be true
 
 The smaller **Deploy Frontend / Backend / Agent to GKE** workflows still build one image at a time and patch the matching deployment. Prefer **`deploy-gke.yml`** when you want Buildx cache, component toggles, and smoke checks in one place.
 
+Until PR12 lands, **`deploy-gke.yml` is the preferred app deploy path**. The one-off component workflows and Cloud Build configs may lag the registry strategy because they still carry direct `gcr.io` assumptions. If PR12 migrates images from Container Registry to Artifact Registry, it must update these legacy paths at the same time or retire them so operators do not accidentally deploy from the old registry.
+
+### PR12 registry surface
+
+Current app image and cache references are still tied to `gcr.io` in these deploy surfaces:
+
+| Surface | Current `gcr.io` usage PR12 must address |
+| --- | --- |
+| `.github/workflows/deploy-gke.yml` | Authenticates Docker to `gcr.io`, uses Buildx cache refs under `gcr.io/$PROJECT_ID/helpudoc-buildcache-*`, builds/pushes backend/frontend/agent images under `gcr.io/$PROJECT_ID/...`, pulls the agent image for smoke import, and patches backend/frontend/agent/init-container/CronJob images to `gcr.io/$PROJECT_ID/...`. |
+| `.github/workflows/deploy-backend-gke.yml` | Authenticates to `gcr.io`, builds/pushes `helpudoc-backend`, applies `50-app.yaml` and `52-daily-reflection-cron.yaml`, then patches backend and reflection CronJob images to `gcr.io/$PROJECT_ID/...`. |
+| `.github/workflows/deploy-frontend-gke.yml` | Authenticates to `gcr.io`, builds/pushes `helpudoc-frontend`, applies `60-frontend.yaml`, then patches the frontend image to `gcr.io/$PROJECT_ID/...`. |
+| `.github/workflows/deploy-agent-gke.yml` | Authenticates to `gcr.io`, builds/runs/pushes `helpudoc-agent`, applies `50-app.yaml`, then patches the agent image to `gcr.io/$PROJECT_ID/...`. It also runs the legacy PVC sync path after deploy. |
+| `infra/cloudbuild.yaml` | Uses Cloud Build builder images from `gcr.io/cloud-builders/*`, pulls cache/source images from `gcr.io/$PROJECT_ID/...:latest`, builds/tags/pushes backend/frontend/agent images to `gcr.io/$PROJECT_ID/...`, rewrites manifest image refs with `sed`, and declares `images:` outputs under `gcr.io/$PROJECT_ID/...`. |
+| `infra/cloudbuild-frontend.yaml` | Uses Cloud Build builder images from `gcr.io/cloud-builders/*`, pulls/builds/tags/pushes `helpudoc-frontend` to `gcr.io/$PROJECT_ID/...`, rewrites `60-frontend.yaml`, and declares a `gcr.io/$PROJECT_ID/...` image output. |
+| `infra/gke/k8s/50-app.yaml` | Checked-in defaults reference `gcr.io/my-rd-coe-demo-gen-ai/helpudoc-agent:latest` for both init containers and the agent container, plus `gcr.io/my-rd-coe-demo-gen-ai/helpudoc-backend:latest` for the backend container. |
+| `infra/gke/k8s/52-daily-reflection-cron.yaml` | Checked-in default reflection job image is `gcr.io/my-rd-coe-demo-gen-ai/helpudoc-backend:latest`. |
+| `infra/gke/k8s/60-frontend.yaml` | Checked-in default frontend image is `gcr.io/my-rd-coe-demo-gen-ai/helpudoc-frontend:latest`. |
+| Current docs | `docs/ci-cd.md`, `docs/deploy.md`, `docs/environment.md`, `docs/repo-cicd-restructure-plan.md`, and `infra/gke/README.md` mention Container Registry, Cloud Build, `gcr.io`, Artifact Registry planning, or manual image patch commands. PR12 should update operator-facing docs for the final registry strategy. |
+
 **Langfuse-only:** **`Deploy Langfuse to GKE`** applies `30-storage.yaml`, `44-clickhouse.yaml`, and `45-langfuse.yaml`, validates required `helpudoc-config` / `helpudoc-secrets` keys, runs `infra/gke/scripts/bootstrap-langfuse-db.sh --wait-rollout`, and waits for Langfuse web/worker rollouts.
 
 In **`deploy-gke.yml`**, when **`deploy_infra` is true**, the workflow applies `infra/gke/k8s/`, creates the demo `helpudoc-config` only if it is missing (`infra/gke/bootstrap/20-configmap.demo.yaml`), runs Langfuse key patching + DB bootstrap, then merges OAuth keys from GitHub secrets. When **`deploy_infra` is false**, none of that runs: the cluster must already have `helpudoc-config` and the workloads you expect (run an infra deploy first on a brand-new cluster). Routine app deploys should keep **`deploy_infra` false** so image tags and rollouts are the only mutations.
 
 ## One Command Deploy (Manual)
+
+Prefer the GitHub Actions full-stack workflow above for routine app deploys until PR12 updates or retires the older deploy paths. These Cloud Build commands remain useful for operator-triggered one-offs, but they still assume `gcr.io` image locations today.
 
 Prereqs:
 - `gcloud` authenticated

--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -168,8 +168,11 @@ flowchart TB
 - `infra/gke/k8s/60-frontend.yaml`
 - `infra/gke/k8s/70-caddy.yaml`
 - `infra/gke/k8s/71-ingress.yaml`
-- `backend/src/api/agent.ts`
+- `backend/src/api/agent/index.ts`
+- `backend/src/api/agent/*`
+- `backend/src/api/settings/index.ts`
+- `backend/src/api/settings/*`
 - `backend/src/services/agentService.ts`
 - `backend/src/middleware/userContext.ts`
 - `agent/helpudoc_agent/mcp_manager.py`
-- `agent/helpudoc_agent/data_agent_tools.py`
+- `agent/helpudoc_agent/tools/data/*`

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -104,6 +104,10 @@ Notes:
   directory. It currently uses the checked-in backend image reference when
   manifests are applied; update it manually if the CronJob must run a specific
   SHA image.
+- Until PR12 migrates or retires legacy registry paths, prefer
+  `.github/workflows/deploy-gke.yml` for app deploys. The smaller component
+  workflows and Cloud Build configs still contain direct `gcr.io` assumptions
+  and may lag the target registry strategy.
 
 See `docs/ci-cd.md` for more workflow details and troubleshooting.
 
@@ -114,6 +118,9 @@ It builds the same three app images in parallel, tags them with Cloud Build
 `$BUILD_ID`, rewrites app/frontend manifest image tags in the build workspace,
 applies `infra/gke/k8s/` through `gke-deploy`, bootstraps Langfuse, syncs
 PVC-backed runtime files, optionally bootstraps an admin user, and can run E2E.
+It currently builds and deploys `gcr.io/$PROJECT_ID/helpudoc-{backend,frontend,agent}`.
+If PR12 moves app images to Artifact Registry, this Cloud Build path must be
+updated in the same PR or clearly retired.
 
 ```bash
 gcloud builds submit . \
@@ -127,6 +134,27 @@ Notes:
   app/frontend deployment manifests to `$BUILD_ID` in the build workspace.
 - `gke-deploy` uses a longer timeout because the agent image is large and can
   take more than 5 minutes to pull on a new node.
+
+### 4.3.1 PR12 registry surface
+
+The current deploy surface still has these Container Registry references:
+
+| Path | Registry surface |
+| --- | --- |
+| `.github/workflows/deploy-gke.yml` | Preferred interim deploy path; still authenticates to `gcr.io`, uses Buildx registry cache at `gcr.io/$PROJECT_ID/helpudoc-buildcache-*`, builds/pushes backend/frontend/agent images to `gcr.io/$PROJECT_ID/...`, pulls the agent image for smoke import, and patches deployment/init-container/CronJob images to `gcr.io/$PROJECT_ID/...`. |
+| `.github/workflows/deploy-backend-gke.yml` | One-off backend path; builds/pushes `gcr.io/$PROJECT_ID/helpudoc-backend:$GITHUB_SHA`, applies `50-app.yaml` and `52-daily-reflection-cron.yaml`, then patches backend and reflection CronJob images. |
+| `.github/workflows/deploy-frontend-gke.yml` | One-off frontend path; builds/pushes `gcr.io/$PROJECT_ID/helpudoc-frontend:$GITHUB_SHA`, applies `60-frontend.yaml`, then patches the frontend image. |
+| `.github/workflows/deploy-agent-gke.yml` | One-off agent path; builds/runs/pushes `gcr.io/$PROJECT_ID/helpudoc-agent:$GITHUB_SHA`, applies `50-app.yaml`, patches the agent image, then runs legacy PVC sync. |
+| `infra/cloudbuild.yaml` | Full-stack Cloud Build path; uses `gcr.io/cloud-builders/*`, pulls `:latest` app images for cache, builds/tags/pushes backend/frontend/agent images under `gcr.io/$PROJECT_ID/...`, rewrites manifests in the build workspace, and declares `gcr.io/$PROJECT_ID/...` outputs. |
+| `infra/cloudbuild-frontend.yaml` | Frontend-only Cloud Build path; uses `gcr.io/cloud-builders/*`, pulls/builds/tags/pushes frontend under `gcr.io/$PROJECT_ID/...`, rewrites `60-frontend.yaml`, and declares a `gcr.io/$PROJECT_ID/...` output. |
+| `infra/gke/k8s/50-app.yaml` | Checked-in defaults still point backend, agent, and agent init containers at `gcr.io/my-rd-coe-demo-gen-ai/...:latest`. |
+| `infra/gke/k8s/52-daily-reflection-cron.yaml` | Checked-in default reflection job image is `gcr.io/my-rd-coe-demo-gen-ai/helpudoc-backend:latest`. |
+| `infra/gke/k8s/60-frontend.yaml` | Checked-in default frontend image is `gcr.io/my-rd-coe-demo-gen-ai/helpudoc-frontend:latest`. |
+
+Operator docs with registry references include `docs/ci-cd.md`, this guide,
+`docs/environment.md`, `docs/repo-cicd-restructure-plan.md`, and
+`infra/gke/README.md`. PR12 should update the docs that remain true after the
+registry migration and remove or mark any retired path.
 
 ### 4.4 Create Secret + ConfigMap (one-time or when values change)
 

--- a/docs/repo-cicd-restructure-plan.md
+++ b/docs/repo-cicd-restructure-plan.md
@@ -39,9 +39,9 @@ Large files worth splitting:
 | `agent/helpudoc_agent/data_agent_tools.py` | 2852 | DuckDB, state, charts, dashboards, report generation, and tool factory together. |
 | `frontend/src/components/chat/ChatMessageBubble.tsx` | 1968 | Message rendering, tool rendering, markdown, interrupts, and artifact previews together. |
 | `agent/helpudoc_agent/tools_and_schemas.py` | 1849 | Tool registry plus many concrete tool implementations. |
-| `backend/src/api/agent.ts` | 1384 | Agent run routes, slash metadata, Paper2Slides, policy, streaming, and proxy concerns together. |
-| `backend/src/api/settings.ts` | 1266 | Runtime config, skills CRUD, skill builder, GitHub import, and admin settings together. |
-| `backend/src/services/agentRunService.ts` | 1162 | Stream persistence, run lifecycle, resume, interrupts, cancellation, and telemetry together. |
+| `backend/src/api/agent/runs.ts` | 720 | Agent run start/resume/cancel/status/stream routes are now split out, but still the largest route leaf. |
+| `backend/src/api/settings/skillBuilder.ts` | 462 | Skill builder route handling is now split out, but remains a sizable settings leaf module. |
+| `backend/src/services/agent-runs/lifecycle.ts` | 1408 | Stream persistence, run lifecycle, resume, interrupts, cancellation, and telemetry are split from the barrel but still concentrated in one lifecycle module. |
 
 Local workspace size is also noisy even though these files are ignored by git:
 
@@ -132,7 +132,7 @@ scripts/
 
 ### Naming Decisions
 
-| Current name | Target name | Why |
+| Current or legacy name | Target name | Why |
 | --- | --- | --- |
 | `agent/helpudoc_agent/graph.py` | `agent/helpudoc_agent/runtime/agent_registry.py` | The file no longer describes a LangGraph graph. It builds/caches DeepAgents/LangChain agents. |
 | `agent/paper2slides/` | `agent/presentation_pipeline/` | The feature now supports more than papers and may generate slides/posters from general docs. |
@@ -219,7 +219,7 @@ Goal: normal deploys mutate only image tags; infra/bootstrap runs only when requ
 | `backend/Dockerfile.gke` | If backend remains the settings owner for skills, also copy `skills/` to a source path or rely on the agent init container. Choose one owner. |
 | `.github/workflows/deploy-gke.yml` | Keep legacy `kubectl exec` skills/config sync default-off behind `inputs.sync_runtime_assets`; remove later only if operators no longer need the emergency bridge. |
 | `infra/gke/k8s/30-storage.yaml` | Keep `skills-pvc` and `agent-config-pvc` only if admin UI needs runtime edits. If config becomes ConfigMap-backed, remove or deprecate `agent-config-pvc` later. |
-| `backend/src/api/settings.ts` | During transition, settings page writes to PVC-backed paths as today. Add a visible version/source field later so operators know when PVC content diverges from image source. |
+| `backend/src/api/settings/*` | During transition, settings page writes to PVC-backed paths as today. Add a visible version/source field later so operators know when PVC content diverges from image source. |
 | `docs/deploy.md` | Document normal deploy versus infra/bootstrap deploy. |
 | `docs/ci-cd.md` | Document component toggles and when to use `deploy_infra`. |
 
@@ -266,8 +266,8 @@ Goal: one canonical env inventory, typed loaders per runtime, and fewer duplicat
 | `backend/src/services/s3Service.ts` | Read typed S3 config from env module. |
 | `backend/src/services/googleOAuthService.ts` | Read typed OAuth config from env module. |
 | `backend/src/services/langfuseClient.ts` | Read typed Langfuse config from env module. |
-| `backend/src/api/agent.ts` | Replace duplicated path/env helpers with config modules. |
-| `backend/src/api/settings.ts` | Replace duplicated path/env helpers with config modules. |
+| `backend/src/api/agent/*` | Keep split route modules on shared config helpers instead of duplicated path/env parsing. |
+| `backend/src/api/settings/*` | Keep split settings route modules on shared config helpers instead of duplicated path/env parsing. |
 | `agent/helpudoc_agent/configuration.py` | Split settings models from env override logic. |
 | `agent/helpudoc_agent/rag_indexer.py` | Move `RagConfig.from_env` into `agent/helpudoc_agent/rag/config.py`. |
 | `agent/helpudoc_agent/rag_worker.py` | Move queue env parsing into `agent/helpudoc_agent/rag/config.py`. |
@@ -284,7 +284,7 @@ Goal: split the agent service by responsibility while keeping imports stable.
 
 ### Runtime and Config
 
-| Current file | Target file(s) | Action |
+| Original file | Target file(s) | Action |
 | --- | --- | --- |
 | `agent/helpudoc_agent/graph.py` | `agent/helpudoc_agent/runtime/agent_registry.py` | Move `AgentRegistry`, `_clone_preservable_context`, model selection, tool binding, and middleware construction. |
 | `agent/helpudoc_agent/graph.py` | Compatibility shim | Re-export `AgentRegistry` for one or two releases so tests and imports do not break immediately. |
@@ -296,7 +296,7 @@ Goal: split the agent service by responsibility while keeping imports stable.
 
 ### FastAPI Surface
 
-| Current file | Target file(s) | Action |
+| Original file | Target file(s) | Action |
 | --- | --- | --- |
 | `agent/helpudoc_agent/app.py` | `agent/helpudoc_agent/api/app.py` | Keep `create_app` only: load settings, register routes, lifecycle. |
 | `agent/helpudoc_agent/app.py` | `agent/helpudoc_agent/api/schemas.py` | Move Pydantic request/response classes. |
@@ -310,7 +310,7 @@ Goal: split the agent service by responsibility while keeping imports stable.
 
 ### Tools
 
-| Current file | Target file(s) | Action |
+| Original file | Target file(s) | Action |
 | --- | --- | --- |
 | `agent/helpudoc_agent/tools_and_schemas.py` | `agent/helpudoc_agent/tools/factory.py` | Move `ToolFactory`. |
 | `agent/helpudoc_agent/tools_and_schemas.py` | `agent/helpudoc_agent/tools/gemini.py` | Move `GeminiClientManager` and Gemini-native tools. |
@@ -322,7 +322,7 @@ Goal: split the agent service by responsibility while keeping imports stable.
 
 ### Skills
 
-| Current file | Target file(s) | Action |
+| Original file | Target file(s) | Action |
 | --- | --- | --- |
 | `agent/helpudoc_agent/skills_registry.py` | `agent/helpudoc_agent/skills/registry.py` | Move discovery/loading. |
 | `agent/helpudoc_agent/skills_registry.py` | `agent/helpudoc_agent/skills/policy.py` | Move `SkillPolicy` and policy helpers. |
@@ -834,17 +834,17 @@ Notes:
 Split backend agent/settings routes and agent run service.
 
 - [x] Create `backend/src/api/agent/index.ts`.
-- [ ] Move agent run endpoints to `backend/src/api/agent/runs.ts`.
-- [ ] Move slash metadata endpoint to `backend/src/api/agent/slash.ts`.
-- [ ] Move Paper2Slides endpoints to `backend/src/api/agent/paper2slides.ts`.
-- [ ] Move presentation endpoint to `backend/src/api/agent/presentation.ts`.
+- [x] Move agent run endpoints to `backend/src/api/agent/runs.ts`.
+- [x] Move slash metadata endpoint to `backend/src/api/agent/slash.ts`.
+- [x] Move Paper2Slides endpoints to `backend/src/api/agent/paper2slides.ts`.
+- [x] Move presentation endpoint to `backend/src/api/agent/presentation.ts`.
 - [x] Move effective agent policy helpers to `backend/src/api/agent/policy.ts` or a service module.
 - [x] Update `backend/src/api/routes.ts` to import the new agent router.
 - [x] Create `backend/src/api/settings/index.ts`.
-- [ ] Move agent config routes to `backend/src/api/settings/agentConfig.ts`.
-- [ ] Move skills CRUD routes to `backend/src/api/settings/skills.ts`.
-- [ ] Move skill builder routes to `backend/src/api/settings/skillBuilder.ts`.
-- [ ] Move GitHub import routes to `backend/src/api/settings/githubImport.ts`.
+- [x] Move agent config routes to `backend/src/api/settings/agentConfig.ts`.
+- [x] Move skills CRUD routes to `backend/src/api/settings/skills.ts`.
+- [x] Move skill builder routes to `backend/src/api/settings/skillBuilder.ts`.
+- [x] Move GitHub import routes to `backend/src/api/settings/githubImport.ts`.
 - [x] Move skill path/frontmatter helpers to `backend/src/services/skills/`.
 - [x] Split `backend/src/services/agentRunService.ts` into `services/agent-runs/*`.
 - [x] Keep a compatibility barrel for old `agentRunService` exports.
@@ -852,7 +852,8 @@ Split backend agent/settings routes and agent run service.
 - [x] Run `cd backend && npm test`.
 
 Notes:
-- Agent and settings route files are still only partially decomposed; `backend/src/api/agent/index.ts` and `backend/src/api/settings/index.ts` remain large and hold the remaining split debt.
+- Agent and settings route split files now exist; `backend/src/api/agent/index.ts` and `backend/src/api/settings/index.ts` are small composition files.
+- Remaining split debt is in the larger leaf route modules and any follow-up service extraction they still need.
 
 ### PR 10 - `frontend-workspace-split`
 
@@ -876,7 +877,8 @@ Split workspace route and chat renderers.
 - [ ] Run relevant Playwright smoke tests if available.
 
 Notes:
-- Major structural move is complete; the hook extraction and `ChatMessageBubble.tsx` decomposition are still open follow-up debt.
+- Major structural move is complete; the hook extraction and `ChatMessageBubble.tsx` decomposition remain open follow-up debt.
+- These PR 10 open items are non-blocking for PR 12; Playwright smoke tests remain unchecked.
 
 ### PR 11 - `presentation-parser-split`
 
@@ -929,6 +931,7 @@ Artifact Registry and Kustomize overlays.
 - [ ] Add `infra/gke/overlays/dev/kustomization.yaml` if needed.
 - [ ] Add `infra/gke/overlays/prod/kustomization.yaml` if needed.
 - [ ] Remove hard-coded `gcr.io/my-rd-coe-demo-gen-ai/...` image references from manifests or isolate them in overlays.
+- [ ] Migrate or intentionally deprecate the old component deploy workflows and Cloud Build configs, not only `.github/workflows/deploy-gke.yml` and Kubernetes manifests.
 - [ ] Update `infra/gke/README.md` with Artifact Registry setup and IAM.
 - [ ] Update `docs/ci-cd.md`.
 - [ ] Update `docs/deploy.md`.


### PR DESCRIPTION
## Summary
- update the restructure tracker so PR9/PR10 status matches the current codebase
- document the PR12 registry/deploy surfaces that still carry `gcr.io` assumptions
- refresh current architecture source references after the backend/data-tool splits

## Validation
- `git diff --check`
- `graphify update .`

## Notes
- PR10 hook extraction and `ChatMessageBubble` decomposition remain follow-up debt, but are documented as non-blocking for PR12.
- PR12 should either migrate or intentionally retire the old one-off deploy workflows and Cloud Build configs, not just `deploy-gke.yml`.
