### PR TITLE
Fixfor react markdown rehype

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,6 +39,8 @@
         "react-router-dom": "^7.9.4",
         "react-simplemde-editor": "^5.2.0",
         "react-syntax-highlighter": "^16.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "xlsx": "^0.18.5",
         "y-monaco": "^0.1.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,8 @@
     "react-router-dom": "^7.9.4",
     "react-simplemde-editor": "^5.2.0",
     "react-syntax-highlighter": "^16.0.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "xlsx": "^0.18.5",
     "y-monaco": "^0.1.6",

--- a/frontend/src/components/FileRenderer.tsx
+++ b/frontend/src/components/FileRenderer.tsx
@@ -35,6 +35,7 @@ import { parsePlotlySpec } from '../utils/plotlySpec';
 import {
   configureMermaid,
   createMarkdownComponents,
+  markdownRehypePlugins,
   useMermaidColorMode,
 } from './markdown/MarkdownShared';
 import {
@@ -754,7 +755,11 @@ const FileRenderer: React.FC<FileRendererProps> = ({
 
       return (
         <div className={`${markdownContainerClassName} helpudoc-markdown`}>
-          <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={markdownRehypePlugins}
+            components={markdownComponents}
+          >
             {fileContent}
           </ReactMarkdown>
         </div>

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -1,6 +1,7 @@
 import { Check, CheckCircle2, ChevronRight, Copy, FilePenLine, ImageIcon, Loader2, RotateCcw } from 'lucide-react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { markdownRehypePlugins } from '../markdown/MarkdownShared';
 import { useCallback, useEffect, useMemo, useState, type Dispatch, type KeyboardEvent, type ReactNode, type SetStateAction } from 'react';
 
 import type {
@@ -2141,7 +2142,7 @@ export default function ChatMessageBubble({
 
             {liveAgentPreviewText ? (
               <div className="agent-markdown mt-3 text-sm">
-                <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={markdownRehypePlugins} components={markdownComponents}>
                   {liveAgentPreviewText}
                 </ReactMarkdown>
               </div>
@@ -2186,7 +2187,7 @@ export default function ChatMessageBubble({
                         </div>
                         {approvalReview.summaryMarkdown ? (
                           <div className="agent-markdown mt-3 text-sm leading-relaxed text-slate-700">
-                            <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={markdownRehypePlugins} components={markdownComponents}>
                               {approvalReview.summaryMarkdown}
                             </ReactMarkdown>
                           </div>

--- a/frontend/src/components/chat/ToolOutputFilePreview.tsx
+++ b/frontend/src/components/chat/ToolOutputFilePreview.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from 'react-markdown';
 import type { Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+import { markdownRehypePlugins } from '../markdown/MarkdownShared';
 import { getFiles, getFileContent, getWorkspaceFilePreview } from '../../services/fileApi';
 import type { File as WorkspaceFile, ToolOutputFile } from '../../types';
 import { inferPreviewEncoding } from '../../utils/files';
@@ -148,7 +149,7 @@ export default function ToolOutputFilePreview({
   if (normalizedMime.includes('markdown')) {
     return (
       <div className="prose prose-sm mt-2 max-w-none">
-        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+        <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={markdownRehypePlugins} components={markdownComponents}>
           {content}
         </ReactMarkdown>
       </div>

--- a/frontend/src/components/markdown/MarkdownShared.tsx
+++ b/frontend/src/components/markdown/MarkdownShared.tsx
@@ -1,8 +1,34 @@
 /* eslint-disable react-refresh/only-export-components */
 import { Children, Suspense, isValidElement, lazy, useEffect, useRef, useState, type ReactNode } from 'react';
 import type { Components } from 'react-markdown';
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+import type { PluggableList } from 'unified';
 import { getWorkspaceFilePreview } from '../../services/fileApi';
 import { parsePlotlySpec } from '../../utils/plotlySpec';
+
+// Sanitization schema for raw HTML embedded in markdown. Extends the
+// rehype-sanitize default (which strips scripts, event handlers, javascript:
+// URLs, etc.) to additionally permit the presentational markup that appears in
+// generated reports — inline `style`/`class`, and tags like `span`/`font`.
+export const markdownSanitizeSchema = {
+  ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames ?? []), 'span', 'div', 'u', 'mark', 'font', 'small'],
+  attributes: {
+    ...defaultSchema.attributes,
+    '*': [...(defaultSchema.attributes?.['*'] ?? []), 'style', 'className', 'class'],
+    font: [...(defaultSchema.attributes?.font ?? []), 'color', 'size', 'face'],
+  },
+};
+
+// Shared rehype pipeline: parse raw HTML into real elements (rehype-raw), then
+// sanitize the result. Order matters — raw must run before sanitize. Use this
+// for every read-only `react-markdown` surface so raw HTML renders consistently
+// (viewer, print/export, chat previews) instead of showing as literal text.
+export const markdownRehypePlugins: PluggableList = [
+  rehypeRaw,
+  [rehypeSanitize, markdownSanitizeSchema],
+];
 
 const PlotlyChart = lazy(() => import('../PlotlyChart'));
 

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -121,7 +121,7 @@ import {
 } from '../../utils/workspaceFileTree';
 import { buildMessageMetadata, mapMessagesToAgentHistory, mergeMessageMetadata, sanitizeRunPolicy } from '../../utils/messages';
 import { getImplicitContinuationContext, buildContinuationPrompt } from '../../utils/implicitSkillContinuation';
-import { createMarkdownComponents } from '../../components/markdown/MarkdownShared';
+import { createMarkdownComponents, markdownRehypePlugins } from '../../components/markdown/MarkdownShared';
 import { applyColorModeToDocument, buildAppTheme, resolveInitialColorMode, useUITheme } from '../../theme';
 
 const FileEditor = lazy(() => import('../../components/FileEditor'));
@@ -1394,7 +1394,7 @@ export default function WorkspacePage() {
         : wrapInDocument(fileContent)
       : wrapInDocument(
         renderToStaticMarkup(
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{fileContent}</ReactMarkdown>
+          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={markdownRehypePlugins}>{fileContent}</ReactMarkdown>
         )
       );
 

--- a/skills/tos-analysis/SKILL.md
+++ b/skills/tos-analysis/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: tos-analysis
+description: Analyze a document table of contents or outline to infer structure, coverage, gaps, and recommended improvements before deeper reading or drafting.
+tools:
+  - docx
+  - pdf
+  - rag_query
+  - request_clarification
+---
+
+# tos-analysis
+
+## Overview
+
+Use this skill when the user asks to analyze, improve, compare, or reason from a table of contents, outline, syllabus, report structure, proposal structure, slide agenda, or chapter list.
+
+This skill focuses on structure before prose: hierarchy, sequencing, coverage, balance, missing sections, duplicated ideas, and whether the outline matches the user's goal.
+
+## Rules
+
+- Treat the table of contents as structural evidence, not proof of the full document's content.
+- If the user provides a document but no visible tos, use `rag_query` to locate headings, sections, or outline-like content.
+- If the target document or goal is unclear, call `request_clarification`.
+- Do not invent section details that are not present in the tos or retrieved context.
+- Keep recommendations concrete and tied to named sections.
+- Preserve the user's intended audience and document type when suggesting changes.
+
+## Workflow
+
+1. Identify the source and goal.
+   - Confirm whether the user wants critique, summary, restructuring, gap analysis, comparison, or drafting help.
+   - Identify the target audience and purpose when the user provides them.
+
+2. Extract the outline.
+   - Use the user-provided tos directly when available.
+   - If the tos is in a workspace document, call `rag_query` for headings, section titles, and outline structure.
+   - Keep section order and hierarchy intact.
+
+3. Analyze structure.
+   - Identify major parts, section depth, ordering, and transitions.
+   - Note overlong, underdeveloped, duplicated, or misplaced sections.
+   - Check whether prerequisites appear before advanced material.
+   - Check whether evidence, methodology, conclusions, and next steps are present when appropriate.
+
+4. Evaluate fit for purpose.
+   - For research reports, check for scope, methodology, findings, synthesis, limitations, and sources.
+   - For proposals, check for problem, context, solution, delivery plan, risks, timeline, and commercial terms.
+   - For educational material, check for learning objectives, conceptual progression, examples, practice, and assessment.
+   - For slide decks, check for narrative arc, decision points, appendix placement, and executive readability.
+
+5. Respond with a concise structural review.
+   - Start with the overall read on the tos.
+   - List the strongest structural choices.
+   - List gaps or risks tied to specific sections.
+   - Provide a revised outline when the user asks for improvements.
+   - Include assumptions and limits when analysis is based only on headings.
+   - Create a summary table section at the end of the document to summarize all violated conduct standards and the reference clause in the ToS document.
+
+6. Write an output markdown file under `results` folder suffixed with `tos-analysis-report.md` for the results.
+
+## Good uses
+
+- "Analyze this report tos and tell me what's missing."
+- "Does this proposal outline flow well for an enterprise buyer?"
+- "Compare these two chapter outlines."
+- "Turn this rough section list into a stronger table of contents."
+- "Find gaps in the structure of this uploaded PDF."
+
+## Avoid
+
+- Claiming you reviewed full section content from headings alone.
+- Rewriting the entire document unless the user asks.
+- Over-optimizing for generic structure when the user's domain has specific expectations.
+
+
+## Files
+
+- `scripts/` for executable helpers
+- `references/` for CCOB's 11 conduct standards.
+- `assets/` for images and static resources
+- `templates/` for reusable templates

--- a/skills/tos-analysis/references/README.md
+++ b/skills/tos-analysis/references/README.md
@@ -1,0 +1,41 @@
+# References
+
+Place reference docs here.
+
+##  Compliance with regulations and standards or guidelines on business conduct
+
+85\. (1) For the purposes of section 84, regulations under
+section 122 and standards or guidelines under section 123 may
+include the following:
+(a) prohibited business conduct;
+(b) promotion of any credit business or credit service business,
+including through the issuance or publication of an
+advertisement;
+
+(c) transparency and disclosure requirements, including
+the provision of information to a credit consumer that
+is accurate, clear, timely and not misleading;
+(d) fairness of terms in a credit agreement;
+(e) imposition of interest, profit, fees or charges;
+(f) provision of assessments of affordability of credit offered
+to credit consumers including circumstances where credit
+shall not be provided;
+(g) fair debt collection practices;
+(h) provision of assistance to a credit consumer with financial
+hardship to meet its financial obligation under a credit
+agreement;
+(i) complaints handling and dispute resolution mechanisms;
+(j) competency of officers or any persons acting on behalf of
+a credit provider or credit service provider including to
+ensure that they are adequately trained to engage with
+credit consumers; and
+
+(k) management of any document or information relating to
+
+the business or affairs of any credit consumer.
+
+(2) Every credit provider or credit service provider shall at all
+times ensure that its internal policies and procedures relating to
+business conduct are consistent with the regulations made under
+paragraph 122(2)(d) and standards or guidelines specified under
+paragraph 123(2)(c).


### PR DESCRIPTION
# Bug:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6bd74b54-cfe0-45e1-8a79-19e0c3aca78c" />

# Expected Behavior:

Spans rendered correctly.
*Note: `amber` is not a valid CSS color keyword. Using #FFBF00 as a replacement for visualization purposes only.*
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d598bae4-c546-434b-ad75-3c1724245a25" />

The markdown editor function is able to render HTML tags such as color rendering properly but not the markdown viewer.

# Summary:

**Root cause**: The viewer and print/export paths used `react-markdown` with only `remarkGfm`. In `react-markdown` v10, raw embedded HTML is discarded/escaped unless the `rehype-raw` plugin is added, which was not installed. 

The editor renders fine only because it's a different engine `(@mdxeditor/editor)` that parses HTML natively.

**Fix**: added two dependecies and a shared, sanitized `rehype` pipeline:

- `frontend/package.json`: added `rehype-raw` and `rehype-sanitize`.
- `frontend/src/components/markdown/MarkdownShared.tsx`: new exports `markdownSanitizeSchema` (extends `rehype-sanitize`'s safe default to permit presentational markup: inline style/class and span/div/u/mark/font/small) and `markdownRehypePlugins` (`rehypeRaw` -> `rehypeSanitize`, order matters).
- Wired `rehypePlugins={markdownRehypePlugins}` into all five read-only ReactMarkdown surfaces:
  - `FileRenderer.tsx` (the viewer)
  - `WorkspacePage.tsx` handlePrintActiveFile (on print/PDF export)
  - `chat/ToolOutputFilePreview.tsx` and two instances in `chat/ChatMessageBubble.tsx` (chat previews, for consistency so this doesn't reappear)

Editor unaffected, continue using `mdxeditor` engine.