### PR TITLE
Add Lumo close option

### DIFF
--- a/frontend/src/components/lumo/LumoPet.css
+++ b/frontend/src/components/lumo/LumoPet.css
@@ -20,6 +20,49 @@
   cursor: grabbing;
 }
 
+.lumo-close-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 3;
+  width: 1.75rem;
+  height: 1.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.18);
+  color: var(--text-secondary);
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transform: scale(0.88);
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    opacity 140ms ease,
+    transform 140ms ease;
+}
+
+.lumo-root:hover .lumo-close-button,
+.lumo-close-button:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: scale(1);
+}
+
+.lumo-close-button:hover {
+  background: var(--surface);
+  color: var(--text-primary);
+}
+
+.lumo-close-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .lumo-pet-button {
   position: relative;
   width: clamp(76px, 7.5vw, 100px);
@@ -346,5 +389,13 @@
 
   .lumo-bubble {
     display: none;
+  }
+}
+
+@media (hover: none) {
+  .lumo-close-button {
+    opacity: 1;
+    pointer-events: auto;
+    transform: scale(1);
   }
 }

--- a/frontend/src/components/lumo/LumoPet.tsx
+++ b/frontend/src/components/lumo/LumoPet.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, useCallback, type PointerEvent } from 'react';
+import { X } from 'lucide-react';
 import lumoSpriteSheet from '../../assets/lumo/lumo-spritesheet.webp';
 import './LumoPet.css';
 
@@ -93,11 +94,12 @@ function clampPosition(x: number, y: number, width: number, height: number): Lum
   };
 }
 
-export default function LumoPet({
+function LumoPetContent({
   colorMode = 'light',
   aiBusy = false,
   hasSuggestion = false,
-}: LumoPetProps) {
+  onClose,
+}: LumoPetProps & { onClose: () => void }) {
   const [state, setState] = useState<PetState>('idle');
   const [frame, setFrame] = useState(0);
   const [facing, setFacing] = useState<'left' | 'right'>('right');
@@ -168,6 +170,15 @@ export default function LumoPet({
       if (typingTimer.current) clearTimeout(typingTimer.current);
     };
   }, [resetSleepTimer]);
+
+  useEffect(
+    () => () => {
+      if (blinkTimer.current) clearTimeout(blinkTimer.current);
+      if (typingTimer.current) clearTimeout(typingTimer.current);
+      if (sleepTimer.current) clearTimeout(sleepTimer.current);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (state !== 'idle') return;
@@ -338,6 +349,15 @@ export default function LumoPet({
     >
       <button
         type="button"
+        className="lumo-close-button"
+        onClick={onClose}
+        aria-label="Close Lumo pet"
+        title="Close Lumo"
+      >
+        <X size={15} strokeWidth={2.25} aria-hidden />
+      </button>
+      <button
+        type="button"
         className="lumo-pet-button"
         onPointerDown={handlePetPointerDown}
         onPointerMove={handlePetPointerMove}
@@ -357,4 +377,12 @@ export default function LumoPet({
       </button>
     </div>
   );
+}
+
+export default function LumoPet(props: LumoPetProps) {
+  const [isVisible, setIsVisible] = useState(true);
+
+  if (!isVisible) return null;
+
+  return <LumoPetContent {...props} onClose={() => setIsVisible(false)} />;
 }


### PR DESCRIPTION
## What changed

- Added an accessible close button to the floating Lumo pet.
- Shows the control on hover or keyboard focus and keeps it visible on touch devices.
- Unmounts the pet after dismissal so animation timers and global listeners are cleaned up.

## Why

Lumo was always visible and could obstruct workspace content. Users had no way to dismiss it.

## Impact

Users can close Lumo for the current page session. Reloading the workspace restores the pet.

## Validation

- `npm run build`
- Focused ESLint check for `LumoPet.tsx`
- Docker frontend image rebuild and local deployment
- Browser QC: close control present, dismissal removes Lumo, reload restores it, and no console errors
- `git diff --check`