### PR TITLE
Add private and team workspace publishing

### DIFF
--- a/backend/scripts/test_workspace_publication_integration.ts
+++ b/backend/scripts/test_workspace_publication_integration.ts
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict';
+import * as fs from 'fs/promises';
+import { v4 as uuidv4 } from 'uuid';
+
+import { ConflictError } from '../src/errors';
+import { DatabaseService } from '../src/services/databaseService';
+import { FileService } from '../src/services/fileService';
+import { UserService } from '../src/services/userService';
+import { WorkspacePublicationService } from '../src/services/workspacePublicationService';
+import { WorkspaceService } from '../src/services/workspaceService';
+
+async function main() {
+  const databaseService = new DatabaseService();
+  await databaseService.initialize();
+  const db = databaseService.getDb();
+  const workspaceService = new WorkspaceService(databaseService);
+  const fileService = new FileService(databaseService, workspaceService);
+  const publicationService = new WorkspacePublicationService(databaseService, workspaceService);
+  const userService = new UserService(databaseService);
+
+  const aliceId = uuidv4();
+  const bobId = uuidv4();
+  const teamId = uuidv4();
+
+  try {
+    await db('users').insert([
+      { id: aliceId, externalId: `publication-alice-${aliceId}`, displayName: 'Alice Publisher' },
+      { id: bobId, externalId: `publication-bob-${bobId}`, displayName: 'Bob Teammate' },
+    ]);
+    await db('groups').insert({ id: teamId, name: `Publication test ${teamId}` });
+    await db('group_members').insert([
+      { groupId: teamId, userId: aliceId },
+      { groupId: teamId, userId: bobId },
+    ]);
+
+    const alicePrivate = await workspaceService.createWorkspace(
+      {
+        userId: aliceId,
+        externalId: `publication-alice-${aliceId}`,
+        displayName: 'Alice Publisher',
+        isAdmin: false,
+      },
+      'Customer research',
+    );
+    const aliceFile = await fileService.createTextFile(
+      alicePrivate.id,
+      'brief.md',
+      'Published version one',
+      aliceId,
+    );
+
+    const firstPublication = await publicationService.publish(alicePrivate.id, aliceId, { teamId });
+    const bobWorkspaces = await workspaceService.listWorkspacesForUser(bobId);
+    const teamWorkspace = bobWorkspaces.find((workspace) => workspace.id === firstPublication.teamWorkspaceId);
+    assert(teamWorkspace);
+    assert.equal(teamWorkspace.visibility, 'team');
+    assert.equal(teamWorkspace.canEdit, false);
+    assert.equal(teamWorkspace.privateCopyWorkspaceId, null);
+
+    const teamFiles = await fileService.getFiles(teamWorkspace.id, bobId);
+    assert.equal(teamFiles.length, 1);
+    await assert.rejects(
+      () => fileService.updateFile(Number(teamFiles[0].id), 'Not allowed', bobId),
+      /Team workspaces are read-only/,
+    );
+
+    const bobPrivate = await publicationService.createPrivateCopy(teamWorkspace.id, bobId);
+    const bobFiles = await fileService.getFiles(bobPrivate.id, bobId);
+    await fileService.updateFile(Number(bobFiles[0].id), 'Bob private changes', bobId);
+
+    await fileService.updateFile(Number(aliceFile.id), 'Alice team changes', aliceId);
+    await publicationService.publish(alicePrivate.id, aliceId, { note: 'Alice update' });
+
+    const bobAfterTeamUpdate = (await workspaceService.listWorkspacesForUser(bobId))
+      .find((workspace) => workspace.id === bobPrivate.id);
+    assert.equal(bobAfterTeamUpdate?.publicationStatus, 'review_needed');
+
+    let conflicts: Array<{ path: string }> = [];
+    try {
+      await publicationService.sync(bobPrivate.id, bobId);
+      assert.fail('Expected overlapping changes to require review');
+    } catch (error) {
+      assert(error instanceof ConflictError);
+      conflicts = (error.details as { conflicts?: Array<{ path: string }> })?.conflicts || [];
+    }
+    assert.deepEqual(conflicts.map((conflict) => conflict.path), ['brief.md']);
+
+    await publicationService.sync(bobPrivate.id, bobId, { 'brief.md': 'private' });
+    const bobAfterReview = (await workspaceService.listWorkspacesForUser(bobId))
+      .find((workspace) => workspace.id === bobPrivate.id);
+    assert.equal(bobAfterReview?.publicationStatus, 'changes_to_publish');
+
+    await workspaceService.addCollaborator(teamWorkspace.id, aliceId, bobId, 'editor');
+    const bobPublication = await publicationService.publish(bobPrivate.id, bobId, { note: 'Bob update' });
+    assert.equal(bobPublication.publishedVersionNumber, 3);
+
+    await publicationService.sync(alicePrivate.id, aliceId);
+    const refreshedAliceFiles = await fileService.getFiles(alicePrivate.id, aliceId);
+    const refreshedBobFiles = await fileService.getFiles(bobPrivate.id, bobId);
+    await fileService.updateFile(Number(refreshedAliceFiles[0].id), 'Alice concurrent publication', aliceId);
+    await fileService.updateFile(Number(refreshedBobFiles[0].id), 'Bob concurrent publication', bobId);
+
+    const concurrentPublications = await Promise.allSettled([
+      publicationService.publish(alicePrivate.id, aliceId, { note: 'Alice concurrent update' }),
+      publicationService.publish(bobPrivate.id, bobId, { note: 'Bob concurrent update' }),
+    ]);
+    assert.equal(
+      concurrentPublications.filter((result) => result.status === 'fulfilled').length,
+      1,
+      'exactly one concurrent publication should succeed',
+    );
+    assert.equal(
+      concurrentPublications.filter((result) => result.status === 'rejected').length,
+      1,
+      'the stale concurrent publication should be rejected',
+    );
+    const winningContent = concurrentPublications[0].status === 'fulfilled'
+      ? 'Alice concurrent publication'
+      : 'Bob concurrent publication';
+    const teamFilesAfterConcurrentPublish = await fileService.getFiles(teamWorkspace.id, aliceId);
+    const teamFileAfterConcurrentPublish = await fileService.getFileContent(
+      Number(teamFilesAfterConcurrentPublish[0].id),
+      aliceId,
+    );
+    assert.equal(teamFileAfterConcurrentPublish.content, winningContent);
+
+    const history = await publicationService.listHistory(teamWorkspace.id, aliceId);
+    assert.deepEqual(history.map((version) => Number(version.versionNumber)), [4, 3, 2, 1]);
+    const firstVersion = history.find((version) => Number(version.versionNumber) === 1);
+    assert(firstVersion);
+    await publicationService.restore(teamWorkspace.id, firstVersion.id, aliceId);
+
+    const restoredFiles = await fileService.getFiles(teamWorkspace.id, aliceId);
+    const restored = await fileService.getFileContent(Number(restoredFiles[0].id), aliceId);
+    assert.equal(restored.content, 'Published version one');
+
+    await userService.removeGroupMember(teamId, bobId);
+    const bobAfterRemoval = await workspaceService.listWorkspacesForUser(bobId);
+    assert.equal(
+      bobAfterRemoval.some((workspace) => workspace.id === teamWorkspace.id),
+      false,
+      'removed team members should no longer list the team workspace',
+    );
+    const bobPrivateAfterRemoval = bobAfterRemoval.find((workspace) => workspace.id === bobPrivate.id);
+    assert(bobPrivateAfterRemoval);
+    assert.equal(bobPrivateAfterRemoval.canPublish, false);
+    assert.equal(bobPrivateAfterRemoval.currentPublishedVersionNumber, null);
+    assert.equal(bobPrivateAfterRemoval.latestPublisherName, null);
+    await assert.rejects(
+      () => workspaceService.ensureMembership(teamWorkspace.id, bobId),
+      /Team membership is required/,
+    );
+    await assert.rejects(
+      () => publicationService.publish(bobPrivate.id, bobId, { note: 'Should not publish' }),
+      /Team membership is required/,
+    );
+
+    assert.equal(await userService.deleteUser(bobId), true);
+    const historyAfterUserDeletion = await publicationService.listHistory(teamWorkspace.id, aliceId);
+    assert(
+      historyAfterUserDeletion.some((version) => version.publisherName === 'Former user'),
+      'published history should remain visible after deleting a publisher',
+    );
+
+    console.log('workspace publication integration ok');
+  } finally {
+    const workspaceIds = await db('workspaces')
+      .whereIn('ownerId', [aliceId, bobId])
+      .select('id');
+    for (const workspace of workspaceIds) {
+      await workspaceService.deleteWorkspaceForCleanup(workspace.id).catch(() => undefined);
+    }
+    await db('groups').where({ id: teamId }).del();
+    await db('users').whereIn('id', [aliceId, bobId]).del();
+    await db.destroy();
+    const root = process.env.WORKSPACE_ROOT;
+    if (root) {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }
+}
+
+void main();

--- a/backend/scripts/test_workspace_user_directory_route.ts
+++ b/backend/scripts/test_workspace_user_directory_route.ts
@@ -22,6 +22,8 @@ const userService = {
   }),
 } as any;
 
+const publicationService = {} as any;
+
 const app = express();
 app.use((req, _res, next) => {
   (req as any).userContext = {
@@ -31,7 +33,7 @@ app.use((req, _res, next) => {
   };
   next();
 });
-app.use('/workspaces', workspaceRoutes(workspaceService, userService));
+app.use('/workspaces', workspaceRoutes(workspaceService, publicationService, userService));
 
 const server = app.listen(0);
 const address = server.address();

--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -14,6 +14,7 @@ import meMemoryRoutes from './meMemory';
 import { requireSystemAdmin } from '../middleware/adminOnly';
 import { DatabaseService } from '../services/databaseService';
 import { WorkspaceService } from '../services/workspaceService';
+import { WorkspacePublicationService } from '../services/workspacePublicationService';
 import { FileService } from '../services/fileService';
 import { ConversationService } from '../services/conversationService';
 import { UserService } from '../services/userService';
@@ -29,6 +30,7 @@ import { configureAgentRunServices } from '../services/agentRunService';
 export default function(dbService: DatabaseService, userService: UserService) {
   const router = Router();
   const workspaceService = new WorkspaceService(dbService);
+  const workspacePublicationService = new WorkspacePublicationService(dbService, workspaceService);
   const fileService = new FileService(dbService, workspaceService);
   const conversationService = new ConversationService(dbService, workspaceService);
   configureAgentRunServices({ conversationService });
@@ -51,7 +53,7 @@ export default function(dbService: DatabaseService, userService: UserService) {
   router.use('/settings/reflections', requireSystemAdmin(userService), settingsReflectionRoutes(dailyReflectionService));
   router.use('/settings/skill-evolution', requireSystemAdmin(userService), settingsSkillEvolutionRoutes(skillEvolutionService));
   router.use('/users', requireSystemAdmin(userService), usersRoutes(userService, workspaceService));
-  router.use('/workspaces', workspaceRoutes(workspaceService, userService));
+  router.use('/workspaces', workspaceRoutes(workspaceService, workspacePublicationService, userService));
   router.use('/workspaces/:workspaceId/files', fileRoutes(fileService, workspaceService, googleOAuthService));
   router.use('/workspaces/:workspaceId/knowledge', knowledgeRoutes(knowledgeService));
   router.use('/workspaces/:workspaceId/schedules', scheduleRoutes(scheduleService));

--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { z } from 'zod';
 import { WorkspaceService } from '../services/workspaceService';
+import { WorkspacePublicationService } from '../services/workspacePublicationService';
 import { UserService } from '../services/userService';
 import { HttpError } from '../errors';
 
@@ -10,6 +11,16 @@ const createWorkspaceSchema = z.object({
 
 const renameWorkspaceSchema = z.object({
   name: z.string().trim().min(1).max(255),
+});
+
+const publishWorkspaceSchema = z.object({
+  teamId: z.string().uuid().optional(),
+  name: z.string().trim().min(1).max(255).optional(),
+  note: z.string().trim().max(1000).optional(),
+});
+
+const syncWorkspaceSchema = z.object({
+  resolutions: z.record(z.string(), z.enum(['private', 'team'])).optional(),
 });
 
 const collaboratorSchema = z
@@ -28,7 +39,11 @@ const collaboratorSchema = z
     }
   });
 
-export default function workspaceRoutes(workspaceService: WorkspaceService, userService: UserService) {
+export default function workspaceRoutes(
+  workspaceService: WorkspaceService,
+  publicationService: WorkspacePublicationService,
+  userService: UserService,
+) {
   const router = Router();
 
   const requireUserContext = (req: Request) => {
@@ -85,6 +100,82 @@ export default function workspaceRoutes(workspaceService: WorkspaceService, user
       res.json({ users });
     } catch (error) {
       handleError(res, error, 'Failed to search users');
+    }
+  });
+
+  router.get('/teams', async (req, res) => {
+    try {
+      const user = requireUserContext(req);
+      const teams = await workspaceService.listEligibleTeams(user.userId);
+      res.json({ teams });
+    } catch (error) {
+      handleError(res, error, 'Failed to list teams');
+    }
+  });
+
+  router.post('/:workspaceId/publish', async (req, res) => {
+    try {
+      const user = requireUserContext(req);
+      const payload = publishWorkspaceSchema.parse(req.body || {});
+      const publication = await publicationService.publish(req.params.workspaceId, user.userId, payload);
+      res.status(201).json(publication);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: 'Invalid publish payload' });
+      }
+      handleError(res, error, 'Failed to publish workspace');
+    }
+  });
+
+  router.post('/:workspaceId/private-copy', async (req, res) => {
+    try {
+      const user = requireUserContext(req);
+      const workspace = await publicationService.createPrivateCopy(req.params.workspaceId, user.userId);
+      res.status(201).json(workspace);
+    } catch (error) {
+      handleError(res, error, 'Failed to create private working copy');
+    }
+  });
+
+  router.post('/:workspaceId/sync', async (req, res) => {
+    try {
+      const user = requireUserContext(req);
+      const payload = syncWorkspaceSchema.parse(req.body || {});
+      const result = await publicationService.sync(
+        req.params.workspaceId,
+        user.userId,
+        payload.resolutions || {},
+      );
+      res.json(result);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: 'Invalid sync payload' });
+      }
+      handleError(res, error, 'Failed to sync team updates');
+    }
+  });
+
+  router.get('/:workspaceId/history', async (req, res) => {
+    try {
+      const user = requireUserContext(req);
+      const versions = await publicationService.listHistory(req.params.workspaceId, user.userId);
+      res.json({ versions });
+    } catch (error) {
+      handleError(res, error, 'Failed to load publication history');
+    }
+  });
+
+  router.post('/:workspaceId/versions/:versionId/restore', async (req, res) => {
+    try {
+      const user = requireUserContext(req);
+      const version = await publicationService.restore(
+        req.params.workspaceId,
+        req.params.versionId,
+        user.userId,
+      );
+      res.status(201).json(version);
+    } catch (error) {
+      handleError(res, error, 'Failed to restore published version');
     }
   });
 

--- a/backend/src/services/conversationService.ts
+++ b/backend/src/services/conversationService.ts
@@ -46,7 +46,7 @@ export class ConversationService {
   }
 
   async createConversation(userId: string, workspaceId: string, persona: string): Promise<ConversationRecord> {
-    await this.workspaceService.ensureMembership(workspaceId, userId);
+    await this.workspaceService.ensureMembership(workspaceId, userId, { requireEdit: true });
     const [conversation] = await this.db('conversations')
       .insert({
         id: uuidv4(),
@@ -64,7 +64,7 @@ export class ConversationService {
   }
 
   async listRecentConversations(userId: string, workspaceId: string, limit = 5): Promise<ConversationRecord[]> {
-    await this.workspaceService.ensureMembership(workspaceId, userId);
+    await this.workspaceService.ensureMembership(workspaceId, userId, { requireEdit: true });
     const conversations = await this.db('conversations')
       .where({ workspaceId })
       .orderBy('updatedAt', 'desc')
@@ -82,7 +82,7 @@ export class ConversationService {
       return null;
     }
 
-    await this.workspaceService.ensureMembership(conversation.workspaceId, userId);
+    await this.workspaceService.ensureMembership(conversation.workspaceId, userId, { requireEdit: true });
 
     const messages = await this.db('conversation_messages')
       .where({ conversationId })
@@ -105,7 +105,7 @@ export class ConversationService {
       throw new NotFoundError('Conversation not found');
     }
 
-    await this.workspaceService.ensureMembership(workspaceId, userId, { requireEdit: options.requireEdit });
+    await this.workspaceService.ensureMembership(workspaceId, userId, { requireEdit: true });
     return conversation as ConversationRecord;
   }
 

--- a/backend/src/services/databaseService.ts
+++ b/backend/src/services/databaseService.ts
@@ -31,10 +31,13 @@ export class DatabaseService {
     await this.createMcpServerGroupGrantsTable();
     await this.createWorkspacesTable();
     await this.createWorkspaceMembersTable();
+    await this.migrateWorkspaceVisibility();
     await this.createMcpServerGrantsTable();
     await this.createMcpConnectionsTable();
     await this.createMcpConnectionGrantsTable();
     await this.createFilesTable();
+    await this.createWorkspacePublishedVersionsTable();
+    await this.createWorkspacePublicationLinksTable();
     await this.createCollabDocumentsTable();
     await this.createKnowledgeSourcesTable();
     await this.createConversationsTable();
@@ -190,6 +193,10 @@ export class DatabaseService {
         table.string('slug').notNullable().unique();
         table.uuid('ownerId').notNullable().references('id').inTable('users').onDelete('CASCADE');
         table.uuid('lastModifiedBy').references('id').inTable('users');
+        table.string('visibility', 16).notNullable().defaultTo('private');
+        table.uuid('teamId').references('id').inTable('groups').onDelete('SET NULL');
+        table.uuid('currentPublishedVersionId');
+        table.integer('contentRevision').notNullable().defaultTo(0);
         table.boolean('skipPlanApprovals').notNullable().defaultTo(false);
         table.timestamp('createdAt').notNullable().defaultTo(this.db.fn.now());
         table.timestamp('updatedAt').notNullable().defaultTo(this.db.fn.now());
@@ -199,8 +206,25 @@ export class DatabaseService {
       await this.ensureColumn('workspaces', 'slug', (table) => table.string('slug').notNullable().defaultTo(this.db.raw('md5(random()::text)')));
       await this.ensureColumn('workspaces', 'ownerId', (table) => table.uuid('ownerId'));
       await this.ensureColumn('workspaces', 'lastModifiedBy', (table) => table.uuid('lastModifiedBy'));
+      await this.ensureColumn('workspaces', 'visibility', (table) => table.string('visibility', 16).notNullable().defaultTo('private'));
+      await this.ensureColumn('workspaces', 'teamId', (table) => table.uuid('teamId').references('id').inTable('groups').onDelete('SET NULL'));
+      await this.ensureColumn('workspaces', 'currentPublishedVersionId', (table) => table.uuid('currentPublishedVersionId'));
+      await this.ensureColumn('workspaces', 'contentRevision', (table) => table.integer('contentRevision').notNullable().defaultTo(0));
       await this.ensureColumn('workspaces', 'skipPlanApprovals', (table) => table.boolean('skipPlanApprovals').notNullable().defaultTo(false));
     }
+  }
+
+  private async migrateWorkspaceVisibility(): Promise<void> {
+    await this.db.raw(`
+      UPDATE workspaces
+      SET visibility = 'team'
+      WHERE visibility = 'private'
+        AND (
+          SELECT COUNT(*)
+          FROM workspace_members
+          WHERE workspace_members."workspaceId" = workspaces.id
+        ) > 1
+    `);
   }
 
   private async createMcpServerGroupGrantsTable(): Promise<void> {
@@ -329,6 +353,80 @@ export class DatabaseService {
       console.log('Created "files" table.');
     } else {
       await this.ensureFilesTableColumns();
+    }
+  }
+
+  private async createWorkspacePublishedVersionsTable(): Promise<void> {
+    const exists = await this.db.schema.hasTable('workspace_published_versions');
+    if (!exists) {
+      await this.db.schema.createTable('workspace_published_versions', (table) => {
+        table.uuid('id').primary();
+        table.uuid('teamWorkspaceId').notNullable().references('id').inTable('workspaces').onDelete('CASCADE');
+        table.integer('versionNumber').notNullable();
+        table.uuid('sourcePrivateWorkspaceId').references('id').inTable('workspaces').onDelete('SET NULL');
+        table.uuid('publisherUserId').references('id').inTable('users').onDelete('SET NULL');
+        table.text('note');
+        table.jsonb('manifest').notNullable().defaultTo('[]');
+        table.timestamp('createdAt').notNullable().defaultTo(this.db.fn.now());
+        table.unique(['teamWorkspaceId', 'versionNumber']);
+        table.index(['teamWorkspaceId', 'createdAt'], 'workspace_published_versions_team_created_idx');
+      });
+      console.log('Created "workspace_published_versions" table.');
+    } else {
+      const foreignKeys = await this.db.raw<{
+        rows: Array<{ constraint_name: string; delete_rule: string }>;
+      }>(`
+        SELECT tc.constraint_name, rc.delete_rule
+        FROM information_schema.table_constraints AS tc
+        JOIN information_schema.key_column_usage AS kcu
+          ON tc.constraint_name = kcu.constraint_name
+          AND tc.constraint_schema = kcu.constraint_schema
+        JOIN information_schema.referential_constraints AS rc
+          ON tc.constraint_name = rc.constraint_name
+          AND tc.constraint_schema = rc.constraint_schema
+        WHERE tc.table_schema = current_schema()
+          AND tc.table_name = 'workspace_published_versions'
+          AND tc.constraint_type = 'FOREIGN KEY'
+          AND kcu.column_name = 'publisherUserId'
+      `);
+      const publisherForeignKey = foreignKeys.rows[0];
+      if (publisherForeignKey?.delete_rule !== 'SET NULL') {
+        if (publisherForeignKey) {
+          await this.db.raw(
+            'ALTER TABLE ?? DROP CONSTRAINT ??',
+            ['workspace_published_versions', publisherForeignKey.constraint_name],
+          );
+        }
+        await this.db.schema.alterTable('workspace_published_versions', (table) => {
+          table.uuid('publisherUserId').nullable().alter();
+          table.foreign('publisherUserId').references('id').inTable('users').onDelete('SET NULL');
+        });
+      }
+    }
+  }
+
+  private async createWorkspacePublicationLinksTable(): Promise<void> {
+    const exists = await this.db.schema.hasTable('workspace_publication_links');
+    if (!exists) {
+      await this.db.schema.createTable('workspace_publication_links', (table) => {
+        table.uuid('privateWorkspaceId').primary().references('id').inTable('workspaces').onDelete('CASCADE');
+        table.uuid('teamWorkspaceId').notNullable().references('id').inTable('workspaces').onDelete('CASCADE');
+        table.uuid('userId').notNullable().references('id').inTable('users').onDelete('CASCADE');
+        table.uuid('basePublishedVersionId').references('id').inTable('workspace_published_versions').onDelete('SET NULL');
+        table.integer('basePrivateContentRevision').notNullable().defaultTo(0);
+        table.boolean('hasUnpublishedChanges').notNullable().defaultTo(false);
+        table.timestamp('createdAt').notNullable().defaultTo(this.db.fn.now());
+        table.timestamp('updatedAt').notNullable().defaultTo(this.db.fn.now());
+        table.unique(['teamWorkspaceId', 'userId']);
+        table.index(['userId', 'teamWorkspaceId'], 'workspace_publication_links_user_team_idx');
+      });
+      console.log('Created "workspace_publication_links" table.');
+    } else {
+      await this.ensureColumn(
+        'workspace_publication_links',
+        'hasUnpublishedChanges',
+        (table) => table.boolean('hasUnpublishedChanges').notNullable().defaultTo(false),
+      );
     }
   }
 

--- a/backend/src/services/fileService.ts
+++ b/backend/src/services/fileService.ts
@@ -148,7 +148,7 @@ export class FileService {
     }
 
     await fs.mkdir(absoluteFolderPath, { recursive: true });
-    await this.workspaceService.touchWorkspace(workspaceId, userId);
+    await this.workspaceService.touchWorkspace(workspaceId, userId, { contentChanged: true });
 
     return { path: normalizedFolder };
   }
@@ -341,7 +341,7 @@ export class FileService {
       updatedBy: userId,
     }).returning('*');
 
-    await this.workspaceService.touchWorkspace(workspaceId, userId);
+    await this.workspaceService.touchWorkspace(workspaceId, userId, { contentChanged: true });
 
     return newFile;
   }
@@ -484,7 +484,7 @@ export class FileService {
       })
       .returning('*');
 
-    await this.workspaceService.touchWorkspace(file.workspaceId, userId);
+    await this.workspaceService.touchWorkspace(file.workspaceId, userId, { contentChanged: true });
 
     return updated;
   }
@@ -552,7 +552,7 @@ export class FileService {
     }
 
     await this.db('files').where({ id: fileId }).del();
-    await this.workspaceService.touchWorkspace(file.workspaceId, userId);
+    await this.workspaceService.touchWorkspace(file.workspaceId, userId, { contentChanged: true });
 
   }
 
@@ -613,7 +613,7 @@ export class FileService {
       console.error(`Failed to delete folder from filesystem: ${absoluteFolderPath}`, error);
     }
 
-    await this.workspaceService.touchWorkspace(workspaceId, userId);
+    await this.workspaceService.touchWorkspace(workspaceId, userId, { contentChanged: true });
 
   }
 
@@ -748,7 +748,7 @@ export class FileService {
       renamedIds.push(file.id);
     }
 
-    await this.workspaceService.touchWorkspace(workspaceId, userId);
+    await this.workspaceService.touchWorkspace(workspaceId, userId, { contentChanged: true });
 
     const files = renamedIds.length
       ? await this.db('files').whereIn('id', renamedIds)
@@ -836,7 +836,7 @@ export class FileService {
       });
     }
 
-    await this.workspaceService.touchWorkspace(file.workspaceId, userId);
+    await this.workspaceService.touchWorkspace(file.workspaceId, userId, { contentChanged: true });
 
     return this.db('files').where({ id: fileId }).first();
   }

--- a/backend/src/services/knowledgeService.ts
+++ b/backend/src/services/knowledgeService.ts
@@ -95,7 +95,7 @@ export class KnowledgeService {
   }
 
   async list(workspaceId: string, userId: string) {
-    await this.workspaceService.ensureMembership(workspaceId, userId);
+    await this.workspaceService.ensureMembership(workspaceId, userId, { requireEdit: true });
     const rows = await this.baseQuery()
       .where('knowledge_sources.workspaceId', workspaceId)
       .orderBy('knowledge_sources.updatedAt', 'desc');
@@ -125,7 +125,7 @@ export class KnowledgeService {
   }
 
   async getById(workspaceId: string, id: number, userId: string) {
-    await this.workspaceService.ensureMembership(workspaceId, userId);
+    await this.workspaceService.ensureMembership(workspaceId, userId, { requireEdit: true });
     const row = await this.baseQuery()
       .where('knowledge_sources.workspaceId', workspaceId)
       .andWhere('knowledge_sources.id', id)

--- a/backend/src/services/scheduleService.ts
+++ b/backend/src/services/scheduleService.ts
@@ -308,7 +308,7 @@ export class ScheduleService {
   }
 
   async listSchedulesForWorkspace(userId: string, workspaceId: string): Promise<WorkspaceSchedule[]> {
-    await this.workspaceService.ensureMembership(workspaceId, userId);
+    await this.workspaceService.ensureMembership(workspaceId, userId, { requireEdit: true });
     const rows = await this.db<WorkspaceScheduleRow>('workspace_schedules')
       .where({ workspaceId })
       .orderBy('createdAt', 'desc');
@@ -322,7 +322,7 @@ export class ScheduleService {
   }
 
   async getSchedule(userId: string, workspaceId: string, scheduleId: string): Promise<WorkspaceSchedule> {
-    await this.workspaceService.ensureMembership(workspaceId, userId);
+    await this.workspaceService.ensureMembership(workspaceId, userId, { requireEdit: true });
     const row = await this.db<WorkspaceScheduleRow>('workspace_schedules')
       .where({ id: scheduleId, workspaceId })
       .first();
@@ -448,7 +448,7 @@ export class ScheduleService {
     scheduleId: string,
     limit = 20,
   ): Promise<WorkspaceScheduleRun[]> {
-    await this.workspaceService.ensureMembership(workspaceId, userId);
+    await this.workspaceService.ensureMembership(workspaceId, userId, { requireEdit: true });
     const rows = await this.db<WorkspaceScheduleRunRow>('workspace_schedule_runs')
       .where({ scheduleId, workspaceId })
       .orderBy('createdAt', 'desc')

--- a/backend/src/services/workspacePublicationDiff.ts
+++ b/backend/src/services/workspacePublicationDiff.ts
@@ -1,0 +1,88 @@
+export type PublicationFileState = {
+  hash: string;
+};
+
+export type PublicationConflict = {
+  path: string;
+  privateChange: 'added' | 'changed' | 'deleted';
+  teamChange: 'added' | 'changed' | 'deleted';
+};
+
+const changeKind = (
+  base: PublicationFileState | undefined,
+  next: PublicationFileState | undefined,
+): PublicationConflict['privateChange'] => {
+  if (!base && next) return 'added';
+  if (base && !next) return 'deleted';
+  return 'changed';
+};
+
+export const hasFileChanged = (
+  base: PublicationFileState | undefined,
+  next: PublicationFileState | undefined,
+): boolean => (base?.hash || null) !== (next?.hash || null);
+
+export const findPublicationConflicts = (
+  base: Map<string, PublicationFileState>,
+  privateFiles: Map<string, PublicationFileState>,
+  teamFiles: Map<string, PublicationFileState>,
+): PublicationConflict[] => {
+  const paths = new Set([...base.keys(), ...privateFiles.keys(), ...teamFiles.keys()]);
+  const conflicts: PublicationConflict[] = [];
+
+  for (const filePath of paths) {
+    const baseFile = base.get(filePath);
+    const privateFile = privateFiles.get(filePath);
+    const teamFile = teamFiles.get(filePath);
+    const privateChanged = hasFileChanged(baseFile, privateFile);
+    const teamChanged = hasFileChanged(baseFile, teamFile);
+    const versionsDiffer = hasFileChanged(privateFile, teamFile);
+
+    if (privateChanged && teamChanged && versionsDiffer) {
+      conflicts.push({
+        path: filePath,
+        privateChange: changeKind(baseFile, privateFile),
+        teamChange: changeKind(baseFile, teamFile),
+      });
+    }
+  }
+
+  return conflicts.sort((left, right) => left.path.localeCompare(right.path));
+};
+
+export const mergePublicationFolders = (
+  baseFolders: Iterable<string>,
+  privateFolders: Iterable<string>,
+  teamFolders: Iterable<string>,
+  selectedFilePaths: Iterable<string> = [],
+): string[] => {
+  const base = new Set(baseFolders);
+  const privateSet = new Set(privateFolders);
+  const team = new Set(teamFolders);
+  const paths = new Set([...base, ...privateSet, ...team]);
+  const merged = new Set<string>();
+
+  for (const folderPath of paths) {
+    const baseHasFolder = base.has(folderPath);
+    const privateHasFolder = privateSet.has(folderPath);
+    const teamHasFolder = team.has(folderPath);
+    const privateChanged = privateHasFolder !== baseHasFolder;
+    const teamChanged = teamHasFolder !== baseHasFolder;
+    const selected = privateChanged
+      ? privateHasFolder
+      : teamChanged
+        ? teamHasFolder
+        : privateHasFolder;
+    if (selected) merged.add(folderPath);
+  }
+
+  for (const filePath of selectedFilePaths) {
+    const parts = filePath.split('/').filter(Boolean);
+    parts.pop();
+    for (let index = 1; index <= parts.length; index += 1) {
+      merged.add(parts.slice(0, index).join('/'));
+    }
+  }
+
+  return [...merged].sort((left, right) => left.localeCompare(right));
+};

--- a/backend/src/services/workspacePublicationService.ts
+++ b/backend/src/services/workspacePublicationService.ts
@@ -1,0 +1,1006 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+
+import { AccessDeniedError, ConflictError, NotFoundError } from '../errors';
+import { resolveWorkspaceRoot } from '../config/workspaceRoot';
+import { DatabaseService } from './databaseService';
+import { S3Service } from './s3Service';
+import { WorkspaceRecord, WorkspaceRole, WorkspaceService } from './workspaceService';
+import {
+  findPublicationConflicts,
+  hasFileChanged,
+  mergePublicationFolders,
+  type PublicationConflict,
+} from './workspacePublicationDiff';
+
+const WORKSPACE_DIR = resolveWorkspaceRoot();
+const VERSION_ROOT = path.join(WORKSPACE_DIR, '.published-versions');
+const INTERNAL_WORKSPACE_DIR_NAMES = new Set(['.system']);
+
+type PublishResolution = 'private' | 'team';
+
+type ContentFile = {
+  name: string;
+  mimeType: string | null;
+  buffer: Buffer;
+  hash: string;
+  size: number;
+};
+
+type PublicationManifestFile = {
+  name: string;
+  mimeType: string | null;
+  hash: string;
+  size: number;
+};
+
+type PublicationManifest = {
+  files: PublicationManifestFile[];
+  folders: string[];
+};
+
+type PublishedVersionRecord = {
+  id: string;
+  teamWorkspaceId: string;
+  versionNumber: number;
+  sourcePrivateWorkspaceId?: string | null;
+  publisherUserId: string | null;
+  note?: string | null;
+  manifest: PublicationManifest | PublicationManifestFile[];
+  createdAt: string;
+};
+
+type PublicationLinkRecord = {
+  privateWorkspaceId: string;
+  teamWorkspaceId: string;
+  userId: string;
+  basePublishedVersionId: string | null;
+  basePrivateContentRevision: number;
+  hasUnpublishedChanges: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type WorkspaceContent = {
+  files: Map<string, ContentFile>;
+  folders: string[];
+};
+
+export class WorkspacePublicationService {
+  private readonly db: Knex;
+  private readonly workspaceService: WorkspaceService;
+  private readonly s3Service: S3Service;
+
+  constructor(databaseService: DatabaseService, workspaceService: WorkspaceService) {
+    this.db = databaseService.getDb();
+    this.workspaceService = workspaceService;
+    this.s3Service = new S3Service();
+  }
+
+  async publish(
+    privateWorkspaceId: string,
+    userId: string,
+    input: { teamId?: string; note?: string; name?: string },
+  ) {
+    const { workspace: privateWorkspace } = await this.workspaceService.ensureMembership(
+      privateWorkspaceId,
+      userId,
+      { requireEdit: true },
+    );
+    if (privateWorkspace.visibility !== 'private' || privateWorkspace.ownerId !== userId) {
+      throw new AccessDeniedError('Only the owner can publish a private workspace');
+    }
+
+    const existingLink = await this.db<PublicationLinkRecord>('workspace_publication_links')
+      .where({ privateWorkspaceId })
+      .first();
+
+    if (!existingLink) {
+      if (!input.teamId) {
+        throw new ConflictError('Choose a team before publishing');
+      }
+      await this.ensureGroupMembership(input.teamId, userId);
+      return this.publishFirstVersion(privateWorkspace, userId, {
+        teamId: input.teamId,
+        note: input.note,
+        name: input.name,
+      });
+    }
+
+    const { workspace: teamWorkspace, membership } = await this.workspaceService.ensureMembership(
+      existingLink.teamWorkspaceId,
+      userId,
+    );
+    this.ensurePublisher(membership.role);
+
+    if (teamWorkspace.currentPublishedVersionId !== existingLink.basePublishedVersionId) {
+      throw new ConflictError('Team updates must be reviewed before publishing', {
+        code: 'TEAM_UPDATES_AVAILABLE',
+        teamWorkspaceId: teamWorkspace.id,
+      });
+    }
+
+    if (
+      !existingLink.hasUnpublishedChanges
+      && Number(privateWorkspace.contentRevision || 0) === Number(existingLink.basePrivateContentRevision || 0)
+    ) {
+      throw new ConflictError('There are no private changes to publish');
+    }
+
+    return this.createPublishedVersion({
+      privateWorkspace,
+      teamWorkspace,
+      userId,
+      note: input.note,
+      existingLink,
+    });
+  }
+
+  async createPrivateCopy(teamWorkspaceId: string, userId: string) {
+    const { workspace: teamWorkspace } = await this.workspaceService.ensureMembership(teamWorkspaceId, userId);
+    if (teamWorkspace.visibility !== 'team') {
+      throw new ConflictError('A private copy can only be created from a team workspace');
+    }
+
+    const existing = await this.db<PublicationLinkRecord>('workspace_publication_links')
+      .where({ teamWorkspaceId, userId })
+      .first();
+    if (existing) {
+      const workspace = await this.db<WorkspaceRecord>('workspaces')
+        .where({ id: existing.privateWorkspaceId })
+        .first();
+      if (workspace) {
+        return this.toPrivateWorkspaceResponse(workspace, teamWorkspaceId);
+      }
+    }
+
+    const currentVersion = await this.ensureCurrentVersion(teamWorkspace, userId);
+    const content = await this.readPublishedVersionContent(currentVersion);
+    const privateWorkspaceId = uuidv4();
+    const name = await this.resolveUniquePrivateCopyName(userId, teamWorkspace.name);
+    const slug = await this.generateUniqueSlug(name);
+
+    await this.db.transaction(async (tx) => {
+      await tx('workspaces').insert({
+        id: privateWorkspaceId,
+        name,
+        slug,
+        ownerId: userId,
+        lastModifiedBy: userId,
+        visibility: 'private',
+        contentRevision: 0,
+      });
+      await tx('workspace_members').insert({
+        workspaceId: privateWorkspaceId,
+        userId,
+        role: 'owner',
+        canEdit: true,
+      });
+    });
+
+    try {
+      const contentRevision = await this.replaceWorkspaceContent(privateWorkspaceId, content, userId);
+      await this.db('workspace_publication_links').insert({
+        privateWorkspaceId,
+        teamWorkspaceId,
+        userId,
+        basePublishedVersionId: currentVersion.id,
+        basePrivateContentRevision: contentRevision,
+      });
+    } catch (error) {
+      await this.db('workspaces').where({ id: privateWorkspaceId }).del();
+      await fs.rm(path.join(WORKSPACE_DIR, privateWorkspaceId), { recursive: true, force: true });
+      throw error;
+    }
+
+    const workspace = await this.db<WorkspaceRecord>('workspaces').where({ id: privateWorkspaceId }).first();
+    if (!workspace) {
+      throw new NotFoundError('Private working copy was not created');
+    }
+    return this.toPrivateWorkspaceResponse(workspace, teamWorkspaceId);
+  }
+
+  async sync(
+    privateWorkspaceId: string,
+    userId: string,
+    resolutions: Record<string, PublishResolution> = {},
+  ) {
+    const { workspace: privateWorkspace } = await this.workspaceService.ensureMembership(
+      privateWorkspaceId,
+      userId,
+      { requireEdit: true },
+    );
+    if (privateWorkspace.visibility !== 'private' || privateWorkspace.ownerId !== userId) {
+      throw new AccessDeniedError('Only the owner can sync a private workspace');
+    }
+
+    const link = await this.db<PublicationLinkRecord>('workspace_publication_links')
+      .where({ privateWorkspaceId, userId })
+      .first();
+    if (!link) {
+      throw new ConflictError('This private workspace is not linked to a team workspace');
+    }
+
+    const { workspace: teamWorkspace } = await this.workspaceService.ensureMembership(link.teamWorkspaceId, userId);
+    const latestVersion = await this.ensureCurrentVersion(teamWorkspace, userId);
+    if (latestVersion.id === link.basePublishedVersionId) {
+      return {
+        workspaceId: privateWorkspaceId,
+        teamWorkspaceId: teamWorkspace.id,
+        status: 'up_to_date',
+        conflicts: [],
+      };
+    }
+
+    const baseVersion = link.basePublishedVersionId
+      ? await this.getPublishedVersion(link.basePublishedVersionId, teamWorkspace.id)
+      : null;
+    const [privateContent, teamContent, baseContent] = await Promise.all([
+      this.readWorkspaceContent(privateWorkspaceId),
+      this.readPublishedVersionContent(latestVersion),
+      baseVersion ? this.readPublishedVersionContent(baseVersion) : Promise.resolve({ files: new Map(), folders: [] }),
+    ]);
+
+    const conflicts = findPublicationConflicts(
+      this.toHashMap(baseContent),
+      this.toHashMap(privateContent),
+      this.toHashMap(teamContent),
+    );
+    const unresolved = conflicts.filter((conflict) => !resolutions[conflict.path]);
+    if (unresolved.length) {
+      throw new ConflictError('Review overlapping workspace changes before syncing', {
+        code: 'REVIEW_NEEDED',
+        conflicts: this.presentConflicts(unresolved, privateContent, teamContent),
+      });
+    }
+
+    const merged = this.mergeWorkspaceContent(baseContent, privateContent, teamContent, resolutions);
+    await this.replaceWorkspaceContent(
+      privateWorkspaceId,
+      merged,
+      userId,
+      undefined,
+      async (tx, contentRevision) => {
+        const updated = await tx('workspace_publication_links')
+          .where({ privateWorkspaceId, userId })
+          .update({
+            basePublishedVersionId: latestVersion.id,
+            basePrivateContentRevision: contentRevision,
+            hasUnpublishedChanges: !this.workspaceContentsMatch(merged, teamContent),
+            updatedAt: tx.fn.now(),
+          });
+        if (updated !== 1) {
+          throw new ConflictError('The private workspace link changed while syncing');
+        }
+      },
+    );
+
+    return {
+      workspaceId: privateWorkspaceId,
+      teamWorkspaceId: teamWorkspace.id,
+      status: conflicts.length ? 'reviewed' : 'synced',
+      conflicts,
+      publishedVersionId: latestVersion.id,
+      publishedVersionNumber: Number(latestVersion.versionNumber),
+    };
+  }
+
+  async listHistory(teamWorkspaceId: string, userId: string) {
+    const { workspace } = await this.workspaceService.ensureMembership(teamWorkspaceId, userId);
+    if (workspace.visibility !== 'team') {
+      throw new ConflictError('Publication history is only available for team workspaces');
+    }
+    await this.ensureCurrentVersion(workspace, userId);
+    return this.db('workspace_published_versions as version')
+      .leftJoin('users as publisher', 'publisher.id', 'version.publisherUserId')
+      .where('version.teamWorkspaceId', teamWorkspaceId)
+      .select(
+        'version.id',
+        'version.versionNumber',
+        'version.note',
+        'version.createdAt',
+        this.db.raw(`COALESCE(publisher."displayName", 'Former user') as "publisherName"`),
+      )
+      .orderBy('version.versionNumber', 'desc');
+  }
+
+  async restore(teamWorkspaceId: string, versionId: string, userId: string) {
+    const { workspace: teamWorkspace, membership } = await this.workspaceService.ensureMembership(
+      teamWorkspaceId,
+      userId,
+    );
+    if (teamWorkspace.visibility !== 'team' || membership.role !== 'owner') {
+      throw new AccessDeniedError('Only the Team owner can restore a published version');
+    }
+    const restoredVersion = await this.getPublishedVersion(versionId, teamWorkspaceId);
+    const content = await this.readPublishedVersionContent(restoredVersion);
+    const newVersionId = uuidv4();
+    const manifest = await this.writeVersionSnapshot(newVersionId, content);
+
+    try {
+      return await this.db.transaction(async (tx) => {
+        const lockedTeam = await tx<WorkspaceRecord>('workspaces')
+          .where({ id: teamWorkspaceId })
+          .forUpdate()
+          .first();
+        if (!lockedTeam) {
+          throw new NotFoundError('Team workspace not found');
+        }
+        const currentOwnerMembership = await tx('workspace_members')
+          .select('role')
+          .where({ workspaceId: lockedTeam.id, userId })
+          .forShare()
+          .first() as { role?: WorkspaceRole } | undefined;
+        if (currentOwnerMembership?.role !== 'owner') {
+          throw new AccessDeniedError('Only the Team owner can restore a published version');
+        }
+        if (lockedTeam.teamId) {
+          const currentGroupMembership = await tx('group_members')
+            .where({ groupId: lockedTeam.teamId, userId })
+            .forShare()
+            .first();
+          if (!currentGroupMembership) {
+            throw new AccessDeniedError('Team membership is required to restore a published version');
+          }
+        }
+        const previousVersion = lockedTeam.currentPublishedVersionId
+          ? await tx<PublishedVersionRecord>('workspace_published_versions')
+            .where({ id: lockedTeam.currentPublishedVersionId, teamWorkspaceId })
+            .first()
+          : null;
+        const previousContent = previousVersion
+          ? await this.readPublishedVersionContent(previousVersion)
+          : await this.readWorkspaceContent(teamWorkspaceId);
+
+        try {
+          const nextVersionNumber = await this.getNextVersionNumber(teamWorkspaceId, tx);
+          await this.replaceWorkspaceContent(teamWorkspaceId, content, userId, tx);
+          const [created] = await tx<PublishedVersionRecord>('workspace_published_versions')
+            .insert({
+              id: newVersionId,
+              teamWorkspaceId,
+              versionNumber: nextVersionNumber,
+              sourcePrivateWorkspaceId: null,
+              publisherUserId: userId,
+              note: `Restored version ${restoredVersion.versionNumber}`,
+              manifest,
+            })
+            .returning('*');
+          await tx('workspaces')
+            .where({ id: teamWorkspaceId })
+            .update({
+              currentPublishedVersionId: created.id,
+              updatedAt: tx.fn.now(),
+              lastModifiedBy: userId,
+            });
+          return created;
+        } catch (error) {
+          await this.replaceWorkspaceContent(teamWorkspaceId, previousContent, userId, tx)
+            .catch((rollbackError) => {
+              console.error('Failed to restore the previous team content after a restore error', rollbackError);
+            });
+          throw error;
+        }
+      });
+    } catch (error) {
+      await fs.rm(this.versionDirectory(newVersionId), { recursive: true, force: true });
+      throw error;
+    }
+  }
+
+  private async publishFirstVersion(
+    privateWorkspace: WorkspaceRecord,
+    userId: string,
+    input: { teamId: string; note?: string; name?: string },
+  ) {
+    const teamWorkspaceId = uuidv4();
+    const resolvedName = String(input.name || privateWorkspace.name).trim().slice(0, 255) || privateWorkspace.name;
+    const slug = await this.generateUniqueSlug(resolvedName);
+
+    await this.db.transaction(async (tx) => {
+      await tx('workspaces').insert({
+        id: teamWorkspaceId,
+        name: resolvedName,
+        slug,
+        ownerId: userId,
+        lastModifiedBy: userId,
+        visibility: 'team',
+        teamId: input.teamId,
+        contentRevision: 0,
+      });
+      await tx('workspace_members').insert({
+        workspaceId: teamWorkspaceId,
+        userId,
+        role: 'owner',
+        canEdit: false,
+      });
+    });
+
+    const teamWorkspace = await this.db<WorkspaceRecord>('workspaces').where({ id: teamWorkspaceId }).first();
+    if (!teamWorkspace) {
+      throw new NotFoundError('Team workspace was not created');
+    }
+
+    try {
+      return await this.createPublishedVersion({
+        privateWorkspace,
+        teamWorkspace,
+        userId,
+        note: input.note,
+        existingLink: null,
+      });
+    } catch (error) {
+      await this.db('workspaces').where({ id: teamWorkspaceId }).del();
+      await fs.rm(path.join(WORKSPACE_DIR, teamWorkspaceId), { recursive: true, force: true });
+      throw error;
+    }
+  }
+
+  private async createPublishedVersion(input: {
+    privateWorkspace: WorkspaceRecord;
+    teamWorkspace: WorkspaceRecord;
+    userId: string;
+    note?: string;
+    existingLink: PublicationLinkRecord | null;
+  }) {
+    const content = await this.readWorkspaceContent(input.privateWorkspace.id);
+    const versionId = uuidv4();
+    const manifest = await this.writeVersionSnapshot(versionId, content);
+
+    try {
+      return await this.db.transaction(async (tx) => {
+        const lockedTeam = await tx<WorkspaceRecord>('workspaces')
+          .where({ id: input.teamWorkspace.id })
+          .forUpdate()
+          .first();
+        if (!lockedTeam) {
+          throw new NotFoundError('Team workspace not found');
+        }
+
+        const currentLink = input.existingLink
+          ? await tx<PublicationLinkRecord>('workspace_publication_links')
+            .where({ privateWorkspaceId: input.privateWorkspace.id })
+            .forUpdate()
+            .first()
+          : null;
+        const currentPrivate = await tx<WorkspaceRecord>('workspaces')
+          .select('contentRevision')
+          .where({ id: input.privateWorkspace.id })
+          .forUpdate()
+          .first();
+        if (
+          input.existingLink
+          && (
+            !currentLink
+            || currentLink.teamWorkspaceId !== lockedTeam.id
+            || currentLink.basePublishedVersionId !== input.existingLink.basePublishedVersionId
+            || currentLink.basePublishedVersionId !== lockedTeam.currentPublishedVersionId
+          )
+        ) {
+          throw new ConflictError('Team updates must be reviewed before publishing', {
+            code: 'TEAM_UPDATES_AVAILABLE',
+            teamWorkspaceId: lockedTeam.id,
+          });
+        }
+        if (
+          currentLink
+          && !currentLink.hasUnpublishedChanges
+          && Number(currentPrivate?.contentRevision || 0) === Number(currentLink.basePrivateContentRevision || 0)
+        ) {
+          throw new ConflictError('There are no private changes to publish');
+        }
+
+        const publisherMembership = await tx('workspace_members')
+          .select('role')
+          .where({ workspaceId: lockedTeam.id, userId: input.userId })
+          .forShare()
+          .first() as { role?: WorkspaceRole } | undefined;
+        if (lockedTeam.teamId) {
+          const currentGroupMembership = await tx('group_members')
+            .where({ groupId: lockedTeam.teamId, userId: input.userId })
+            .forShare()
+            .first();
+          if (!currentGroupMembership) {
+            throw new AccessDeniedError('Team membership is required to publish changes');
+          }
+        }
+        if (input.existingLink) {
+          this.ensurePublisher(publisherMembership?.role || 'viewer');
+        }
+
+        const previousTeamContent = input.existingLink
+          ? lockedTeam.currentPublishedVersionId
+            ? await this.readPublishedVersionContent(
+              await this.getPublishedVersion(lockedTeam.currentPublishedVersionId, lockedTeam.id),
+            )
+            : await this.readWorkspaceContent(lockedTeam.id)
+          : null;
+
+        try {
+          const versionNumber = await this.getNextVersionNumber(lockedTeam.id, tx);
+          await this.replaceWorkspaceContent(lockedTeam.id, content, input.userId, tx);
+          const [version] = await tx<PublishedVersionRecord>('workspace_published_versions')
+            .insert({
+              id: versionId,
+              teamWorkspaceId: lockedTeam.id,
+              versionNumber,
+              sourcePrivateWorkspaceId: input.privateWorkspace.id,
+              publisherUserId: input.userId,
+              note: String(input.note || '').trim() || null,
+              manifest,
+            })
+            .returning('*');
+
+          await tx('workspaces')
+            .where({ id: lockedTeam.id })
+            .update({
+              currentPublishedVersionId: version.id,
+              updatedAt: tx.fn.now(),
+              lastModifiedBy: input.userId,
+            });
+          const linkPayload = {
+            teamWorkspaceId: lockedTeam.id,
+            userId: input.userId,
+            basePublishedVersionId: version.id,
+            basePrivateContentRevision: Number(currentPrivate?.contentRevision || 0),
+            hasUnpublishedChanges: false,
+            updatedAt: tx.fn.now(),
+          };
+          if (input.existingLink) {
+            await tx('workspace_publication_links')
+              .where({ privateWorkspaceId: input.privateWorkspace.id })
+              .update(linkPayload);
+          } else {
+            await tx('workspace_publication_links').insert({
+              privateWorkspaceId: input.privateWorkspace.id,
+              ...linkPayload,
+            });
+          }
+
+          return {
+            teamWorkspaceId: lockedTeam.id,
+            privateWorkspaceId: input.privateWorkspace.id,
+            publishedVersionId: version.id,
+            publishedVersionNumber: Number(version.versionNumber),
+            publishedAt: version.createdAt,
+          };
+        } catch (error) {
+          if (previousTeamContent) {
+            await this.replaceWorkspaceContent(lockedTeam.id, previousTeamContent, input.userId, tx)
+              .catch((rollbackError) => {
+                console.error('Failed to restore the previous team content after a publish error', rollbackError);
+              });
+          }
+          throw error;
+        }
+      });
+    } catch (error) {
+      await fs.rm(this.versionDirectory(versionId), { recursive: true, force: true });
+      throw error;
+    }
+  }
+
+  private async ensureCurrentVersion(
+    teamWorkspace: WorkspaceRecord,
+    userId: string,
+  ): Promise<PublishedVersionRecord> {
+    if (teamWorkspace.currentPublishedVersionId) {
+      return this.getPublishedVersion(teamWorkspace.currentPublishedVersionId, teamWorkspace.id);
+    }
+
+    // Legacy shared workspaces are frozen as team workspaces during migration.
+    // Their first immutable version is created lazily when publication features are used.
+    const content = await this.readWorkspaceContent(teamWorkspace.id);
+    const versionId = uuidv4();
+    const manifest = await this.writeVersionSnapshot(versionId, content);
+    const publisherUserId = teamWorkspace.ownerId || userId;
+    const [version] = await this.db<PublishedVersionRecord>('workspace_published_versions')
+      .insert({
+        id: versionId,
+        teamWorkspaceId: teamWorkspace.id,
+        versionNumber: 1,
+        sourcePrivateWorkspaceId: null,
+        publisherUserId,
+        note: 'Initial published version',
+        manifest,
+      })
+      .returning('*');
+    await this.db('workspaces')
+      .where({ id: teamWorkspace.id })
+      .whereNull('currentPublishedVersionId')
+      .update({ currentPublishedVersionId: version.id });
+    return version;
+  }
+
+  private ensurePublisher(role: WorkspaceRole): void {
+    if (role !== 'owner' && role !== 'editor') {
+      throw new AccessDeniedError('Publisher access is required to publish changes');
+    }
+  }
+
+  private async ensureGroupMembership(groupId: string, userId: string): Promise<void> {
+    const group = await this.db('groups').where({ id: groupId }).first();
+    if (!group) {
+      throw new NotFoundError('Team not found');
+    }
+    const membership = await this.db('group_members').where({ groupId, userId }).first();
+    if (!membership) {
+      throw new AccessDeniedError('You are not a member of this team');
+    }
+  }
+
+  private async getPublishedVersion(versionId: string, teamWorkspaceId: string): Promise<PublishedVersionRecord> {
+    const version = await this.db<PublishedVersionRecord>('workspace_published_versions')
+      .where({ id: versionId, teamWorkspaceId })
+      .first();
+    if (!version) {
+      throw new NotFoundError('Published version not found');
+    }
+    return version;
+  }
+
+  private async getNextVersionNumber(
+    teamWorkspaceId: string,
+    database: Knex | Knex.Transaction = this.db,
+  ): Promise<number> {
+    const row = await database('workspace_published_versions')
+      .where({ teamWorkspaceId })
+      .max<{ max: string | number | null }>('versionNumber as max')
+      .first();
+    return Number(row?.max || 0) + 1;
+  }
+
+  private normalizeManifest(value: PublicationManifest | PublicationManifestFile[] | string): PublicationManifest {
+    const parsed = typeof value === 'string' ? JSON.parse(value) : value;
+    if (Array.isArray(parsed)) {
+      return { files: parsed, folders: [] };
+    }
+    return {
+      files: Array.isArray(parsed?.files) ? parsed.files : [],
+      folders: Array.isArray(parsed?.folders) ? parsed.folders : [],
+    };
+  }
+
+  private async readPublishedVersionContent(version: PublishedVersionRecord): Promise<WorkspaceContent> {
+    const manifest = this.normalizeManifest(version.manifest);
+    const files = new Map<string, ContentFile>();
+    for (const file of manifest.files) {
+      const safeName = this.normalizeRelativePath(file.name);
+      const buffer = await fs.readFile(path.join(this.versionDirectory(version.id), safeName));
+      files.set(safeName, {
+        name: safeName,
+        mimeType: file.mimeType || null,
+        buffer,
+        hash: file.hash,
+        size: Number(file.size || buffer.length),
+      });
+    }
+    return { files, folders: manifest.folders.map((folder) => this.normalizeRelativePath(folder)) };
+  }
+
+  private async readWorkspaceContent(workspaceId: string): Promise<WorkspaceContent> {
+    const rows = await this.db('files').where({ workspaceId }).orderBy('name', 'asc');
+    const files = new Map<string, ContentFile>();
+    for (const row of rows) {
+      if (this.isInternalWorkspacePath(String(row.name || ''))) continue;
+      const name = this.normalizeRelativePath(row.name);
+      const buffer = row.storageType === 'local'
+        ? await fs.readFile(row.path)
+        : await this.s3Service.getFile(row.path);
+      files.set(name, {
+        name,
+        mimeType: row.mimeType || null,
+        buffer,
+        hash: this.hashBuffer(buffer),
+        size: buffer.length,
+      });
+    }
+    return {
+      files,
+      folders: await this.listVisibleFolders(workspaceId),
+    };
+  }
+
+  private async writeVersionSnapshot(versionId: string, content: WorkspaceContent): Promise<PublicationManifest> {
+    const target = this.versionDirectory(versionId);
+    await fs.mkdir(target, { recursive: true });
+    const manifestFiles: PublicationManifestFile[] = [];
+    for (const file of content.files.values()) {
+      const destination = path.join(target, this.normalizeRelativePath(file.name));
+      await fs.mkdir(path.dirname(destination), { recursive: true });
+      await fs.writeFile(destination, file.buffer);
+      manifestFiles.push({
+        name: file.name,
+        mimeType: file.mimeType,
+        hash: file.hash,
+        size: file.size,
+      });
+    }
+    return {
+      files: manifestFiles.sort((left, right) => left.name.localeCompare(right.name)),
+      folders: [...new Set(content.folders)].sort(),
+    };
+  }
+
+  private async replaceWorkspaceContent(
+    workspaceId: string,
+    content: WorkspaceContent,
+    userId: string,
+    transaction?: Knex.Transaction,
+    afterDatabaseUpdate?: (transaction: Knex.Transaction, contentRevision: number) => Promise<void>,
+  ): Promise<number> {
+    const workspacePath = path.join(WORKSPACE_DIR, workspaceId);
+    const stagePath = path.join(WORKSPACE_DIR, `.workspace-stage-${uuidv4()}`);
+    const backupPath = path.join(WORKSPACE_DIR, `.workspace-backup-${uuidv4()}`);
+    await fs.mkdir(stagePath, { recursive: true });
+
+    try {
+      for (const folder of content.folders) {
+        await fs.mkdir(path.join(stagePath, this.normalizeRelativePath(folder)), { recursive: true });
+      }
+      for (const file of content.files.values()) {
+        const destination = path.join(stagePath, this.normalizeRelativePath(file.name));
+        await fs.mkdir(path.dirname(destination), { recursive: true });
+        await fs.writeFile(destination, file.buffer);
+      }
+      await this.copyInternalDirectories(workspacePath, stagePath);
+
+      let hadWorkspaceDirectory = true;
+      try {
+        await fs.rename(workspacePath, backupPath);
+      } catch (error: any) {
+        if (error?.code !== 'ENOENT') throw error;
+        hadWorkspaceDirectory = false;
+      }
+      await fs.rename(stagePath, workspacePath);
+
+      try {
+        const updateDatabaseRecords = async (tx: Knex | Knex.Transaction) => {
+          const existingFiles = await tx('files').where({ workspaceId });
+          const visibleIds = existingFiles
+            .filter((file) => !this.isInternalWorkspacePath(String(file.name || '')))
+            .map((file) => file.id);
+          if (visibleIds.length) {
+            await tx('files').whereIn('id', visibleIds).del();
+          }
+          if (content.files.size) {
+            await tx('files').insert([...content.files.values()].map((file) => ({
+              name: file.name,
+              workspaceId,
+              storageType: 'local',
+              path: path.join(workspacePath, file.name),
+              mimeType: file.mimeType,
+              publicUrl: null,
+              createdBy: userId,
+              updatedBy: userId,
+              version: 1,
+            })));
+          }
+          const [updated] = await tx('workspaces')
+            .where({ id: workspaceId })
+            .update({
+              contentRevision: tx.raw('COALESCE("contentRevision", 0) + 1'),
+              updatedAt: tx.fn.now(),
+              lastModifiedBy: userId,
+            })
+            .returning('contentRevision');
+          return Number(updated?.contentRevision || 0);
+        };
+        const applyDatabaseChanges = async (tx: Knex.Transaction) => {
+          const contentRevision = await updateDatabaseRecords(tx);
+          await afterDatabaseUpdate?.(tx, contentRevision);
+          return contentRevision;
+        };
+        const contentRevision = transaction
+          ? await applyDatabaseChanges(transaction)
+          : await this.db.transaction(applyDatabaseChanges);
+        await fs.rm(backupPath, { recursive: true, force: true });
+        return contentRevision;
+      } catch (error) {
+        await fs.rm(workspacePath, { recursive: true, force: true });
+        if (hadWorkspaceDirectory) {
+          await fs.rename(backupPath, workspacePath);
+        }
+        throw error;
+      }
+    } finally {
+      await fs.rm(stagePath, { recursive: true, force: true });
+      await fs.rm(backupPath, { recursive: true, force: true });
+    }
+  }
+
+  private mergeWorkspaceContent(
+    base: WorkspaceContent,
+    privateContent: WorkspaceContent,
+    teamContent: WorkspaceContent,
+    resolutions: Record<string, PublishResolution>,
+  ): WorkspaceContent {
+    const files = new Map<string, ContentFile>();
+    const paths = new Set([...base.files.keys(), ...privateContent.files.keys(), ...teamContent.files.keys()]);
+
+    for (const filePath of paths) {
+      const baseFile = base.files.get(filePath);
+      const privateFile = privateContent.files.get(filePath);
+      const teamFile = teamContent.files.get(filePath);
+      const privateChanged = hasFileChanged(baseFile, privateFile);
+      const teamChanged = hasFileChanged(baseFile, teamFile);
+      const versionsDiffer = hasFileChanged(privateFile, teamFile);
+
+      let selected: ContentFile | undefined;
+      if (privateChanged && teamChanged && versionsDiffer) {
+        selected = resolutions[filePath] === 'team' ? teamFile : privateFile;
+      } else if (teamChanged) {
+        selected = teamFile;
+      } else {
+        selected = privateFile;
+      }
+      if (selected) files.set(filePath, selected);
+    }
+
+    return {
+      files,
+      folders: mergePublicationFolders(
+        base.folders,
+        privateContent.folders,
+        teamContent.folders,
+        files.keys(),
+      ),
+    };
+  }
+
+  private toHashMap(content: WorkspaceContent): Map<string, { hash: string }> {
+    return new Map([...content.files.entries()].map(([filePath, file]) => [filePath, { hash: file.hash }]));
+  }
+
+  private presentConflicts(
+    conflicts: PublicationConflict[],
+    privateContent: WorkspaceContent,
+    teamContent: WorkspaceContent,
+  ) {
+    return conflicts.map((conflict) => {
+      const privateFile = privateContent.files.get(conflict.path);
+      const teamFile = teamContent.files.get(conflict.path);
+      const canCompareText = this.isTextContent(privateFile) && this.isTextContent(teamFile);
+      return {
+        ...conflict,
+        ...(canCompareText
+          ? {
+              privateText: privateFile!.buffer.toString('utf-8').slice(0, 20_000),
+              teamText: teamFile!.buffer.toString('utf-8').slice(0, 20_000),
+              textTruncated: privateFile!.size > 20_000 || teamFile!.size > 20_000,
+            }
+          : {}),
+      };
+    });
+  }
+
+  private isTextContent(file: ContentFile | undefined): boolean {
+    if (!file) return false;
+    const mimeType = String(file.mimeType || '').toLowerCase();
+    if (
+      mimeType.startsWith('text/')
+      || mimeType === 'application/json'
+      || mimeType === 'application/javascript'
+      || mimeType === 'image/svg+xml'
+    ) {
+      return true;
+    }
+    return ['.md', '.txt', '.json', '.csv', '.html', '.css', '.js', '.ts', '.tsx', '.jsx', '.svg', '.yaml', '.yml']
+      .includes(path.extname(file.name).toLowerCase());
+  }
+
+  private workspaceContentsMatch(left: WorkspaceContent, right: WorkspaceContent): boolean {
+    if (left.files.size !== right.files.size) return false;
+    for (const [filePath, leftFile] of left.files) {
+      if (right.files.get(filePath)?.hash !== leftFile.hash) return false;
+    }
+    const leftFolders = [...new Set(left.folders)].sort();
+    const rightFolders = [...new Set(right.folders)].sort();
+    return leftFolders.length === rightFolders.length
+      && leftFolders.every((folder, index) => folder === rightFolders[index]);
+  }
+
+  private async copyInternalDirectories(sourceRoot: string, destinationRoot: string): Promise<void> {
+    let entries: Array<import('fs').Dirent> = [];
+    try {
+      entries = await fs.readdir(sourceRoot, { withFileTypes: true });
+    } catch (error: any) {
+      if (error?.code === 'ENOENT') return;
+      throw error;
+    }
+    for (const entry of entries) {
+      if (!entry.name.startsWith('.')) continue;
+      await fs.cp(
+        path.join(sourceRoot, entry.name),
+        path.join(destinationRoot, entry.name),
+        { recursive: true },
+      );
+    }
+  }
+
+  private async listVisibleFolders(workspaceId: string): Promise<string[]> {
+    const root = path.join(WORKSPACE_DIR, workspaceId);
+    const result: string[] = [];
+    const walk = async (current: string): Promise<void> => {
+      let entries: Array<import('fs').Dirent>;
+      try {
+        entries = await fs.readdir(current, { withFileTypes: true });
+      } catch (error: any) {
+        if (error?.code === 'ENOENT') return;
+        throw error;
+      }
+      for (const entry of entries) {
+        if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+        const absolute = path.join(current, entry.name);
+        const relative = path.relative(root, absolute).replace(/\\/g, '/');
+        if (!this.isInternalWorkspacePath(relative)) {
+          result.push(relative);
+          await walk(absolute);
+        }
+      }
+    };
+    await walk(root);
+    return result.sort();
+  }
+
+  private async resolveUniquePrivateCopyName(userId: string, baseName: string): Promise<string> {
+    const existing = await this.db('workspaces')
+      .where({ ownerId: userId, visibility: 'private' })
+      .select('name');
+    const names = new Set(existing.map((row) => String(row.name).toLowerCase()));
+    if (!names.has(baseName.toLowerCase())) return baseName;
+    let suffix = 2;
+    while (names.has(`${baseName} (${suffix})`.toLowerCase())) suffix += 1;
+    return `${baseName} (${suffix})`;
+  }
+
+  private async generateUniqueSlug(name: string): Promise<string> {
+    const base = name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .replace(/-{2,}/g, '-') || 'workspace';
+    let candidate = base;
+    let counter = 1;
+    while (await this.db('workspaces').where({ slug: candidate }).first()) {
+      candidate = `${base}-${counter}`;
+      counter += 1;
+    }
+    return candidate;
+  }
+
+  private toPrivateWorkspaceResponse(workspace: WorkspaceRecord, teamWorkspaceId: string) {
+    return {
+      ...workspace,
+      role: 'owner' as const,
+      canEdit: true,
+      visibility: 'private' as const,
+      publicationStatus: 'up_to_date' as const,
+      linkedTeamWorkspaceId: teamWorkspaceId,
+    };
+  }
+
+  private normalizeRelativePath(value: string): string {
+    const normalized = path.posix.normalize(String(value || '').replace(/\\/g, '/').replace(/^\/+/, ''));
+    if (!normalized || normalized === '.' || normalized === '..' || normalized.startsWith('../')) {
+      throw new ConflictError('Invalid workspace content path');
+    }
+    return normalized;
+  }
+
+  private isInternalWorkspacePath(value: string): boolean {
+    const parts = String(value || '').replace(/\\/g, '/').split('/').filter(Boolean);
+    return parts.some((part) => INTERNAL_WORKSPACE_DIR_NAMES.has(part.toLowerCase()) || part.startsWith('.'));
+  }
+
+  private versionDirectory(versionId: string): string {
+    return path.join(VERSION_ROOT, versionId);
+  }
+
+  private hashBuffer(buffer: Buffer): string {
+    return crypto.createHash('sha256').update(buffer).digest('hex');
+  }
+}

--- a/backend/src/services/workspaceService.ts
+++ b/backend/src/services/workspaceService.ts
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { DatabaseService } from './databaseService';
 import { S3Service } from './s3Service';
 import { UserContext } from '../types/user';
-import { AccessDeniedError, NotFoundError } from '../errors';
+import { AccessDeniedError, ConflictError, NotFoundError } from '../errors';
 import { resolveWorkspaceRoot } from '../config/workspaceRoot';
 
 const WORKSPACE_DIR = resolveWorkspaceRoot();
@@ -18,6 +18,10 @@ export interface WorkspaceRecord {
   slug: string;
   ownerId: string;
   lastModifiedBy?: string | null;
+  visibility: 'private' | 'team';
+  teamId?: string | null;
+  currentPublishedVersionId?: string | null;
+  contentRevision: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -59,28 +63,176 @@ export class WorkspaceService {
     }
   }
 
-  async listWorkspacesForUser(userId: string): Promise<Array<WorkspaceRecord & { role: WorkspaceRole; canEdit: boolean }>> {
-    const rows = await this.db('workspace_members')
-      .join('workspaces', 'workspace_members.workspaceId', 'workspaces.id')
-      .select(
-        'workspaces.*',
-        'workspace_members.role',
-        'workspace_members.canEdit',
+  async listWorkspacesForUser(userId: string): Promise<Array<WorkspaceRecord & {
+    role: WorkspaceRole;
+    canEdit: boolean;
+    canPublish: boolean;
+    teamName?: string | null;
+    publicationStatus: 'private_draft' | 'up_to_date' | 'changes_to_publish' | 'team_updates_available' | 'review_needed';
+    linkedTeamWorkspaceId?: string | null;
+    privateCopyWorkspaceId?: string | null;
+    currentPublishedVersionNumber?: number | null;
+    latestPublisherName?: string | null;
+    lastPublishedAt?: string | null;
+  }>> {
+    const rows = await this.db('workspaces as w')
+      .leftJoin('workspace_members as wm', function joinDirectMembership() {
+        this.on('wm.workspaceId', '=', 'w.id').andOnVal('wm.userId', '=', userId);
+      })
+      .leftJoin('group_members as gm', function joinTeamMembership() {
+        this.on('gm.groupId', '=', 'w.teamId').andOnVal('gm.userId', '=', userId);
+      })
+      .leftJoin('groups as g', 'g.id', 'w.teamId')
+      .leftJoin('workspace_publication_links as private_link', 'private_link.privateWorkspaceId', 'w.id')
+      .leftJoin('workspaces as linked_team', 'linked_team.id', 'private_link.teamWorkspaceId')
+      .leftJoin('workspace_members as linked_team_member', function joinLinkedTeamMembership() {
+        this.on('linked_team_member.workspaceId', '=', 'private_link.teamWorkspaceId')
+          .andOnVal('linked_team_member.userId', '=', userId);
+      })
+      .leftJoin('group_members as linked_team_group_member', function joinLinkedTeamGroupMembership() {
+        this.on('linked_team_group_member.groupId', '=', 'linked_team.teamId')
+          .andOnVal('linked_team_group_member.userId', '=', userId);
+      })
+      .leftJoin('workspace_publication_links as team_link', function joinPrivateCopy() {
+        this.on('team_link.teamWorkspaceId', '=', 'w.id').andOnVal('team_link.userId', '=', userId);
+      })
+      .leftJoin(
+        'workspace_published_versions as published',
+        'published.id',
+        this.db.raw('COALESCE(w."currentPublishedVersionId", linked_team."currentPublishedVersionId")'),
       )
-      .where('workspace_members.userId', userId)
-      .orderBy('workspaces.updatedAt', 'desc');
+      .leftJoin('users as publisher', 'publisher.id', 'published.publisherUserId')
+      .distinct(
+        'w.id',
+        'w.name',
+        'w.slug',
+        'w.ownerId',
+        'w.lastModifiedBy',
+        'w.visibility',
+        'w.teamId',
+        'w.currentPublishedVersionId',
+        'w.contentRevision',
+        'w.createdAt',
+        'w.updatedAt',
+        'wm.role as directRole',
+        'wm.canEdit as directCanEdit',
+        'g.name as teamName',
+        'private_link.teamWorkspaceId as linkedTeamWorkspaceId',
+        'linked_team.teamId as linkedTeamId',
+        'linked_team.currentPublishedVersionId as linkedTeamCurrentPublishedVersionId',
+        'private_link.basePublishedVersionId',
+        'private_link.basePrivateContentRevision',
+        'private_link.hasUnpublishedChanges',
+        'linked_team_member.role as linkedTeamRole',
+        'linked_team_group_member.userId as linkedTeamGroupMemberUserId',
+        'team_link.privateWorkspaceId as privateCopyWorkspaceId',
+        'published.versionNumber as currentPublishedVersionNumber',
+        'published.createdAt as lastPublishedAt',
+        'publisher.displayName as latestPublisherName',
+      )
+      .where((query) => {
+        query
+          .where((privateQuery) => {
+            privateQuery.where('w.visibility', 'private').andWhere('w.ownerId', userId);
+          })
+          .orWhere((teamQuery) => {
+            teamQuery
+              .where('w.visibility', 'team')
+              .andWhere((accessQuery) => {
+                accessQuery
+                  .where((groupBackedQuery) => {
+                    groupBackedQuery.whereNotNull('w.teamId').whereNotNull('gm.userId');
+                  })
+                  .orWhere((legacyQuery) => {
+                    legacyQuery.whereNull('w.teamId').whereNotNull('wm.userId');
+                  });
+              });
+          });
+      })
+      .orderBy('w.updatedAt', 'desc');
 
-    return rows.map((row: any) => ({
-      id: row.id,
-      name: row.name,
-      slug: row.slug,
-      ownerId: row.ownerId,
-      lastModifiedBy: row.lastModifiedBy,
-      createdAt: row.createdAt,
-      updatedAt: row.updatedAt,
-      role: row.role as WorkspaceRole,
-      canEdit: Boolean(row.canEdit),
-    }));
+    return rows.map((row: any) => {
+      const visibility = row.visibility === 'team' ? 'team' : 'private';
+      const privateChanged = visibility === 'private'
+        && row.linkedTeamWorkspaceId
+        && (
+          Boolean(row.hasUnpublishedChanges)
+          || Number(row.contentRevision || 0) !== Number(row.basePrivateContentRevision || 0)
+        );
+      const linkedTeamAccessible = visibility === 'private'
+        && row.linkedTeamWorkspaceId
+        && (
+          row.linkedTeamId
+            ? Boolean(row.linkedTeamGroupMemberUserId)
+            : Boolean(row.linkedTeamRole)
+        );
+      const teamChanged = visibility === 'private'
+        && row.linkedTeamWorkspaceId
+        && linkedTeamAccessible
+        && String(row.linkedTeamCurrentPublishedVersionId || '') !== String(row.basePublishedVersionId || '');
+      const publicationStatus = visibility === 'team'
+        ? 'up_to_date'
+        : !row.linkedTeamWorkspaceId
+          ? 'private_draft'
+          : privateChanged && teamChanged
+            ? 'review_needed'
+            : privateChanged
+              ? 'changes_to_publish'
+              : teamChanged
+                ? 'team_updates_available'
+                : 'up_to_date';
+
+      return {
+        id: row.id,
+        name: row.name,
+        slug: row.slug,
+        ownerId: row.ownerId,
+        lastModifiedBy: row.lastModifiedBy,
+        visibility,
+        teamId: row.teamId,
+        currentPublishedVersionId: row.currentPublishedVersionId,
+        contentRevision: Number(row.contentRevision || 0),
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        role: visibility === 'private' ? 'owner' : (row.directRole || 'viewer') as WorkspaceRole,
+        canEdit: visibility === 'private',
+        canPublish: visibility === 'private'
+          ? !row.linkedTeamWorkspaceId
+            || (
+              (row.linkedTeamRole === 'owner' || row.linkedTeamRole === 'editor')
+              && linkedTeamAccessible
+            )
+          : row.directRole === 'owner' || row.directRole === 'editor',
+        teamName: row.teamName || null,
+        publicationStatus,
+        linkedTeamWorkspaceId: row.linkedTeamWorkspaceId || null,
+        privateCopyWorkspaceId: row.privateCopyWorkspaceId || null,
+        currentPublishedVersionNumber: (
+          visibility === 'private'
+          && row.linkedTeamWorkspaceId
+          && !linkedTeamAccessible
+        ) || row.currentPublishedVersionNumber == null
+          ? null
+          : Number(row.currentPublishedVersionNumber),
+        latestPublisherName: visibility === 'private' && row.linkedTeamWorkspaceId && !linkedTeamAccessible
+          ? null
+          : row.latestPublisherName || null,
+        lastPublishedAt: visibility === 'private' && row.linkedTeamWorkspaceId && !linkedTeamAccessible
+          ? null
+          : row.lastPublishedAt || null,
+      };
+    });
+  }
+
+  async listEligibleTeams(userId: string): Promise<Array<{ id: string; name: string }>> {
+    return this.db('groups as g')
+      .join('group_members as gm', 'gm.groupId', 'g.id')
+      .where('gm.userId', userId)
+      .select(
+        'g.id',
+        'g.name',
+      )
+      .orderBy('g.name', 'asc');
   }
 
   async createWorkspace(user: UserContext, name?: string): Promise<WorkspaceRecord> {
@@ -94,6 +246,8 @@ export class WorkspaceService {
         slug,
         ownerId: user.userId,
         lastModifiedBy: user.userId,
+        visibility: 'private',
+        contentRevision: 0,
       })
       .returning('*');
 
@@ -151,9 +305,40 @@ export class WorkspaceService {
     };
     const normalizedWorkspace: WorkspaceRecord = workspaceRest;
 
-    const membership = await this.db<WorkspaceMembershipRecord>('workspace_members')
+    const directMembership = await this.db<WorkspaceMembershipRecord>('workspace_members')
       .where({ workspaceId, userId })
       .first();
+
+    let membership = directMembership;
+    if (normalizedWorkspace.visibility === 'private') {
+      if (normalizedWorkspace.ownerId !== userId) {
+        throw new AccessDeniedError('Private workspace access denied');
+      }
+      membership = membership || {
+        workspaceId,
+        userId,
+        role: 'owner',
+        canEdit: true,
+        createdAt: normalizedWorkspace.createdAt,
+        updatedAt: normalizedWorkspace.updatedAt,
+      };
+    } else if (normalizedWorkspace.teamId) {
+      const groupMembership = await this.db('group_members')
+        .where({ groupId: normalizedWorkspace.teamId, userId })
+        .first();
+      if (!groupMembership) {
+        throw new AccessDeniedError('Team membership is required to access this workspace');
+      }
+      membership = membership || {
+        workspaceId,
+        userId,
+        role: 'viewer',
+        canEdit: false,
+        createdAt: groupMembership.createdAt,
+        updatedAt: groupMembership.updatedAt,
+      };
+    }
+
     if (!membership) {
       throw new AccessDeniedError('Workspace access denied');
     }
@@ -161,9 +346,12 @@ export class WorkspaceService {
     const normalizedMembership: WorkspaceMembershipRecord = {
       ...membership,
       role: membership.role as WorkspaceRole,
-      canEdit: Boolean(membership.canEdit),
+      canEdit: normalizedWorkspace.visibility === 'private' && Boolean(membership.canEdit),
     };
 
+    if (options.requireEdit && normalizedWorkspace.visibility === 'team') {
+      throw new AccessDeniedError('Team workspaces are read-only. Work privately to make changes.');
+    }
     if (options.requireEdit && !normalizedMembership.canEdit) {
       throw new AccessDeniedError('Workspace is read-only for this user');
     }
@@ -229,8 +417,20 @@ export class WorkspaceService {
     role: WorkspaceRole,
   ): Promise<void> {
     const { membership } = await this.ensureMembership(workspaceId, actingUserId);
+    const workspace = await this.db<WorkspaceRecord>('workspaces').where({ id: workspaceId }).first();
+    if (workspace?.visibility !== 'team') {
+      throw new ConflictError('Private workspaces cannot have collaborators');
+    }
     if (membership.role !== 'owner') {
-      throw new AccessDeniedError('Only workspace owners can invite collaborators');
+      throw new AccessDeniedError('Only Team owners can manage publishing access');
+    }
+    if (workspace.teamId) {
+      const teamMember = await this.db('group_members')
+        .where({ groupId: workspace.teamId, userId: targetUserId })
+        .first();
+      if (!teamMember) {
+        throw new AccessDeniedError('Publishing access can only be granted to a member of this team');
+      }
     }
 
     const canEdit = role !== 'viewer';
@@ -297,12 +497,19 @@ export class WorkspaceService {
     }));
   }
 
-  async touchWorkspace(workspaceId: string, userId: string): Promise<void> {
+  async touchWorkspace(
+    workspaceId: string,
+    userId: string,
+    options: { contentChanged?: boolean } = {},
+  ): Promise<void> {
     await this.db('workspaces')
       .where({ id: workspaceId })
       .update({
         updatedAt: this.db.fn.now(),
         lastModifiedBy: userId,
+        ...(options.contentChanged
+          ? { contentRevision: this.db.raw('COALESCE("contentRevision", 0) + 1') }
+          : {}),
       });
   }
 
@@ -316,8 +523,20 @@ export class WorkspaceService {
   }
 
   private async performWorkspaceDeletion(workspaceId: string): Promise<void> {
+    const publishedVersions = await this.db('workspace_published_versions')
+      .select('id')
+      .where({ teamWorkspaceId: workspaceId })
+      .catch(() => [] as Array<{ id: string }>);
     await this.db('workspaces').where({ id: workspaceId }).del();
     await this.performWorkspaceCleanup(workspaceId);
+    await Promise.all(
+      publishedVersions.map((version) =>
+        fs.rm(path.join(WORKSPACE_DIR, '.published-versions', String(version.id)), {
+          recursive: true,
+          force: true,
+        }),
+      ),
+    );
   }
 
   private async performWorkspaceCleanup(workspaceId: string): Promise<void> {

--- a/backend/tests/workspacePublicationDiff.test.ts
+++ b/backend/tests/workspacePublicationDiff.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  findPublicationConflicts,
+  hasFileChanged,
+  mergePublicationFolders,
+} from '../src/services/workspacePublicationDiff';
+
+const state = (entries: Record<string, string>) =>
+  new Map(Object.entries(entries).map(([filePath, hash]) => [filePath, { hash }]));
+
+test('hasFileChanged detects additions, edits, and deletions', () => {
+  assert.equal(hasFileChanged(undefined, { hash: 'a' }), true);
+  assert.equal(hasFileChanged({ hash: 'a' }, { hash: 'b' }), true);
+  assert.equal(hasFileChanged({ hash: 'a' }, undefined), true);
+  assert.equal(hasFileChanged({ hash: 'a' }, { hash: 'a' }), false);
+  assert.equal(hasFileChanged(undefined, undefined), false);
+});
+
+test('different files can change without creating a conflict', () => {
+  const conflicts = findPublicationConflicts(
+    state({ 'brief.md': 'brief-1', 'data.csv': 'data-1' }),
+    state({ 'brief.md': 'brief-2', 'data.csv': 'data-1' }),
+    state({ 'brief.md': 'brief-1', 'data.csv': 'data-2' }),
+  );
+  assert.deepEqual(conflicts, []);
+});
+
+test('the same resulting content is not a conflict', () => {
+  const conflicts = findPublicationConflicts(
+    state({ 'brief.md': 'brief-1' }),
+    state({ 'brief.md': 'brief-2' }),
+    state({ 'brief.md': 'brief-2' }),
+  );
+  assert.deepEqual(conflicts, []);
+});
+
+test('overlapping edits and delete-versus-edit changes require review', () => {
+  const conflicts = findPublicationConflicts(
+    state({ 'brief.md': 'brief-1', 'old.md': 'old-1' }),
+    state({ 'brief.md': 'brief-private' }),
+    state({ 'brief.md': 'brief-team', 'old.md': 'old-team' }),
+  );
+
+  assert.deepEqual(conflicts, [
+    {
+      path: 'brief.md',
+      privateChange: 'changed',
+      teamChange: 'changed',
+    },
+    {
+      path: 'old.md',
+      privateChange: 'deleted',
+      teamChange: 'changed',
+    },
+  ]);
+});
+
+test('conflicts are returned in stable path order', () => {
+  const conflicts = findPublicationConflicts(
+    state({ 'z.md': '1', 'a.md': '1' }),
+    state({ 'z.md': '2', 'a.md': '2' }),
+    state({ 'z.md': '3', 'a.md': '3' }),
+  );
+
+  assert.deepEqual(conflicts.map((conflict) => conflict.path), ['a.md', 'z.md']);
+});
+
+test('folder merge preserves one-sided additions and deletions', () => {
+  assert.deepEqual(
+    mergePublicationFolders(
+      ['deleted-privately', 'deleted-by-team', 'unchanged'],
+      ['deleted-by-team', 'unchanged', 'private-added'],
+      ['deleted-privately', 'unchanged', 'team-added'],
+    ),
+    ['private-added', 'team-added', 'unchanged'],
+  );
+});
+
+test('folder merge includes parent folders required by selected files', () => {
+  assert.deepEqual(
+    mergePublicationFolders(['reports'], [], ['reports'], ['reports/2026/summary.md']),
+    ['reports', 'reports/2026'],
+  );
+});

--- a/docs/private-team-workspaces-spec.md
+++ b/docs/private-team-workspaces-spec.md
@@ -1,0 +1,465 @@
+# Private and Team Workspaces — Product Specification
+
+Status: Implemented MVP
+Branch: `feat/private-team-workspaces`
+
+## 1. Summary
+
+HelpUDoc will separate workspaces into two categories:
+
+- **Private workspaces** are visible only to their owner and are where editing happens.
+- **Team workspaces** contain explicitly published versions that approved teammates can access.
+
+Publishing must not grant teammates access to the underlying private workspace. A team workspace is a separate, stable version linked to one or more private working copies.
+
+The user-facing model is:
+
+- **Publish changes** sends a private workspace version to the team.
+- **Sync team updates** brings the latest team version into a linked private workspace.
+
+Version-control technology may be used internally, but its terminology must not appear in the product interface.
+
+## 2. Problem
+
+The current collaboration model shares one live workspace with owners, editors, and viewers. This does not meet the intended privacy model:
+
+- Users want to experiment and make unfinished changes without exposing them.
+- Teammates need access to approved workspace content, not the owner's live working environment.
+- Users need deliberate control over when changes become visible to the team.
+- Team members need a safe way to build on published work without editing it directly.
+
+Changing labels on the existing sharing flow is insufficient. Private and team workspaces need separate content states and access boundaries.
+
+## 3. Product Principles
+
+1. **Private by default**
+   Every newly created workspace starts as private.
+
+2. **Publishing is deliberate**
+   Private changes are never exposed automatically.
+
+3. **Published content is stable**
+   A team workspace changes only when an authorized user publishes a new version.
+
+4. **Editing happens privately**
+   Users create or open a private working copy before making changes to team content.
+
+5. **The direction of every action is clear**
+   `Publish changes` means private to team. `Sync team updates` means team to private.
+
+6. **No silent overwrites**
+   When both the private and team versions changed, the user reviews conflicts before publishing.
+
+7. **Publishing has a narrow privacy boundary**
+   Only supported workspace content is published. Personal activity and credentials are excluded.
+
+## 4. Terminology
+
+| Term | User-facing meaning |
+|---|---|
+| Private workspace | A workspace visible and editable only by its owner |
+| Team workspace | The latest published workspace version available to a team |
+| Private working copy | A private workspace linked to a team workspace |
+| Publish changes | Update the team workspace from a private working copy |
+| Sync team updates | Bring the latest team changes into a private working copy |
+| Published version | A saved team version with author and publication time |
+| Review needed | Both the private copy and team version changed since the last sync |
+
+Do not use terms such as repository, commit, branch, push, pull, merge, local, remote, or origin in the UI.
+
+## 5. Goals
+
+- Clearly separate private and team workspaces in navigation.
+- Keep all newly created work private until explicitly published.
+- Let authorized users publish a complete workspace version to a team.
+- Let teammates browse stable published content.
+- Let teammates create private working copies of team workspaces.
+- Support incoming team updates without silently discarding private work.
+- Show enough status information for users to understand whether their private copy and the team version differ.
+- Preserve published history for audit and recovery.
+
+## 6. Non-goals for the First Release
+
+- Real-time collaborative editing of a private workspace.
+- Sharing a private workspace with selected individuals.
+- Publishing selected files or folders.
+- Simultaneously publishing one private workspace to multiple teams.
+- Public or anonymous workspace links.
+- Commenting, approvals, or formal review workflows.
+- Advanced line-by-line conflict editing.
+- Automatically publishing private changes.
+
+## 7. Roles and Permissions
+
+### Private workspace
+
+| Role | Permissions |
+|---|---|
+| Owner | View, edit, rename, delete, sync, and publish if authorized for the linked team |
+| Everyone else | No access |
+
+A private workspace must never have collaborators or additional membership records.
+
+### Team workspace
+
+| Role | Permissions |
+|---|---|
+| Team owner | View, create a private working copy, manage access, publish, restore, archive |
+| Publisher | View, create a private working copy, publish new versions |
+| Viewer | View and create a private working copy |
+
+Team workspaces are read-only during normal browsing. Even publishers edit through a private working copy.
+
+Existing `editor` access may map to `Publisher`, while existing `viewer` access may remain `Viewer`.
+
+## 8. Information Architecture
+
+The workspace sidebar must have two visible sections:
+
+### Private workspaces
+
+- Contains private drafts and private working copies.
+- Provides the primary `New workspace` action.
+- Shows private/team synchronization status where applicable.
+
+### Team workspaces
+
+- Contains published workspaces available through team membership.
+- Shows the team name, latest publisher, and last published time.
+- Does not present direct file-editing controls.
+
+Search should operate across both sections while preserving the category labels in its results.
+
+If a user belongs to multiple teams, team workspaces should be grouped or labeled by team.
+
+## 9. Workspace States
+
+The state of a private workspace is derived from:
+
+- whether it is linked to a team workspace;
+- the team version on which it was last based;
+- whether the private workspace changed after that version; and
+- whether the team workspace has a newer published version.
+
+| State | Condition | Primary action |
+|---|---|---|
+| Private draft | Never published | Publish to team |
+| Published — up to date | No private or team changes | None |
+| Changes to publish | Private changed; team did not | Publish changes |
+| Team updates available | Team changed; private did not | Sync team updates |
+| Review needed | Both private and team changed | Review changes |
+
+Status must be shown in the private workspace list and within the opened workspace.
+
+## 10. User Stories and Acceptance Criteria
+
+### Story 1 — Create a private workspace
+
+As a user, I want new workspaces to be private so that I can work without exposing unfinished content.
+
+Acceptance criteria:
+
+- A new workspace appears under `Private workspaces`.
+- Only its creator can list, open, search, or access it.
+- It has no share or collaborator action.
+- Its initial status is `Private draft`.
+- Creating or editing content does not create a team workspace.
+
+### Story 2 — Publish a private workspace for the first time
+
+As an authorized user, I want to publish a private workspace so that my team can access an approved version without seeing my private workspace.
+
+Acceptance criteria:
+
+- The workspace offers `Publish to team`.
+- The publish dialog asks for a destination team.
+- If the user belongs to one eligible team, it may be preselected.
+- The dialog identifies what will and will not be published.
+- Confirming creates a separate team workspace and its first published version.
+- The private workspace remains private and becomes linked to the team workspace.
+- Teammates cannot access the private workspace ID, files, conversations, or activity.
+- The team workspace appears under `Team workspaces` for eligible team members.
+- The private workspace status becomes `Published — up to date`.
+
+### Story 3 — Browse a team workspace
+
+As a teammate, I want to browse the latest published workspace so that I can use approved team content.
+
+Acceptance criteria:
+
+- A team workspace opens in read-only mode.
+- It shows the latest publisher and publication time.
+- File creation, editing, renaming, moving, and deletion controls are unavailable.
+- The primary action is `Work privately`.
+- A user cannot discover unpublished private changes through search, previews, APIs, activity feeds, or agent context.
+
+### Story 4 — Create a private working copy
+
+As a teammate, I want a private working copy so that I can modify published work without changing what the team currently sees.
+
+Acceptance criteria:
+
+- `Work privately` creates a private workspace based on the latest team version.
+- The new workspace appears under `Private workspaces`.
+- It records which team workspace and published version it came from.
+- The original team workspace remains unchanged.
+- If the user already has a linked private working copy, the action opens it instead of silently creating a duplicate.
+- Unpublished edits are visible only to that user.
+
+### Story 5 — Publish changes to an existing team workspace
+
+As a Publisher, I want to publish my private changes so that the team workspace receives a deliberate new version.
+
+Acceptance criteria:
+
+- `Publish changes` is available when private changes exist and the user has publishing permission.
+- Pending autosaves complete before publication begins.
+- The user can enter an optional publication note.
+- Publication creates a complete, immutable team version.
+- The team workspace changes atomically; teammates never see a partially published version.
+- The published version records its author and time.
+- After success, the private workspace status becomes `Published — up to date`.
+- Viewers may continue private work but cannot publish.
+
+### Story 6 — Sync team updates
+
+As a user with a private working copy, I want to bring in newer team changes so that my work is based on the latest published version.
+
+Acceptance criteria:
+
+- `Sync team updates` appears when the team has a newer version.
+- If the private copy has no changes, syncing updates it directly.
+- Syncing never publishes the user's private content.
+- Syncing updates the recorded base team version.
+- The user receives a completion message describing the result.
+- A failed sync leaves the private workspace unchanged.
+
+### Story 7 — Review concurrent changes
+
+As a user, I want to review overlapping changes so that neither my work nor a teammate's published work is silently lost.
+
+Acceptance criteria:
+
+- If both sides changed, the status becomes `Review needed`.
+- Changes to different files are combined automatically.
+- For files changed on both sides, the review screen offers:
+  - `Keep mine`
+  - `Use team version`
+  - a text comparison when supported
+- Binary files do not attempt text comparison.
+- File additions, deletions, moves, and renames are represented in the review.
+- Resolving a review updates the private copy only.
+- The user must still select `Publish changes` to update the team workspace.
+- Cancelling review does not modify either version.
+
+### Story 8 — View and restore publication history
+
+As a Team owner, I want to inspect and restore published versions so that the team can recover from an incorrect publication.
+
+Acceptance criteria:
+
+- History shows publisher, publication time, optional note, and version identifier.
+- A historical version can be previewed without changing the current version.
+- Restoring creates a new published version rather than deleting history.
+- Restoration does not modify anyone's private workspace automatically.
+- Linked private copies show `Team updates available` after a restore.
+
+## 11. Publishable Content Boundary
+
+### Included in the first release
+
+- User-visible workspace files.
+- Folder structure.
+- User-visible dashboard and artifact packages stored in the workspace.
+- File and folder names, MIME types, and supported workspace metadata.
+
+### Excluded
+
+- Conversations and chat history.
+- Agent messages, tool calls, run logs, and approval history.
+- Draft prompts and unsent text.
+- Workspace schedules and schedule run history.
+- OAuth tokens, API keys, secrets, and credentials.
+- MCP connection credentials and personal integrations.
+- Personal settings, recent activity, and UI preferences.
+- Hidden runtime files and internal system state.
+- Temporary uploads, caches, and generated previews.
+
+Search indexes and derived previews should be rebuilt from the published content rather than copied with private runtime state.
+
+The publish confirmation must summarize this boundary in plain language.
+
+## 12. Publishing and Sync Rules
+
+### First publication
+
+1. Complete pending file saves.
+2. Validate the user's team and publishing permission.
+3. Create the team workspace.
+4. Save publication version 1 from an allowlisted content snapshot.
+5. Link the private workspace to the team workspace and version 1.
+6. Make the team workspace visible to eligible team members.
+
+If any step fails, no partially visible team workspace should remain.
+
+### Later publication
+
+1. Complete pending file saves.
+2. Compare the private workspace's base version with the current team version.
+3. If they match, create a new team version atomically.
+4. If the team version is newer, require sync or review first.
+5. Update the private workspace's base version only after publication succeeds.
+
+### Sync
+
+1. Load the private base version and latest team version.
+2. Determine private and team changes relative to the base.
+3. Apply non-overlapping changes to the private workspace.
+4. Require review for overlapping changes.
+5. Leave the team workspace unchanged.
+
+## 13. UX Requirements
+
+### Primary actions
+
+| Context | Action label |
+|---|---|
+| Unpublished private workspace | Publish to team |
+| Linked private workspace with changes | Publish changes |
+| Linked private workspace with incoming updates | Sync team updates |
+| Linked private workspace with concurrent changes | Review changes |
+| Team workspace without a private copy | Work privately |
+| Team workspace with an existing private copy | Open private copy |
+
+### Publish confirmation
+
+The confirmation must show:
+
+- destination team;
+- team workspace name;
+- whether this creates a new team workspace or updates an existing one;
+- the content included in publication;
+- a concise reminder that conversations, activity, and credentials remain private;
+- an optional publication note;
+- a final `Publish` action.
+
+### Feedback
+
+- Show progress for publication and sync operations.
+- Prevent duplicate submissions while an operation is running.
+- Report success with the new publication time.
+- Report failures without changing status optimistically.
+- Do not use vague messages such as `Sync complete` without stating what was updated.
+
+## 14. Conceptual Data Model
+
+The exact schema is an engineering decision, but the product requires these concepts:
+
+### Workspace
+
+- `visibility`: `private` or `team`
+- `ownerId`: required for private workspaces
+- `teamId`: required for team workspaces
+- `currentPublishedVersionId`: set for team workspaces
+
+### Private/team link
+
+- `privateWorkspaceId`
+- `teamWorkspaceId`
+- `basePublishedVersionId`
+- one active link per user and team workspace
+
+### Published version
+
+- immutable version ID
+- team workspace ID
+- sequential display number
+- content snapshot reference
+- publisher user ID
+- publication note
+- publication time
+
+Team membership controls access to team workspaces. A publication link does not grant access to a private workspace.
+
+## 15. Service and Security Requirements
+
+- Every private workspace read or write must verify ownership.
+- Team workspace reads must verify current team membership.
+- Normal file mutation endpoints must reject team workspace mutations.
+- Only the publication service may update a team workspace's current version.
+- Publishing permission must be checked at publication time, not only when rendering the button.
+- Published snapshots must use an explicit allowlist; they must not copy an entire workspace directory blindly.
+- Removing a user from a team removes future team access but does not delete their private workspace.
+- A removed user cannot publish to the former team.
+- Server logs and error messages must not expose private paths or content to teammates.
+
+## 16. Existing Workspace Migration
+
+Recommended migration:
+
+- Workspaces with only their owner as a member become private workspaces.
+- Workspaces with multiple members become team workspaces using their current content as the initial published version.
+- Existing owners become Team owners.
+- Existing editors become Publishers.
+- Existing viewers remain Viewers.
+- Existing members retain access to the migrated team workspace.
+- Private working copies are created only when a user selects `Work privately`.
+
+Migration must preserve existing workspace IDs or provide redirects for saved links.
+
+This migration plan requires product confirmation before implementation.
+
+## 17. MVP Delivery Slices
+
+### Slice 1 — Categories and privacy
+
+- Add private/team workspace types.
+- Categorize the sidebar.
+- Make new workspaces private by default.
+- Enforce owner-only access for private workspaces.
+- Remove the private workspace sharing action.
+
+### Slice 2 — First publication and team browsing
+
+- Add team identity and publishing roles.
+- Publish a private workspace to a team.
+- Browse team workspaces in read-only mode.
+- Enforce the publishable content boundary.
+
+### Slice 3 — Private working copies and updates
+
+- Create/open a private working copy.
+- Publish later changes.
+- Detect and display workspace states.
+- Sync non-conflicting team updates.
+
+### Slice 4 — Review and history
+
+- Review overlapping changes.
+- Add publication notes and history.
+- Preview and restore earlier published versions.
+
+## 18. End-to-End Acceptance Scenario
+
+1. Alice creates `Customer research`; it appears only in her Private section.
+2. Alice adds files and conversations. Bob cannot find or access any of them.
+3. Alice publishes the workspace to the Research team.
+4. Bob sees `Customer research` under Team workspaces and can browse its published files.
+5. Bob cannot see Alice's conversations, agent activity, credentials, or later private edits.
+6. Bob selects `Work privately` and edits his private copy.
+7. Bob's changes remain invisible to Alice and the team.
+8. Alice publishes another version. Bob sees `Team updates available`.
+9. Bob syncs. Changes to different files are combined automatically.
+10. If Alice and Bob changed the same file, Bob sees `Review needed` and chooses the desired content.
+11. Bob publishes the resolved private copy if he is a Publisher.
+12. The team sees Bob's new published version while Alice's and Bob's private workspaces remain private.
+
+## 19. Implementation Decisions
+
+The MVP uses these decisions:
+
+1. Existing administrative groups are the initial teams used for workspace publication.
+2. All team members may browse team workspaces and create private working copies.
+3. Team owners and Publishers may publish immediately; an approval workflow is not included.
+4. Existing single-member workspaces migrate to private workspaces. Existing multi-member workspaces migrate to team workspaces while preserving direct access.
+5. Publication history and owner-only restore are included.

--- a/frontend/src/components/CollapsibleDrawer.tsx
+++ b/frontend/src/components/CollapsibleDrawer.tsx
@@ -13,7 +13,11 @@ interface CollapsibleDrawerProps {
   workspaceSearchQuery: string;
   setWorkspaceSearchQuery: (name: string) => void;
   handleDeleteWorkspace: (id: string) => void;
-  onShareWorkspace?: (workspace: Workspace) => void;
+  onPublishWorkspace?: (workspace: Workspace) => void;
+  onSyncWorkspace?: (workspace: Workspace) => void;
+  onWorkPrivately?: (workspace: Workspace) => void;
+  onHistoryWorkspace?: (workspace: Workspace) => void;
+  onManageTeamAccess?: (workspace: Workspace) => void;
   onSelectWorkspace: (workspace: Workspace) => void;
   onCreateWorkspace: () => void | Promise<void>;
   onOpenSchedules?: () => void;
@@ -34,7 +38,11 @@ const CollapsibleDrawer: React.FC<CollapsibleDrawerProps> = ({
   workspaceSearchQuery,
   setWorkspaceSearchQuery,
   handleDeleteWorkspace,
-  onShareWorkspace,
+  onPublishWorkspace,
+  onSyncWorkspace,
+  onWorkPrivately,
+  onHistoryWorkspace,
+  onManageTeamAccess,
   onSelectWorkspace,
   onCreateWorkspace,
   onOpenSchedules,
@@ -96,7 +104,7 @@ const CollapsibleDrawer: React.FC<CollapsibleDrawerProps> = ({
                 size="small"
                 title={scheduleCount ? `Schedules (${scheduleCount})` : 'Schedules'}
                 aria-label={scheduleCount ? `Open schedules, ${scheduleCount} scheduled jobs` : 'Open schedules'}
-                disabled={!selectedWorkspace}
+                disabled={!selectedWorkspace || selectedWorkspace.visibility === 'team'}
                 sx={{ border: (theme) => `1px solid ${theme.palette.divider}`, borderRadius: 2 }}
               >
                 <Badge
@@ -119,6 +127,8 @@ const CollapsibleDrawer: React.FC<CollapsibleDrawerProps> = ({
           <IconButton
             onClick={handleDrawerClose}
             size="small"
+            title="Close workspace menu"
+            aria-label="Close workspace menu"
             sx={{ border: (theme) => `1px solid ${theme.palette.divider}`, borderRadius: 2 }}
           >
             <ChevronLeft fontSize="small" />
@@ -165,7 +175,11 @@ const CollapsibleDrawer: React.FC<CollapsibleDrawerProps> = ({
               selectedWorkspace={selectedWorkspace}
               onSelectWorkspace={onSelectWorkspace}
               onDeleteWorkspace={handleDeleteWorkspace}
-              onShareWorkspace={onShareWorkspace}
+              onPublishWorkspace={onPublishWorkspace}
+              onSyncWorkspace={onSyncWorkspace}
+              onWorkPrivately={onWorkPrivately}
+              onHistoryWorkspace={onHistoryWorkspace}
+              onManageTeamAccess={onManageTeamAccess}
             />
           </Box>
           <Box

--- a/frontend/src/components/ExpandableSidebar.tsx
+++ b/frontend/src/components/ExpandableSidebar.tsx
@@ -32,7 +32,11 @@ const ExpandableSidebar: React.FC<SidebarProps> = ({ handleDrawerToggle, isDrawe
     >
       {!isDrawerOpen && (
         <>
-          <IconButton onClick={handleDrawerToggle}>
+          <IconButton
+            onClick={handleDrawerToggle}
+            title="Open workspace menu"
+            aria-label="Open workspace menu"
+          >
             <MenuIcon />
           </IconButton>
           <IconButton onClick={onOpenSettings} title="Settings">

--- a/frontend/src/components/WorkspaceConflictDialog.tsx
+++ b/frontend/src/components/WorkspaceConflictDialog.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Typography,
+} from '@mui/material';
+
+import type { PublicationConflict } from '../services/workspaceApi';
+
+type WorkspaceConflictDialogProps = {
+  open: boolean;
+  conflicts: PublicationConflict[];
+  busy?: boolean;
+  error?: string;
+  onClose: () => void;
+  onConfirm: (resolutions: Record<string, 'private' | 'team'>) => void | Promise<void>;
+};
+
+const WorkspaceConflictDialog: React.FC<WorkspaceConflictDialogProps> = ({
+  open,
+  conflicts,
+  busy = false,
+  error,
+  onClose,
+  onConfirm,
+}) => {
+  const [resolutions, setResolutions] = useState<Record<string, 'private' | 'team'>>({});
+
+  useEffect(() => {
+    if (open) setResolutions({});
+  }, [open, conflicts]);
+
+  const complete = useMemo(
+    () => conflicts.length > 0 && conflicts.every((conflict) => Boolean(resolutions[conflict.path])),
+    [conflicts, resolutions],
+  );
+
+  return (
+    <Dialog open={open} onClose={busy ? undefined : onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Review workspace changes</DialogTitle>
+      <DialogContent dividers>
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          These files changed in both your private copy and the team version. Choose which version to keep.
+        </Alert>
+        {conflicts.map((conflict) => (
+          <div key={conflict.path} style={{ marginBottom: 18 }}>
+            <Typography variant="subtitle2">{conflict.path}</Typography>
+            <Typography variant="caption" color="text.secondary">
+              Your copy: {conflict.privateChange}; team: {conflict.teamChange}
+            </Typography>
+            {conflict.privateText !== undefined && conflict.teamText !== undefined ? (
+              <>
+                <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1, mt: 1 }}>
+                  <Box>
+                    <Typography variant="caption" sx={{ fontWeight: 700 }}>Your copy</Typography>
+                    <Box
+                      component="pre"
+                      sx={{
+                        m: 0,
+                        mt: 0.5,
+                        p: 1,
+                        maxHeight: 180,
+                        overflow: 'auto',
+                        border: 1,
+                        borderColor: 'divider',
+                        borderRadius: 1,
+                        fontSize: '0.72rem',
+                        whiteSpace: 'pre-wrap',
+                      }}
+                    >
+                      {conflict.privateText}
+                    </Box>
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" sx={{ fontWeight: 700 }}>Team version</Typography>
+                    <Box
+                      component="pre"
+                      sx={{
+                        m: 0,
+                        mt: 0.5,
+                        p: 1,
+                        maxHeight: 180,
+                        overflow: 'auto',
+                        border: 1,
+                        borderColor: 'divider',
+                        borderRadius: 1,
+                        fontSize: '0.72rem',
+                        whiteSpace: 'pre-wrap',
+                      }}
+                    >
+                      {conflict.teamText}
+                    </Box>
+                  </Box>
+                </Box>
+                {conflict.textTruncated ? (
+                  <Typography variant="caption" color="text.secondary">
+                    Preview shortened for this large file.
+                  </Typography>
+                ) : null}
+              </>
+            ) : null}
+            <RadioGroup
+              row
+              value={resolutions[conflict.path] || ''}
+              onChange={(event) => {
+                const value = event.target.value as 'private' | 'team';
+                setResolutions((current) => ({ ...current, [conflict.path]: value }));
+              }}
+            >
+              <FormControlLabel value="private" control={<Radio />} label="Keep mine" />
+              <FormControlLabel value="team" control={<Radio />} label="Use team version" />
+            </RadioGroup>
+          </div>
+        ))}
+        {error ? <Alert severity="error">{error}</Alert> : null}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={busy}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={() => void onConfirm(resolutions)}
+          disabled={!complete || busy}
+        >
+          Apply team updates
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default WorkspaceConflictDialog;

--- a/frontend/src/components/WorkspaceFileTree.tsx
+++ b/frontend/src/components/WorkspaceFileTree.tsx
@@ -78,6 +78,7 @@ interface WorkspaceFileTreeProps {
   selectedFiles: Set<string>;
   copiedPublicUrlFileId: string | null;
   dashboardArtifactsByPath?: Record<string, DashboardArtifactInfo>;
+  readOnly?: boolean;
   isDraftWorkspaceFile: (file?: WorkspaceFile | null) => boolean;
   onSelectFile: (file: WorkspaceFile) => void;
   onSelectFolder?: (folderPath: string) => void;
@@ -183,6 +184,7 @@ const TreeFileRow: React.FC<{
   setDraggedFileId: (fileId: string | null) => void;
   setDropTargetPath: (path: string | null) => void;
   colorMode: 'light' | 'dark';
+  readOnly: boolean;
 }> = ({
   node,
   selected,
@@ -201,12 +203,13 @@ const TreeFileRow: React.FC<{
   setDraggedFileId,
   setDropTargetPath,
   colorMode,
+  readOnly,
 }) => {
   const { file } = node;
   const displayName = getFileDisplayName(file.name || '');
   const fileIcon = getFileTypeIcon(file.name || '');
   const isDraft = isDraftWorkspaceFile(file);
-  const isDraggable = !isDraft;
+  const isDraggable = !isDraft && !readOnly;
   const fileId = String(file.id);
   const isBeingDragged = draggedFileId === fileId;
   const isDarkMode = colorMode === 'dark';
@@ -259,13 +262,15 @@ const TreeFileRow: React.FC<{
         clearDragState();
       }}
     >
-      <input
-        type="checkbox"
-        checked={selectedFiles.has(fileId)}
-        onChange={() => onToggleFileSelection(fileId)}
-        onClick={(event) => event.stopPropagation()}
-        className="mt-1 shrink-0"
-      />
+      {!readOnly ? (
+        <input
+          type="checkbox"
+          checked={selectedFiles.has(fileId)}
+          onChange={() => onToggleFileSelection(fileId)}
+          onClick={(event) => event.stopPropagation()}
+          className="mt-1 shrink-0"
+        />
+      ) : null}
       <div
         role="button"
         tabIndex={0}
@@ -325,7 +330,7 @@ const TreeFileRow: React.FC<{
               )}
             </button>
           )}
-          {!isDraft && (
+          {!isDraft && !readOnly && (
             <button
               type="button"
               onClick={(event) => {
@@ -338,7 +343,7 @@ const TreeFileRow: React.FC<{
               <Edit size={14} />
             </button>
           )}
-          <button
+          {!readOnly ? <button
             type="button"
             onClick={(event) => {
               event.stopPropagation();
@@ -348,7 +353,7 @@ const TreeFileRow: React.FC<{
             title="Delete"
           >
             <Trash size={14} />
-          </button>
+          </button> : null}
       </div>
     </div>
   );
@@ -368,6 +373,7 @@ const TreeFolderRow: React.FC<{
   dropTargetPath: string | null;
   children: React.ReactNode;
   colorMode: 'light' | 'dark';
+  readOnly: boolean;
 }> = ({
   node,
   expanded,
@@ -382,6 +388,7 @@ const TreeFolderRow: React.FC<{
   dropTargetPath,
   children,
   colorMode,
+  readOnly,
 }) => {
   const isDropTarget = dropTargetPath === node.path;
   const isDarkMode = colorMode === 'dark';
@@ -428,9 +435,9 @@ const TreeFolderRow: React.FC<{
     <div
       className="select-none"
       data-workspace-folder-path={node.path}
-      onDragOver={handleFolderDragOver}
-      onDragLeave={handleFolderDragLeave}
-      onDrop={handleFolderDrop}
+      onDragOver={readOnly ? undefined : handleFolderDragOver}
+      onDragLeave={readOnly ? undefined : handleFolderDragLeave}
+      onDrop={readOnly ? undefined : handleFolderDrop}
     >
       <div
         className={`group flex items-center gap-2 rounded-lg px-2 py-1.5 transition-colors ${containerClassName}`}
@@ -484,7 +491,7 @@ const TreeFolderRow: React.FC<{
             </span>
           </div>
         </button>
-        <button
+        {!readOnly ? <button
           type="button"
           onClick={(event) => {
             event.stopPropagation();
@@ -499,8 +506,8 @@ const TreeFolderRow: React.FC<{
           aria-label={`Rename folder ${node.path}`}
         >
           <Edit size={14} />
-        </button>
-        <button
+        </button> : null}
+        {!readOnly ? <button
           type="button"
           onClick={(event) => {
             event.stopPropagation();
@@ -515,7 +522,7 @@ const TreeFolderRow: React.FC<{
           aria-label={`Delete folder ${node.path}`}
         >
           <Trash size={14} />
-        </button>
+        </button> : null}
       </div>
       {expanded && <div className="mt-1 space-y-1 pl-5">{children}</div>}
     </div>
@@ -548,6 +555,7 @@ const renderTreeNodes = (
     setDropTargetPath: (path: string | null) => void;
     dropTargetPath: string | null;
     colorMode: 'light' | 'dark';
+    readOnly: boolean;
   },
 ): React.ReactNode => {
   return nodes.map((node) => {
@@ -568,6 +576,7 @@ const renderTreeNodes = (
           setDropTargetPath={options.setDropTargetPath}
           dropTargetPath={options.dropTargetPath}
           colorMode={options.colorMode}
+          readOnly={options.readOnly}
         >
           {renderTreeNodes(node.children, options)}
         </TreeFolderRow>
@@ -594,6 +603,7 @@ const renderTreeNodes = (
         setDraggedFileId={options.setDraggedFileId}
         setDropTargetPath={options.setDropTargetPath}
         colorMode={options.colorMode}
+        readOnly={options.readOnly}
       />
     );
   });
@@ -607,6 +617,7 @@ export default function WorkspaceFileTree({
   selectedDashboardPath,
   selectedFiles,
   dashboardArtifactsByPath,
+  readOnly = false,
   isDraftWorkspaceFile,
   onSelectFile,
   onSelectFolder,
@@ -698,7 +709,7 @@ export default function WorkspaceFileTree({
           .filter((selectedFile): selectedFile is WorkspaceFile => Boolean(selectedFile))
           .filter((selectedFile) => !isDraftWorkspaceFile(selectedFile))
       : [file];
-    if (filesToMove.length > 0) {
+    if (!readOnly && filesToMove.length > 0) {
       onMoveFiles(filesToMove, folderPath);
     }
     draggedFileIdRef.current = null;
@@ -728,7 +739,7 @@ export default function WorkspaceFileTree({
       className={`flex h-full min-h-0 flex-col overflow-hidden ${
         draggedFileId ? (isDarkMode ? 'bg-sky-500/5' : 'bg-blue-50/30') : ''
       }`}
-      onDragOver={(event) => {
+      onDragOver={readOnly ? undefined : (event) => {
         if (!canAcceptWorkspaceFileDrop(event, draggedFileIdRef)) {
           return;
         }
@@ -736,7 +747,7 @@ export default function WorkspaceFileTree({
         event.dataTransfer.dropEffect = 'move';
         setDropTargetPath(getWorkspaceFolderPathFromPoint(event.clientX, event.clientY));
       }}
-      onDrop={handleRootDrop}
+      onDrop={readOnly ? undefined : handleRootDrop}
     >
       <div className="flex-1 overflow-y-auto px-1 py-1">
         {tree.children.length ? (
@@ -765,6 +776,7 @@ export default function WorkspaceFileTree({
               setDropTargetPath,
               dropTargetPath,
               colorMode,
+              readOnly,
             })}
           </div>
         ) : (

--- a/frontend/src/components/WorkspaceHistoryDialog.tsx
+++ b/frontend/src/components/WorkspaceHistoryDialog.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  List,
+  ListItem,
+  ListItemText,
+} from '@mui/material';
+
+import type { Workspace } from '../types';
+import {
+  listPublishedWorkspaceHistory,
+  restorePublishedWorkspaceVersion,
+  type PublishedWorkspaceVersion,
+} from '../services/workspaceApi';
+
+type WorkspaceHistoryDialogProps = {
+  open: boolean;
+  workspace: Workspace | null;
+  onClose: () => void;
+  onRestored: () => void | Promise<void>;
+};
+
+const WorkspaceHistoryDialog: React.FC<WorkspaceHistoryDialogProps> = ({
+  open,
+  workspace,
+  onClose,
+  onRestored,
+}) => {
+  const [versions, setVersions] = useState<PublishedWorkspaceVersion[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [restoreId, setRestoreId] = useState<string | null>(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!open || !workspace) return;
+    setLoading(true);
+    setError('');
+    void listPublishedWorkspaceHistory(workspace.id)
+      .then(setVersions)
+      .catch((reason) => setError(reason instanceof Error ? reason.message : 'Failed to load history'))
+      .finally(() => setLoading(false));
+  }, [open, workspace]);
+
+  const handleRestore = async (version: PublishedWorkspaceVersion) => {
+    if (!workspace) return;
+    if (!window.confirm(`Restore published version ${version.versionNumber}?`)) return;
+    setRestoreId(version.id);
+    setError('');
+    try {
+      await restorePublishedWorkspaceVersion(workspace.id, version.id);
+      await onRestored();
+      const refreshed = await listPublishedWorkspaceHistory(workspace.id);
+      setVersions(refreshed);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : 'Failed to restore version');
+    } finally {
+      setRestoreId(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={restoreId ? undefined : onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Published history</DialogTitle>
+      <DialogContent dividers>
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+            <CircularProgress size={28} />
+          </Box>
+        ) : (
+          <List disablePadding>
+            {versions.map((version, index) => (
+              <ListItem
+                key={version.id}
+                divider
+                secondaryAction={
+                  workspace?.role === 'owner' && index > 0 ? (
+                    <Button
+                      size="small"
+                      disabled={Boolean(restoreId)}
+                      onClick={() => void handleRestore(version)}
+                    >
+                      {restoreId === version.id ? 'Restoring…' : 'Restore'}
+                    </Button>
+                  ) : undefined
+                }
+              >
+                <ListItemText
+                  primary={`Version ${version.versionNumber}${index === 0 ? ' · Current' : ''}`}
+                  secondary={`${version.publisherName} · ${new Date(version.createdAt).toLocaleString()}${
+                    version.note ? ` · ${version.note}` : ''
+                  }`}
+                />
+              </ListItem>
+            ))}
+          </List>
+        )}
+        {error ? <Alert severity="error" sx={{ mt: 2 }}>{error}</Alert> : null}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={Boolean(restoreId)}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default WorkspaceHistoryDialog;

--- a/frontend/src/components/WorkspaceList.tsx
+++ b/frontend/src/components/WorkspaceList.tsx
@@ -1,6 +1,24 @@
 import React from 'react';
-import { Box, IconButton, List, ListItemButton, ListItemText } from '@mui/material';
-import { Delete, Share } from '@mui/icons-material';
+import {
+  Box,
+  Chip,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemText,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import {
+  ContentCopy,
+  Delete,
+  Groups,
+  History,
+  Lock,
+  ManageAccounts,
+  Publish,
+  Sync,
+} from '@mui/icons-material';
 
 import type { Workspace } from '../types';
 
@@ -9,152 +27,217 @@ interface WorkspaceListProps {
   selectedWorkspace: Workspace | null;
   onSelectWorkspace: (workspace: Workspace) => void;
   onDeleteWorkspace: (id: string) => void;
-  onShareWorkspace?: (workspace: Workspace) => void;
+  onPublishWorkspace?: (workspace: Workspace) => void;
+  onSyncWorkspace?: (workspace: Workspace) => void;
+  onWorkPrivately?: (workspace: Workspace) => void;
+  onHistoryWorkspace?: (workspace: Workspace) => void;
+  onManageTeamAccess?: (workspace: Workspace) => void;
 }
+
+const STATUS_LABELS: Record<NonNullable<Workspace['publicationStatus']>, string> = {
+  private_draft: 'Private draft',
+  up_to_date: 'Up to date',
+  changes_to_publish: 'Changes to publish',
+  team_updates_available: 'Team updates available',
+  review_needed: 'Review needed',
+};
 
 const WorkspaceList: React.FC<WorkspaceListProps> = ({
   workspaces,
   selectedWorkspace,
   onSelectWorkspace,
   onDeleteWorkspace,
-  onShareWorkspace,
+  onPublishWorkspace,
+  onSyncWorkspace,
+  onWorkPrivately,
+  onHistoryWorkspace,
+  onManageTeamAccess,
 }) => {
-  return (
-    <List disablePadding>
-      {workspaces.map((workspace) => {
-        const isOwner = workspace.role === 'owner';
-        const isSelected = selectedWorkspace?.id === workspace.id;
+  const privateWorkspaces = workspaces.filter((workspace) => workspace.visibility !== 'team');
+  const teamWorkspaces = workspaces.filter((workspace) => workspace.visibility === 'team');
 
-        return (
-          <Box
-            key={workspace.id}
-            sx={{
-              position: 'relative',
-              borderRadius: 2,
-              overflow: 'hidden',
-              mb: 1,
-              border: (theme) =>
-                isSelected ? `1px solid ${theme.palette.divider}` : '1px solid transparent',
-              backgroundColor: (theme) => {
-                if (isSelected) {
-                  return theme.palette.mode === 'light'
-                    ? 'rgba(37, 99, 235, 0.09)'
-                    : 'rgba(96, 165, 250, 0.14)';
-                }
-                return 'transparent';
-              },
-              transition: (theme) =>
-                theme.transitions.create(['background-color', 'border-color'], {
-                  duration: theme.transitions.duration.shorter,
-                }),
-              '&:hover': {
-                borderColor: (theme) => theme.palette.divider,
-                backgroundColor: (theme) =>
-                  isSelected
-                    ? undefined
-                    : theme.palette.mode === 'light'
-                      ? 'rgba(15, 23, 42, 0.04)'
-                      : 'rgba(148, 163, 184, 0.08)',
-              },
-              '&:hover .workspace-list-actions': {
-                opacity: 1,
-                pointerEvents: 'auto',
-              },
-              '&:focus-within .workspace-list-actions': {
-                opacity: 1,
-                pointerEvents: 'auto',
+  const renderWorkspace = (workspace: Workspace) => {
+    const isPrivate = workspace.visibility !== 'team';
+    const isOwner = workspace.role === 'owner';
+    const isSelected = selectedWorkspace?.id === workspace.id;
+    const status = workspace.publicationStatus || (isPrivate ? 'private_draft' : 'up_to_date');
+    const canPublish = isPrivate
+      && workspace.canPublish !== false
+      && (status === 'private_draft' || status === 'changes_to_publish');
+    const canSync = isPrivate
+      && (status === 'team_updates_available' || status === 'review_needed');
+
+    const actions = [
+      canPublish && onPublishWorkspace ? {
+        label: status === 'private_draft' ? `Publish ${workspace.name} to team` : `Publish changes from ${workspace.name}`,
+        icon: <Publish fontSize="small" />,
+        onClick: () => onPublishWorkspace(workspace),
+      } : null,
+      canSync && onSyncWorkspace ? {
+        label: status === 'review_needed'
+          ? `Review changes for ${workspace.name}`
+          : `Sync team updates into ${workspace.name}`,
+        icon: <Sync fontSize="small" />,
+        onClick: () => onSyncWorkspace(workspace),
+      } : null,
+      !isPrivate && onWorkPrivately ? {
+        label: workspace.privateCopyWorkspaceId
+          ? `Open private copy of ${workspace.name}`
+          : `Work privately on ${workspace.name}`,
+        icon: <ContentCopy fontSize="small" />,
+        onClick: () => onWorkPrivately(workspace),
+      } : null,
+      !isPrivate && onHistoryWorkspace ? {
+        label: `View published history for ${workspace.name}`,
+        icon: <History fontSize="small" />,
+        onClick: () => onHistoryWorkspace(workspace),
+      } : null,
+      !isPrivate && isOwner && onManageTeamAccess ? {
+        label: `Manage publishing access for ${workspace.name}`,
+        icon: <ManageAccounts fontSize="small" />,
+        onClick: () => onManageTeamAccess(workspace),
+      } : null,
+      (isPrivate || isOwner) ? {
+        label: `Delete ${workspace.name}`,
+        icon: <Delete fontSize="small" />,
+        onClick: () => onDeleteWorkspace(workspace.id),
+      } : null,
+    ].filter(Boolean) as Array<{ label: string; icon: React.ReactNode; onClick: () => void }>;
+
+    return (
+      <Box
+        key={workspace.id}
+        sx={{
+          position: 'relative',
+          borderRadius: 2,
+          overflow: 'hidden',
+          mb: 1,
+          border: (theme) => isSelected ? `1px solid ${theme.palette.divider}` : '1px solid transparent',
+          backgroundColor: (theme) => isSelected
+            ? theme.palette.mode === 'light' ? 'rgba(37, 99, 235, 0.09)' : 'rgba(96, 165, 250, 0.14)'
+            : 'transparent',
+          '&:hover': {
+            borderColor: (theme) => theme.palette.divider,
+            backgroundColor: (theme) => isSelected
+              ? undefined
+              : theme.palette.mode === 'light' ? 'rgba(15, 23, 42, 0.04)' : 'rgba(148, 163, 184, 0.08)',
+          },
+          '&:hover .workspace-list-actions, &:focus-within .workspace-list-actions': {
+            opacity: 1,
+            pointerEvents: 'auto',
+          },
+        }}
+      >
+        <ListItemButton
+          selected={isSelected}
+          onClick={() => onSelectWorkspace(workspace)}
+          sx={{
+            minWidth: 0,
+            minHeight: 68,
+            py: 1,
+            pl: 1.5,
+            pr: actions.length ? Math.min(12, 2.5 + actions.length * 3.5) : 1.5,
+            borderRadius: 2,
+            backgroundColor: 'transparent',
+            '&.Mui-selected, &.Mui-selected:hover, &:hover': { backgroundColor: 'transparent' },
+          }}
+        >
+          <ListItemText
+            primary={workspace.name}
+            secondary={
+              isPrivate
+                ? STATUS_LABELS[status]
+                : `${workspace.teamName || 'Team'}${workspace.latestPublisherName
+                  ? ` · ${workspace.latestPublisherName}`
+                  : ''}`
+            }
+            primaryTypographyProps={{
+              noWrap: true,
+              sx: { fontWeight: 600, fontSize: '0.92rem', lineHeight: 1.3, mb: 0.2 },
+            }}
+            secondaryTypographyProps={{
+              noWrap: true,
+              sx: {
+                fontSize: '0.76rem',
+                lineHeight: 1.3,
+                color: status === 'review_needed'
+                  ? 'warning.main'
+                  : status === 'changes_to_publish' || status === 'team_updates_available'
+                    ? 'primary.main'
+                    : 'text.secondary',
               },
             }}
+          />
+        </ListItemButton>
+        {actions.length ? (
+          <Box
+            className="workspace-list-actions"
+            sx={{
+              position: 'absolute',
+              top: '50%',
+              right: 6,
+              transform: 'translateY(-50%)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.1,
+              opacity: 0,
+              pointerEvents: 'none',
+              backgroundColor: (theme) => theme.palette.mode === 'light'
+                ? 'rgba(248, 250, 252, 0.92)'
+                : 'rgba(15, 23, 42, 0.9)',
+              borderRadius: 1.5,
+              px: 0.2,
+              py: 0.2,
+              backdropFilter: 'blur(6px)',
+            }}
           >
-            <ListItemButton
-              selected={isSelected}
-              onClick={() => onSelectWorkspace(workspace)}
-              sx={{
-                minWidth: 0,
-                minHeight: 64,
-                py: 1.25,
-                pl: 1.75,
-                pr: isOwner ? 8.5 : 1.75,
-                borderRadius: 2,
-                backgroundColor: 'transparent',
-                '&.Mui-selected': {
-                  backgroundColor: 'transparent',
-                },
-                '&.Mui-selected:hover': {
-                  backgroundColor: 'transparent',
-                },
-                '&:hover': {
-                  backgroundColor: 'transparent',
-                },
-              }}
-            >
-              <ListItemText
-                primary={workspace.name}
-                secondary={`Last used: ${workspace.lastUsed}`}
-                primaryTypographyProps={{
-                  noWrap: true,
-                  sx: { fontWeight: 600, fontSize: '0.95rem', lineHeight: 1.35, mb: 0.25 },
-                }}
-                secondaryTypographyProps={{
-                  noWrap: true,
-                  sx: { fontSize: '0.82rem', lineHeight: 1.35 },
-                }}
-              />
-            </ListItemButton>
-            {isOwner ? (
-              <Box
-                className="workspace-list-actions"
-                sx={{
-                  position: 'absolute',
-                  top: '50%',
-                  right: 8,
-                  transform: 'translateY(-50%)',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 0.5,
-                  opacity: 0,
-                  pointerEvents: 'none',
-                  transition: (theme) =>
-                    theme.transitions.create('opacity', { duration: theme.transitions.duration.shorter }),
-                  backgroundColor: (theme) =>
-                    theme.palette.mode === 'light'
-                      ? 'rgba(248, 250, 252, 0.86)'
-                      : 'rgba(15, 23, 42, 0.84)',
-                  borderRadius: 1.5,
-                  px: 0.25,
-                  py: 0.25,
-                  backdropFilter: 'blur(6px)',
-                }}
-              >
-                {onShareWorkspace ? (
-                  <IconButton
-                    size="small"
-                    aria-label={`Share ${workspace.name}`}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onShareWorkspace(workspace);
-                    }}
-                    sx={{ width: 30, height: 30 }}
-                  >
-                    <Share fontSize="small" />
-                  </IconButton>
-                ) : null}
+            {actions.map((action) => (
+              <Tooltip key={action.label} title={action.label}>
                 <IconButton
                   size="small"
-                  aria-label={`Delete ${workspace.name}`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDeleteWorkspace(workspace.id);
+                  aria-label={action.label}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    action.onClick();
                   }}
-                  sx={{ width: 30, height: 30 }}
+                  sx={{ width: 29, height: 29 }}
                 >
-                  <Delete fontSize="small" />
+                  {action.icon}
                 </IconButton>
-              </Box>
-            ) : null}
+              </Tooltip>
+            ))}
           </Box>
-        );
-      })}
+        ) : null}
+      </Box>
+    );
+  };
+
+  const renderSection = (
+    title: string,
+    icon: React.ReactNode,
+    items: Workspace[],
+    emptyLabel: string,
+  ) => (
+    <Box sx={{ mb: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, px: 0.5, mb: 0.75 }}>
+        {icon}
+        <Typography variant="overline" sx={{ fontWeight: 700, lineHeight: 1.5 }}>
+          {title}
+        </Typography>
+        <Chip label={items.length} size="small" sx={{ height: 18, fontSize: '0.68rem' }} />
+      </Box>
+      {items.length ? items.map(renderWorkspace) : (
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', px: 1, py: 1 }}>
+          {emptyLabel}
+        </Typography>
+      )}
+    </Box>
+  );
+
+  return (
+    <List disablePadding>
+      {renderSection('Private workspaces', <Lock sx={{ fontSize: 16 }} />, privateWorkspaces, 'No private workspaces')}
+      {renderSection('Team workspaces', <Groups sx={{ fontSize: 16 }} />, teamWorkspaces, 'No team workspaces')}
     </List>
   );
 };

--- a/frontend/src/components/WorkspacePublishDialog.tsx
+++ b/frontend/src/components/WorkspacePublishDialog.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+import type { Workspace } from '../types';
+import {
+  listWorkspaceTeams,
+  publishWorkspace,
+  type WorkspaceTeam,
+} from '../services/workspaceApi';
+
+type WorkspacePublishDialogProps = {
+  open: boolean;
+  workspace: Workspace | null;
+  onClose: () => void;
+  onBeforePublish?: (workspace: Workspace) => void | Promise<void>;
+  onPublished: () => void | Promise<void>;
+};
+
+const WorkspacePublishDialog: React.FC<WorkspacePublishDialogProps> = ({
+  open,
+  workspace,
+  onClose,
+  onBeforePublish,
+  onPublished,
+}) => {
+  const [teams, setTeams] = useState<WorkspaceTeam[]>([]);
+  const [teamId, setTeamId] = useState('');
+  const [note, setNote] = useState('');
+  const [loadingTeams, setLoadingTeams] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const firstPublication = !workspace?.linkedTeamWorkspaceId;
+
+  useEffect(() => {
+    if (!open) {
+      setTeamId('');
+      setNote('');
+      setError('');
+      return;
+    }
+    if (!firstPublication) return;
+    setLoadingTeams(true);
+    void listWorkspaceTeams()
+      .then((items) => {
+        setTeams(items);
+        if (items.length === 1) setTeamId(items[0].id);
+      })
+      .catch((reason) => setError(reason instanceof Error ? reason.message : 'Failed to list teams'))
+      .finally(() => setLoadingTeams(false));
+  }, [firstPublication, open]);
+
+  const canPublish = useMemo(
+    () => Boolean(workspace && (!firstPublication || teamId) && !busy && !loadingTeams),
+    [busy, firstPublication, loadingTeams, teamId, workspace],
+  );
+
+  const handlePublish = async () => {
+    if (!workspace || !canPublish) return;
+    setBusy(true);
+    setError('');
+    try {
+      await onBeforePublish?.(workspace);
+      await publishWorkspace(workspace.id, {
+        ...(firstPublication ? { teamId } : {}),
+        note: note.trim() || undefined,
+      });
+      await onPublished();
+      onClose();
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : 'Failed to publish workspace');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={busy ? undefined : onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{firstPublication ? 'Publish to team' : 'Publish changes'}</DialogTitle>
+      <DialogContent dividers>
+        <Typography variant="body2" sx={{ mb: 2 }}>
+          Publish a stable version of <strong>{workspace?.name}</strong>. Your private workspace remains visible only
+          to you.
+        </Typography>
+
+        {firstPublication ? (
+          loadingTeams ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+              <CircularProgress size={26} />
+            </Box>
+          ) : teams.length ? (
+            <FormControl fullWidth size="small" sx={{ mb: 2 }}>
+              <InputLabel id="publish-team-label">Team</InputLabel>
+              <Select
+                labelId="publish-team-label"
+                label="Team"
+                value={teamId}
+                onChange={(event) => setTeamId(String(event.target.value))}
+              >
+                {teams.map((team) => (
+                  <MenuItem key={team.id} value={team.id}>{team.name}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          ) : (
+            <Alert severity="info" sx={{ mb: 2 }}>
+              You need to belong to a team before you can publish this workspace.
+            </Alert>
+          )
+        ) : null}
+
+        <TextField
+          label="Publication note (optional)"
+          placeholder="Describe what changed"
+          value={note}
+          onChange={(event) => setNote(event.target.value)}
+          multiline
+          minRows={2}
+          fullWidth
+          inputProps={{ maxLength: 1000 }}
+          sx={{ mb: 2 }}
+        />
+
+        <Alert severity="info">
+          Files, folders, and visible workspace artifacts will be published. Conversations, agent activity,
+          schedules, connections, credentials, and personal settings stay private.
+        </Alert>
+        {error ? <Alert severity="error" sx={{ mt: 2 }}>{error}</Alert> : null}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={busy}>Cancel</Button>
+        <Button variant="contained" onClick={() => void handlePublish()} disabled={!canPublish}>
+          {busy ? <CircularProgress size={18} color="inherit" /> : 'Publish'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default WorkspacePublishDialog;

--- a/frontend/src/components/WorkspaceShareDialog.tsx
+++ b/frontend/src/components/WorkspaceShareDialog.tsx
@@ -145,7 +145,7 @@ const WorkspaceShareDialog: React.FC<WorkspaceShareDialogProps> = ({ open, works
       setSelected([]);
       await loadCollaborators();
     } catch (e) {
-      setInviteError(e instanceof Error ? e.message : 'Failed to share workspace');
+      setInviteError(e instanceof Error ? e.message : 'Failed to update publishing access');
     } finally {
       setInviteBusy(false);
     }
@@ -167,7 +167,7 @@ const WorkspaceShareDialog: React.FC<WorkspaceShareDialogProps> = ({ open, works
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', pr: 1 }}>
-        <span>Share workspace</span>
+        <span>Manage publishing access</span>
         <IconButton aria-label="close" onClick={onClose} size="small">
           <CloseIcon />
         </IconButton>
@@ -180,7 +180,7 @@ const WorkspaceShareDialog: React.FC<WorkspaceShareDialogProps> = ({ open, works
         ) : null}
 
         <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
-          People with access
+          Team publishing roles
         </Typography>
         {collaboratorsLoading ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
@@ -208,7 +208,7 @@ const WorkspaceShareDialog: React.FC<WorkspaceShareDialogProps> = ({ open, works
                     {c.displayName}
                   </Typography>
                   <Typography variant="caption" color="text.secondary">
-                    {c.role}
+                    {c.role === 'editor' ? 'Publisher' : c.role === 'owner' ? 'Team owner' : 'Viewer'}
                   </Typography>
                 </Box>
                 {c.role !== 'owner' ? (
@@ -277,7 +277,7 @@ const WorkspaceShareDialog: React.FC<WorkspaceShareDialogProps> = ({ open, works
               if (v) setInviteRole(v);
             }}
           >
-            <ToggleButton value="editor">Editor</ToggleButton>
+            <ToggleButton value="editor">Publisher</ToggleButton>
             <ToggleButton value="viewer">Viewer</ToggleButton>
           </ToggleButtonGroup>
         </Box>
@@ -297,7 +297,7 @@ const WorkspaceShareDialog: React.FC<WorkspaceShareDialogProps> = ({ open, works
           disabled={!workspaceId || selected.length === 0 || inviteBusy}
           onClick={() => void handleInvite()}
         >
-          {inviteBusy ? <CircularProgress size={22} color="inherit" /> : 'Share'}
+          {inviteBusy ? <CircularProgress size={22} color="inherit" /> : 'Update access'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -11,7 +11,16 @@ import {
 import { BookOpen, Check, CheckSquare, Copy, Edit, Trash, Plus, Minus, X, ChevronLeft, ChevronDown, RotateCcw, Printer, Download, Link as LinkIcon, Loader2, FolderPlus, FolderUp, Upload, Home, ArrowUp, Search, File as FileIcon, Wrench, Plug, Sparkles, Info } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { getWorkspaces, createWorkspace, deleteWorkspace, renameWorkspace } from '../../services/workspaceApi';
+import {
+  WorkspaceApiError,
+  createPrivateWorkspaceCopy,
+  createWorkspace,
+  deleteWorkspace,
+  getWorkspaces,
+  renameWorkspace,
+  syncWorkspaceWithTeam,
+  type PublicationConflict,
+} from '../../services/workspaceApi';
 import {
   createWorkspaceSchedule,
   deleteWorkspaceSchedule,
@@ -77,6 +86,9 @@ import type {
 } from '../../types';
 import CollapsibleDrawer from '../../components/CollapsibleDrawer';
 import WorkspaceShareDialog from '../../components/WorkspaceShareDialog';
+import WorkspacePublishDialog from '../../components/WorkspacePublishDialog';
+import WorkspaceConflictDialog from '../../components/WorkspaceConflictDialog';
+import WorkspaceHistoryDialog from '../../components/WorkspaceHistoryDialog';
 import ScheduleDialog from '../../components/schedules/ScheduleDialog';
 import WorkspaceSchedulesPanel from '../../components/schedules/WorkspaceSchedulesPanel';
 import type { UIBlock } from '../../components/UIBlockRenderer';
@@ -771,6 +783,12 @@ export default function WorkspacePage() {
   const [internetSearchEnabled, setInternetSearchEnabled] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [shareWorkspace, setShareWorkspace] = useState<Workspace | null>(null);
+  const [publishWorkspaceTarget, setPublishWorkspaceTarget] = useState<Workspace | null>(null);
+  const [historyWorkspaceTarget, setHistoryWorkspaceTarget] = useState<Workspace | null>(null);
+  const [syncWorkspaceTarget, setSyncWorkspaceTarget] = useState<Workspace | null>(null);
+  const [syncConflicts, setSyncConflicts] = useState<PublicationConflict[]>([]);
+  const [syncBusy, setSyncBusy] = useState(false);
+  const [syncError, setSyncError] = useState('');
   const personas = DEFAULT_PERSONAS;
   const [selectedPersona, setSelectedPersona] = useState(DEFAULT_PERSONA_NAME);
   const [isEditMode, setIsEditMode] = useState(false);
@@ -821,6 +839,7 @@ export default function WorkspacePage() {
   const landingWorkspacePickerRef = useRef<HTMLDivElement | null>(null);
   const workspaceNameInputRef = useRef<HTMLInputElement | null>(null);
   const autoSaveTimerRef = useRef<number | null>(null);
+  const pendingAutoSaveRef = useRef<Promise<boolean> | null>(null);
   const lastAutoSavedContentRef = useRef<string>('');
   const fileContentRequestIdRef = useRef(0);
   const [isMentionOpen, setIsMentionOpen] = useState(false);
@@ -844,6 +863,14 @@ export default function WorkspacePage() {
     }
     return workspaces.filter((workspace) => workspace.name.toLowerCase().includes(query));
   }, [workspaceSearchQuery, workspaces]);
+  const mobilePrivateWorkspaces = useMemo(
+    () => filteredWorkspaces.filter((workspace) => workspace.visibility !== 'team').slice(0, 8),
+    [filteredWorkspaces],
+  );
+  const mobileTeamWorkspaces = useMemo(
+    () => filteredWorkspaces.filter((workspace) => workspace.visibility === 'team').slice(0, 8),
+    [filteredWorkspaces],
+  );
   const landingFilteredWorkspaces = useMemo(() => {
     const query = landingWorkspaceQuery.trim().toLowerCase();
     if (!query) {
@@ -885,6 +912,22 @@ export default function WorkspacePage() {
   const resumeInFlightRef = useRef<Set<string>>(new Set());
   const resumeAttemptedRef = useRef<Set<string>>(new Set());
   const theme = useMemo(() => buildAppTheme(colorMode), [colorMode]);
+
+  const markPrivateWorkspaceChanged = useCallback((workspaceId: string) => {
+    const update = (workspace: Workspace): Workspace => {
+      if (workspace.id !== workspaceId || workspace.visibility === 'team') return workspace;
+      const publicationStatus = !workspace.linkedTeamWorkspaceId
+        ? 'private_draft'
+        : workspace.publicationStatus === 'team_updates_available'
+          ? 'review_needed'
+          : workspace.publicationStatus === 'review_needed'
+            ? 'review_needed'
+            : 'changes_to_publish';
+      return { ...workspace, publicationStatus };
+    };
+    setWorkspaces((current) => current.map(update));
+    setSelectedWorkspace((current) => current ? update(current) : current);
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -1759,6 +1802,7 @@ export default function WorkspacePage() {
 
       try {
         const updated = await renameFile(selectedWorkspace.id, file.id, { path: normalizedFolder });
+        markPrivateWorkspaceChanged(selectedWorkspace.id);
         applyWorkspaceFileUpdate(file.name, updated);
       } catch (error) {
         console.error('Failed to move file:', error);
@@ -1911,16 +1955,21 @@ export default function WorkspacePage() {
     cancelStreamForConversation(activeConversationId);
   };
 
-  const loadFilesForWorkspace = useCallback(async (workspaceId: string | null) => {
+  const loadFilesForWorkspace = useCallback(async (
+    workspaceId: string | null,
+    options: { includePrivateData?: boolean } = {},
+  ) => {
     if (!workspaceId) return;
     try {
       const [files, folders, knowledge] = await Promise.all([
         getFiles(workspaceId),
         getFolders(workspaceId),
-        listKnowledge(workspaceId).catch((error) => {
-          console.error('Failed to load knowledge for workspace', error);
-          return [];
-        }),
+        options.includePrivateData === false
+          ? Promise.resolve([])
+          : listKnowledge(workspaceId).catch((error) => {
+              console.error('Failed to load knowledge for workspace', error);
+              return [];
+            }),
       ]);
       setFolderPaths(folders);
       setFiles(files);
@@ -2778,8 +2827,10 @@ export default function WorkspacePage() {
   }, [selectedWorkspace?.id]);
 
   useEffect(() => {
-    void loadSchedulesForWorkspace(selectedWorkspace?.id || null);
-  }, [loadSchedulesForWorkspace, selectedWorkspace?.id]);
+    void loadSchedulesForWorkspace(
+      selectedWorkspace?.visibility === 'team' ? null : selectedWorkspace?.id || null,
+    );
+  }, [loadSchedulesForWorkspace, selectedWorkspace?.id, selectedWorkspace?.visibility]);
 
   const ensureConversation = useCallback(async (workspaceOverride?: Workspace | null) => {
     const targetWorkspaceId = workspaceOverride?.id || selectedWorkspace?.id || null;
@@ -2845,7 +2896,7 @@ export default function WorkspacePage() {
 
   useEffect(() => {
     const loadConversations = async () => {
-      if (!selectedWorkspace) {
+      if (!selectedWorkspace || selectedWorkspace.visibility === 'team') {
         setConversationHistory([]);
         setActiveConversationId(null);
         agentMessageBufferRef.current.clear();
@@ -2869,13 +2920,22 @@ export default function WorkspacePage() {
     loadConversations();
   }, [selectedWorkspace, refreshConversationHistory, loadConversationMessages, cancelAllStreams]);
 
-  useEffect(() => {
-    const fetchWorkspaces = async () => {
-      const fetchedWorkspaces = await getWorkspaces();
-      setWorkspaces((fetchedWorkspaces || []).map((ws: Omit<Workspace, 'lastUsed'>) => hydrateWorkspace(ws)));
-    };
-    fetchWorkspaces();
+  const refreshWorkspaceList = useCallback(async () => {
+    const fetchedWorkspaces = await getWorkspaces();
+    const hydrated = (fetchedWorkspaces || []).map(
+      (workspace: Omit<Workspace, 'lastUsed'>) => hydrateWorkspace(workspace),
+    );
+    setWorkspaces(hydrated);
+    setSelectedWorkspace((current) => {
+      if (!current) return current;
+      return hydrated.find((workspace: Workspace) => workspace.id === current.id) || current;
+    });
+    return hydrated as Workspace[];
   }, []);
+
+  useEffect(() => {
+    void refreshWorkspaceList();
+  }, [refreshWorkspaceList]);
 
   useEffect(() => {
     if (!selectedWorkspace) {
@@ -2884,7 +2944,7 @@ export default function WorkspacePage() {
       return;
     }
     setWorkspaceNameDraft(selectedWorkspace.name);
-  }, [selectedWorkspace]);
+  }, [markPrivateWorkspaceChanged, selectedWorkspace]);
 
   useEffect(() => {
     if (isWorkspaceRenameActive && workspaceNameInputRef.current) {
@@ -2931,15 +2991,22 @@ export default function WorkspacePage() {
 
   const handleSelectWorkspace = useCallback((workspace: Workspace) => {
     setIsWorkspaceRenameActive(false);
+    setIsEditMode(false);
     setWorkspaceNameDraft(workspace.name);
     setFolderPaths([]);
     setSelectedWorkspace(workspace);
     setIsLandingPageVisible(false);
+    if (workspace.visibility === 'team') {
+      setIsAgentPaneVisible(false);
+      setMobileSurface('canvas');
+    }
   }, []);
 
   useEffect(() => {
     if (selectedWorkspace) {
-      loadFilesForWorkspace(selectedWorkspace.id);
+      loadFilesForWorkspace(selectedWorkspace.id, {
+        includePrivateData: selectedWorkspace.visibility !== 'team',
+      });
     }
   }, [selectedWorkspace, loadFilesForWorkspace]);
   const handleRefreshFiles = () => {
@@ -6047,12 +6114,14 @@ export default function WorkspacePage() {
           const uploadedFiles: WorkspaceFile[] = [];
           for (const attachment of localAttachments) {
             uploadedFiles.push(await createFile(workspaceId, attachment.file));
+            markPrivateWorkspaceChanged(workspaceId);
           }
           if (driveAttachments.length) {
             const imported = await importGoogleDriveFiles(
               workspaceId,
               driveAttachments.map((attachment) => attachment.driveItem.id),
             );
+            markPrivateWorkspaceChanged(workspaceId);
             if (Array.isArray(imported?.files)) {
               uploadedFiles.push(...imported.files);
             }
@@ -6312,24 +6381,85 @@ export default function WorkspacePage() {
   };
 
   const handleDeleteWorkspace = async (id: string) => {
+    const target = workspaces.find((workspace) => workspace.id === id);
+    if (target && !window.confirm(`Delete ${target.visibility === 'team' ? 'team' : 'private'} workspace "${target.name}"?`)) {
+      return;
+    }
     try {
       await deleteWorkspace(id);
-      setWorkspaces(workspaces.filter((workspace) => workspace.id !== id));
-      setSelectedWorkspace(null);
-      setFiles([]);
-      setFolderPaths([]);
-      setIsLandingPageVisible(true);
+      setWorkspaces((current) => current.filter((workspace) => workspace.id !== id));
+      if (selectedWorkspace?.id === id) {
+        setSelectedWorkspace(null);
+        setFiles([]);
+        setFolderPaths([]);
+        setIsLandingPageVisible(true);
+      }
     } catch (error) {
       console.error('Failed to delete workspace:', error);
     }
   };
 
-  const handleShareWorkspace = useCallback((ws: Workspace) => {
-    setShareWorkspace(ws);
+  const handleManageTeamAccess = useCallback((workspace: Workspace) => {
+    if (workspace.visibility === 'team') setShareWorkspace(workspace);
   }, []);
 
-  const handleUpdateFile = useCallback(async (targetFile: WorkspaceFile | null, content: string) => {
-    if (!selectedWorkspace || !targetFile) return;
+  const handleWorkPrivately = useCallback(async (workspace: Workspace) => {
+    try {
+      if (workspace.privateCopyWorkspaceId) {
+        const existing = workspaces.find((item) => item.id === workspace.privateCopyWorkspaceId);
+        if (existing) {
+          handleSelectWorkspace(existing);
+          return;
+        }
+      }
+      const created = hydrateWorkspace(await createPrivateWorkspaceCopy(workspace.id));
+      const refreshed = await refreshWorkspaceList();
+      const privateCopy = refreshed.find((item) => item.id === created.id) || created;
+      handleSelectWorkspace(privateCopy);
+    } catch (error) {
+      console.error('Failed to open private working copy:', error);
+    }
+  }, [handleSelectWorkspace, refreshWorkspaceList, workspaces]);
+
+  const applyTeamSync = useCallback(async (
+    workspace: Workspace,
+    resolutions: Record<string, 'private' | 'team'> = {},
+  ) => {
+    setSyncBusy(true);
+    setSyncError('');
+    try {
+      await syncWorkspaceWithTeam(workspace.id, resolutions);
+      setSyncConflicts([]);
+      setSyncWorkspaceTarget(null);
+      await refreshWorkspaceList();
+      await loadFilesForWorkspace(workspace.id, { includePrivateData: true });
+    } catch (error) {
+      if (error instanceof WorkspaceApiError) {
+        const details = error.details as { code?: string; conflicts?: PublicationConflict[] } | undefined;
+        if (details?.code === 'REVIEW_NEEDED' && Array.isArray(details.conflicts)) {
+          setSyncWorkspaceTarget(workspace);
+          setSyncConflicts(details.conflicts);
+          return;
+        }
+      }
+      setSyncError(error instanceof Error ? error.message : 'Failed to sync team updates');
+      if (resolutions && Object.keys(resolutions).length) {
+        setSyncWorkspaceTarget(workspace);
+      }
+    } finally {
+      setSyncBusy(false);
+    }
+  }, [loadFilesForWorkspace, refreshWorkspaceList]);
+
+  const handleSyncWorkspace = useCallback((workspace: Workspace) => {
+    void applyTeamSync(workspace);
+  }, [applyTeamSync]);
+
+  const handleUpdateFile = useCallback(async (
+    targetFile: WorkspaceFile | null,
+    content: string,
+  ): Promise<boolean> => {
+    if (!selectedWorkspace || !targetFile) return false;
 
     try {
       if (isDraftWorkspaceFile(targetFile)) {
@@ -6338,6 +6468,7 @@ export default function WorkspacePage() {
           content,
           mimeType: targetFile.mimeType || 'text/markdown',
         });
+        markPrivateWorkspaceChanged(selectedWorkspace.id);
         setFiles((prev) => {
           const withoutDraft = prev.filter((file) => String(file.id) !== String(targetFile.id));
           return [createdFile, ...withoutDraft];
@@ -6350,13 +6481,30 @@ export default function WorkspacePage() {
         setSelectedFileDetails(hydratedCreatedFile);
       } else {
         await updateFileContent(selectedWorkspace.id, Number(targetFile.id), content);
+        markPrivateWorkspaceChanged(selectedWorkspace.id);
         setSelectedFileDetails((prev) => (prev ? { ...prev, content } : prev));
       }
       lastAutoSavedContentRef.current = content;
+      return true;
     } catch (error) {
       console.error('Failed to update file:', error);
+      return false;
     }
-  }, [selectedWorkspace]);
+  }, [markPrivateWorkspaceChanged, selectedWorkspace]);
+
+  const runTrackedWorkspaceSave = useCallback((
+    targetFile: WorkspaceFile | null,
+    content: string,
+  ): Promise<boolean> => {
+    const pendingSave = handleUpdateFile(targetFile, content);
+    pendingAutoSaveRef.current = pendingSave;
+    void pendingSave.finally(() => {
+      if (pendingAutoSaveRef.current === pendingSave) {
+        pendingAutoSaveRef.current = null;
+      }
+    });
+    return pendingSave;
+  }, [handleUpdateFile]);
 
   useEffect(() => {
     if (!isEditMode || !selectedWorkspace || !selectedFile || isDraftWorkspaceFile(selectedFile)) return;
@@ -6369,8 +6517,7 @@ export default function WorkspacePage() {
       if (fileContent === lastAutoSavedContentRef.current) {
         return;
       }
-      await handleUpdateFile(selectedFile, fileContent);
-      lastAutoSavedContentRef.current = fileContent;
+      await runTrackedWorkspaceSave(selectedFile, fileContent);
     }, 2000);
 
     return () => {
@@ -6378,7 +6525,34 @@ export default function WorkspacePage() {
         window.clearTimeout(autoSaveTimerRef.current);
       }
     };
-  }, [fileContent, isEditMode, selectedFile, selectedWorkspace, handleUpdateFile]);
+  }, [fileContent, isEditMode, selectedFile, selectedWorkspace, runTrackedWorkspaceSave]);
+
+  const flushPendingWorkspaceSave = useCallback(async (workspaceId: string) => {
+    if (
+      selectedWorkspace?.id !== workspaceId
+      || !selectedFile
+      || !isEditMode
+    ) {
+      return;
+    }
+    if (autoSaveTimerRef.current) {
+      window.clearTimeout(autoSaveTimerRef.current);
+      autoSaveTimerRef.current = null;
+    }
+    if (pendingAutoSaveRef.current) {
+      await pendingAutoSaveRef.current;
+    }
+    if (
+      !isDraftWorkspaceFile(selectedFile)
+      && fileContent === lastAutoSavedContentRef.current
+    ) {
+      return;
+    }
+    const saved = await runTrackedWorkspaceSave(selectedFile, fileContent);
+    if (!saved) {
+      throw new Error('Save the current file before publishing.');
+    }
+  }, [fileContent, isEditMode, runTrackedWorkspaceSave, selectedFile, selectedWorkspace?.id]);
 
   const handleBulkDelete = async () => {
     if (!selectedWorkspace) return;
@@ -6454,6 +6628,7 @@ export default function WorkspacePage() {
         }
 
         const created = await createFolder(selectedWorkspace.id, normalizedFolder);
+        markPrivateWorkspaceChanged(selectedWorkspace.id);
         const createdPath = typeof created?.path === 'string' ? created.path : normalizedFolder;
         setFolderPaths((prev) => addFolderPath(prev, createdPath));
         setWorkspaceFileDialog(null);
@@ -6480,6 +6655,7 @@ export default function WorkspacePage() {
         const parentFolder = getWorkspaceParentFolderPath(sourceFolder);
         const destinationFolder = parentFolder ? `${parentFolder}/${normalizedName}` : normalizedName;
         const renamed = await renameFolder(selectedWorkspace.id, sourceFolder, normalizedName);
+        markPrivateWorkspaceChanged(selectedWorkspace.id);
         const updatedFiles = Array.isArray(renamed?.files) ? renamed.files as WorkspaceFile[] : [];
         const updatedFilesById = new Map(updatedFiles.map((file) => [String(file.id), file]));
         const renameFilePath = (file: WorkspaceFile): WorkspaceFile => {
@@ -6515,6 +6691,7 @@ export default function WorkspacePage() {
         }
 
         const updated = await renameFile(selectedWorkspace.id, currentDialog.file.id, { name: proposedName });
+        markPrivateWorkspaceChanged(selectedWorkspace.id);
         applyWorkspaceFileUpdate(currentDialog.file.name, updated);
         setWorkspaceFileDialog(null);
         return;
@@ -6523,6 +6700,7 @@ export default function WorkspacePage() {
       if (currentDialog.kind === 'delete-file') {
         const { file } = currentDialog;
         await deleteFile(selectedWorkspace.id, file.id);
+        markPrivateWorkspaceChanged(selectedWorkspace.id);
         setFiles((prev) => prev.filter((item) => item.id !== file.id));
         setSelectedFiles((prev) => {
           const next = new Set(prev);
@@ -6548,6 +6726,7 @@ export default function WorkspacePage() {
         });
 
         await deleteFolder(selectedWorkspace.id, folder.path);
+        markPrivateWorkspaceChanged(selectedWorkspace.id);
 
         const deletedIds = new Set(filesInFolder.map((file) => file.id));
         setFiles((prev) =>
@@ -6582,6 +6761,7 @@ export default function WorkspacePage() {
           continue;
         }
         await deleteFile(selectedWorkspace.id, fileId);
+        markPrivateWorkspaceChanged(selectedWorkspace.id);
       }
       setFiles((prevFiles) => prevFiles.filter((file) => !fileIdsToDelete.has(file.id)));
       setSelectedFiles(new Set());
@@ -6630,6 +6810,7 @@ export default function WorkspacePage() {
 
       try {
         await createFile(workspaceId, file, destinationPath);
+        markPrivateWorkspaceChanged(workspaceId);
         uploadedCount += 1;
       } catch (error) {
         console.error('Failed to upload workspace file:', error);
@@ -6740,6 +6921,7 @@ export default function WorkspacePage() {
     try {
       setIsDriveImporting(true);
       const imported = await importGoogleDriveFiles(workspaceId, items.map((item) => item.id));
+      markPrivateWorkspaceChanged(workspaceId);
       const importedFiles = Array.isArray(imported.files) ? imported.files : [];
       if (importedFiles.length && selectedWorkspaceIdRef.current === workspaceId) {
         await loadFilesForWorkspace(workspaceId);
@@ -7013,19 +7195,21 @@ export default function WorkspacePage() {
             </span>
           </button>
           <div className="flex shrink-0 items-center gap-2">
-            <button
-              type="button"
-              onClick={() => {
-                void handleNewChat();
-                setMobileSurface('chat');
-              }}
-              className={`inline-flex h-10 w-10 items-center justify-center rounded-xl ${
-                isDarkMode ? 'text-slate-300 hover:bg-slate-800' : 'text-slate-600 hover:bg-slate-100'
-              }`}
-              aria-label="Start new chat"
-            >
-              <Plus size={18} />
-            </button>
+            {selectedWorkspace?.visibility !== 'team' ? (
+              <button
+                type="button"
+                onClick={() => {
+                  void handleNewChat();
+                  setMobileSurface('chat');
+                }}
+                className={`inline-flex h-10 w-10 items-center justify-center rounded-xl ${
+                  isDarkMode ? 'text-slate-300 hover:bg-slate-800' : 'text-slate-600 hover:bg-slate-100'
+                }`}
+                aria-label="Start new chat"
+              >
+                <Plus size={18} />
+              </button>
+            ) : null}
             <button
               type="button"
               onClick={() => setIsMobileWorkspaceSheetOpen(true)}
@@ -7038,10 +7222,15 @@ export default function WorkspacePage() {
             </button>
           </div>
         </div>
-        <div className={`mt-3 grid grid-cols-2 rounded-2xl p-1 ${
+        <div className={`mt-3 grid ${
+          selectedWorkspace?.visibility === 'team' ? 'grid-cols-1' : 'grid-cols-2'
+        } rounded-2xl p-1 ${
           isDarkMode ? 'bg-slate-900' : 'bg-slate-100'
         }`}>
-          {(['chat', 'canvas'] as const).map((surface) => (
+          {(selectedWorkspace?.visibility === 'team'
+            ? (['canvas'] as MobileWorkspaceSurface[])
+            : (['chat', 'canvas'] as MobileWorkspaceSurface[])
+          ).map((surface) => (
             <button
               key={surface}
               type="button"
@@ -7060,9 +7249,51 @@ export default function WorkspacePage() {
             </button>
           ))}
         </div>
+        {selectedWorkspace?.visibility === 'team' ? (
+          <button
+            type="button"
+            onClick={() => void handleWorkPrivately(selectedWorkspace)}
+            className={`mt-2 w-full rounded-xl px-3 py-2 text-sm font-semibold ${
+              isDarkMode
+                ? 'bg-sky-500/15 text-sky-200 hover:bg-sky-500/25'
+                : 'bg-blue-50 text-blue-700 hover:bg-blue-100'
+            }`}
+          >
+            {selectedWorkspace.privateCopyWorkspaceId ? 'Open private copy' : 'Work privately'}
+          </button>
+        ) : selectedWorkspace?.publicationStatus === 'team_updates_available'
+          || selectedWorkspace?.publicationStatus === 'review_needed' ? (
+            <button
+              type="button"
+              onClick={() => handleSyncWorkspace(selectedWorkspace)}
+              className={`mt-2 w-full rounded-xl px-3 py-2 text-sm font-semibold ${
+                isDarkMode
+                  ? 'bg-amber-500/15 text-amber-200 hover:bg-amber-500/25'
+                  : 'bg-amber-50 text-amber-700 hover:bg-amber-100'
+              }`}
+            >
+              {selectedWorkspace.publicationStatus === 'review_needed' ? 'Review changes' : 'Sync team updates'}
+            </button>
+          ) : selectedWorkspace?.canPublish
+            && (
+              selectedWorkspace.publicationStatus === 'private_draft'
+              || selectedWorkspace.publicationStatus === 'changes_to_publish'
+            ) ? (
+              <button
+                type="button"
+                onClick={() => setPublishWorkspaceTarget(selectedWorkspace)}
+                className={`mt-2 w-full rounded-xl px-3 py-2 text-sm font-semibold ${
+                  isDarkMode
+                    ? 'bg-emerald-500/15 text-emerald-200 hover:bg-emerald-500/25'
+                    : 'bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
+                }`}
+              >
+                {selectedWorkspace.publicationStatus === 'private_draft' ? 'Publish to team' : 'Publish changes'}
+              </button>
+            ) : null}
       </header>
 
-      {mobileSurface === 'chat' ? (
+      {mobileSurface === 'chat' && selectedWorkspace?.visibility !== 'team' ? (
         <div className={`flex min-h-0 flex-1 flex-col overflow-hidden ${isDarkMode ? 'bg-[#0d1524]' : 'bg-white'}`}>
           <ChatMessageList
             colorMode={colorMode}
@@ -7168,7 +7399,7 @@ export default function WorkspacePage() {
             <div className="max-h-[70dvh] overflow-y-auto px-4 pb-5">
               <section className="space-y-2">
                 <p className={`text-[10px] font-semibold uppercase tracking-normal ${isDarkMode ? 'text-slate-500' : 'text-slate-500'}`}>
-                  Workspaces
+                  Private workspaces
                 </p>
                 <button
                   type="button"
@@ -7184,7 +7415,7 @@ export default function WorkspacePage() {
                   <Plus size={15} />
                   New Workspace
                 </button>
-                {filteredWorkspaces.slice(0, 8).map((workspace) => (
+                {mobilePrivateWorkspaces.map((workspace) => (
                   <button
                     key={workspace.id}
                     type="button"
@@ -7203,6 +7434,52 @@ export default function WorkspacePage() {
                     {selectedWorkspace?.id === workspace.id ? <Check size={15} className="shrink-0" /> : null}
                   </button>
                 ))}
+                {!mobilePrivateWorkspaces.length ? (
+                  <p className={`rounded-xl px-3 py-3 text-sm ${
+                    isDarkMode ? 'bg-slate-900 text-slate-500' : 'bg-slate-50 text-slate-500'
+                  }`}>
+                    No private workspaces.
+                  </p>
+                ) : null}
+              </section>
+
+              <section className="mt-5 space-y-2">
+                <p className={`text-[10px] font-semibold uppercase tracking-normal ${isDarkMode ? 'text-slate-500' : 'text-slate-500'}`}>
+                  Team workspaces
+                </p>
+                {mobileTeamWorkspaces.map((workspace) => (
+                  <button
+                    key={workspace.id}
+                    type="button"
+                    onClick={() => {
+                      handleSelectWorkspace(workspace);
+                      setIsMobileWorkspaceSheetOpen(false);
+                      setMobileSurface('canvas');
+                    }}
+                    className={`flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-left text-sm transition ${
+                      selectedWorkspace?.id === workspace.id
+                        ? isDarkMode ? 'bg-sky-500/15 text-sky-200' : 'bg-blue-50 text-blue-700'
+                        : isDarkMode ? 'text-slate-200 hover:bg-slate-900' : 'text-slate-700 hover:bg-slate-50'
+                    }`}
+                  >
+                    <span className="min-w-0">
+                      <span className="block truncate">{workspace.name}</span>
+                      <span className={`block truncate text-[10px] ${
+                        isDarkMode ? 'text-slate-500' : 'text-slate-500'
+                      }`}>
+                        {workspace.teamName || 'Team workspace'}
+                      </span>
+                    </span>
+                    {selectedWorkspace?.id === workspace.id ? <Check size={15} className="shrink-0" /> : null}
+                  </button>
+                ))}
+                {!mobileTeamWorkspaces.length ? (
+                  <p className={`rounded-xl px-3 py-3 text-sm ${
+                    isDarkMode ? 'bg-slate-900 text-slate-500' : 'bg-slate-50 text-slate-500'
+                  }`}>
+                    No team workspaces.
+                  </p>
+                ) : null}
               </section>
 
               <section className="mt-5 space-y-2">
@@ -7336,7 +7613,13 @@ export default function WorkspacePage() {
           workspaceSearchQuery={workspaceSearchQuery}
           setWorkspaceSearchQuery={setWorkspaceSearchQuery}
           handleDeleteWorkspace={handleDeleteWorkspace}
-          onShareWorkspace={handleShareWorkspace}
+          onPublishWorkspace={setPublishWorkspaceTarget}
+          onSyncWorkspace={handleSyncWorkspace}
+          onWorkPrivately={(workspace) => {
+            void handleWorkPrivately(workspace);
+          }}
+          onHistoryWorkspace={setHistoryWorkspaceTarget}
+          onManageTeamAccess={handleManageTeamAccess}
           onSelectWorkspace={handleSelectWorkspace}
           onCreateWorkspace={() => {
             void handleCreateWorkspace();
@@ -7828,6 +8111,19 @@ export default function WorkspacePage() {
                   <h2 className={`text-lg font-semibold ${isDarkMode ? 'text-slate-100' : 'text-gray-800'}`}>No workspace selected</h2>
                 )}
                 </div>
+                {selectedWorkspace?.visibility === 'team' ? (
+                  <button
+                    type="button"
+                    onClick={() => void handleWorkPrivately(selectedWorkspace)}
+                    className={`inline-flex h-9 shrink-0 items-center justify-center rounded-lg px-3 text-sm font-medium ${
+                      isDarkMode
+                        ? 'bg-sky-500/15 text-sky-200 hover:bg-sky-500/25'
+                        : 'bg-blue-50 text-blue-700 hover:bg-blue-100'
+                    }`}
+                  >
+                    {selectedWorkspace.privateCopyWorkspaceId ? 'Open private copy' : 'Work privately'}
+                  </button>
+                ) : null}
               </div>
               <div className="flex-1 flex min-h-0">
                 {/* File Explorer */}
@@ -7888,7 +8184,7 @@ export default function WorkspacePage() {
                           <button
                             type="button"
                             onClick={() => setIsFileActionMenuOpen((prev) => !prev)}
-                            disabled={!selectedWorkspace}
+                            disabled={!selectedWorkspace?.canEdit}
                             className={`h-8 w-8 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
                               isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-gray-100'
                             }`}
@@ -7983,7 +8279,7 @@ export default function WorkspacePage() {
                         </button>
                         <button
                           onClick={handleSelectAllFiles}
-                          disabled={visibleFiles.length === 0}
+                          disabled={!selectedWorkspace?.canEdit || visibleFiles.length === 0}
                           className={`h-8 w-8 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
                             isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-gray-100'
                           }`}
@@ -7993,7 +8289,7 @@ export default function WorkspacePage() {
                         </button>
                         <button
                           onClick={handleBulkDelete}
-                          disabled={selectedFiles.size === 0}
+                          disabled={!selectedWorkspace?.canEdit || selectedFiles.size === 0}
                           className={`h-8 w-8 inline-flex items-center justify-center rounded-lg disabled:opacity-50 ${
                             isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-gray-100'
                           }`}
@@ -8036,12 +8332,13 @@ export default function WorkspacePage() {
                         selectedFiles={selectedFiles}
                         copiedPublicUrlFileId={copiedPublicUrlFileId}
                         dashboardArtifactsByPath={dashboardArtifactsByPath}
+                        readOnly={!selectedWorkspace?.canEdit}
                         isDraftWorkspaceFile={isDraftWorkspaceFile}
                         onSelectFile={(file) => {
                           setSelectedFile(file);
                           setSelectedFileDetails(null);
                           setFileContent('');
-                          setIsEditMode(shouldForceEditMode(file.name));
+                          setIsEditMode(Boolean(selectedWorkspace?.canEdit) && shouldForceEditMode(file.name));
                         }}
                         onSelectFolder={handleDashboardFolderSelect}
                         onToggleFileSelection={handleFileSelect}
@@ -8142,7 +8439,7 @@ export default function WorkspacePage() {
                             }
                             setIsEditMode(!isEditMode);
                           }}
-                          disabled={!selectedFile || !isFileEditable(selectedFile.name)}
+                          disabled={!selectedWorkspace?.canEdit || !selectedFile || !isFileEditable(selectedFile.name)}
                         >
                           <Edit size={16} className={isDarkMode ? 'text-slate-300' : 'text-gray-600'} />
                         </button>
@@ -8151,8 +8448,8 @@ export default function WorkspacePage() {
                         className={`h-8 px-3 inline-flex items-center justify-center rounded-lg text-xs font-medium disabled:opacity-50 ${
                           isDarkMode ? 'text-slate-200 hover:bg-slate-800' : 'text-slate-700 hover:bg-gray-200'
                         }`}
-                        onClick={() => selectedFile && handleUpdateFile(selectedFile, fileContent)}
-                        disabled={!isEditMode}
+                        onClick={() => selectedFile && runTrackedWorkspaceSave(selectedFile, fileContent)}
+                        disabled={!selectedWorkspace?.canEdit || !isEditMode}
                       >
                         Save
                       </button>
@@ -8509,6 +8806,42 @@ export default function WorkspacePage() {
         open={shareWorkspace !== null}
         workspace={shareWorkspace}
         onClose={() => setShareWorkspace(null)}
+      />
+      <WorkspacePublishDialog
+        open={publishWorkspaceTarget !== null}
+        workspace={publishWorkspaceTarget}
+        onClose={() => setPublishWorkspaceTarget(null)}
+        onBeforePublish={(workspace) => flushPendingWorkspaceSave(workspace.id)}
+        onPublished={async () => {
+          await refreshWorkspaceList();
+        }}
+      />
+      <WorkspaceConflictDialog
+        open={syncWorkspaceTarget !== null && syncConflicts.length > 0}
+        conflicts={syncConflicts}
+        busy={syncBusy}
+        error={syncError}
+        onClose={() => {
+          setSyncWorkspaceTarget(null);
+          setSyncConflicts([]);
+          setSyncError('');
+        }}
+        onConfirm={(resolutions) => {
+          if (syncWorkspaceTarget) {
+            void applyTeamSync(syncWorkspaceTarget, resolutions);
+          }
+        }}
+      />
+      <WorkspaceHistoryDialog
+        open={historyWorkspaceTarget !== null}
+        workspace={historyWorkspaceTarget}
+        onClose={() => setHistoryWorkspaceTarget(null)}
+        onRestored={async () => {
+          await refreshWorkspaceList();
+          if (historyWorkspaceTarget) {
+            await loadFilesForWorkspace(historyWorkspaceTarget.id, { includePrivateData: false });
+          }
+        }}
       />
     </ThemeProvider>
   );

--- a/frontend/src/services/workspaceApi.ts
+++ b/frontend/src/services/workspaceApi.ts
@@ -1,5 +1,26 @@
 import { API_URL, apiFetch } from './apiClient';
 
+export class WorkspaceApiError extends Error {
+  status: number;
+  details?: unknown;
+
+  constructor(message: string, status: number, details?: unknown) {
+    super(message);
+    this.name = 'WorkspaceApiError';
+    this.status = status;
+    this.details = details;
+  }
+}
+
+const throwWorkspaceApiError = async (response: Response, fallback: string): Promise<never> => {
+  const payload = await response.json().catch(() => ({}));
+  throw new WorkspaceApiError(
+    typeof payload?.error === 'string' ? payload.error : fallback,
+    response.status,
+    payload?.details,
+  );
+};
+
 export const getWorkspaces = async () => {
   const response = await apiFetch(`${API_URL}/workspaces`);
   if (!response.ok) {
@@ -111,4 +132,106 @@ export const removeWorkspaceCollaborator = async (workspaceId: string, targetUse
     const err = await response.json().catch(() => ({}));
     throw new Error(typeof err?.error === 'string' ? err.error : 'Failed to remove collaborator');
   }
+};
+
+export type WorkspaceTeam = {
+  id: string;
+  name: string;
+};
+
+export type PublicationConflict = {
+  path: string;
+  privateChange: 'added' | 'changed' | 'deleted';
+  teamChange: 'added' | 'changed' | 'deleted';
+  privateText?: string;
+  teamText?: string;
+  textTruncated?: boolean;
+};
+
+export type PublishedWorkspaceVersion = {
+  id: string;
+  versionNumber: number;
+  note: string | null;
+  createdAt: string;
+  publisherName: string;
+};
+
+export const listWorkspaceTeams = async (): Promise<WorkspaceTeam[]> => {
+  const response = await apiFetch(`${API_URL}/workspaces/teams`);
+  if (!response.ok) {
+    return throwWorkspaceApiError(response, 'Failed to list teams');
+  }
+  const payload = await response.json() as { teams?: WorkspaceTeam[] };
+  return payload.teams || [];
+};
+
+export const publishWorkspace = async (
+  workspaceId: string,
+  payload: { teamId?: string; name?: string; note?: string },
+) => {
+  const response = await apiFetch(`${API_URL}/workspaces/${workspaceId}/publish`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    return throwWorkspaceApiError(response, 'Failed to publish workspace');
+  }
+  return response.json() as Promise<{
+    teamWorkspaceId: string;
+    privateWorkspaceId: string;
+    publishedVersionId: string;
+    publishedVersionNumber: number;
+    publishedAt: string;
+  }>;
+};
+
+export const createPrivateWorkspaceCopy = async (teamWorkspaceId: string) => {
+  const response = await apiFetch(`${API_URL}/workspaces/${teamWorkspaceId}/private-copy`, {
+    method: 'POST',
+  });
+  if (!response.ok) {
+    return throwWorkspaceApiError(response, 'Failed to create private working copy');
+  }
+  return response.json();
+};
+
+export const syncWorkspaceWithTeam = async (
+  privateWorkspaceId: string,
+  resolutions: Record<string, 'private' | 'team'> = {},
+) => {
+  const response = await apiFetch(`${API_URL}/workspaces/${privateWorkspaceId}/sync`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ resolutions }),
+  });
+  if (!response.ok) {
+    return throwWorkspaceApiError(response, 'Failed to sync team updates');
+  }
+  return response.json();
+};
+
+export const listPublishedWorkspaceHistory = async (
+  teamWorkspaceId: string,
+): Promise<PublishedWorkspaceVersion[]> => {
+  const response = await apiFetch(`${API_URL}/workspaces/${teamWorkspaceId}/history`);
+  if (!response.ok) {
+    return throwWorkspaceApiError(response, 'Failed to load publication history');
+  }
+  const payload = await response.json() as { versions?: PublishedWorkspaceVersion[] };
+  return payload.versions || [];
+};
+
+export const restorePublishedWorkspaceVersion = async (
+  teamWorkspaceId: string,
+  versionId: string,
+) => {
+  const response = await apiFetch(
+    `${API_URL}/workspaces/${teamWorkspaceId}/versions/${versionId}/restore`,
+    { method: 'POST' },
+  );
+  if (!response.ok) {
+    return throwWorkspaceApiError(response, 'Failed to restore published version');
+  }
+  return response.json();
 };

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -5,6 +5,22 @@ export interface Workspace {
   slug?: string;
   role?: 'owner' | 'editor' | 'viewer';
   canEdit?: boolean;
+  canPublish?: boolean;
+  visibility?: 'private' | 'team';
+  teamId?: string | null;
+  teamName?: string | null;
+  publicationStatus?:
+    | 'private_draft'
+    | 'up_to_date'
+    | 'changes_to_publish'
+    | 'team_updates_available'
+    | 'review_needed';
+  linkedTeamWorkspaceId?: string | null;
+  privateCopyWorkspaceId?: string | null;
+  currentPublishedVersionId?: string | null;
+  currentPublishedVersionNumber?: number | null;
+  latestPublisherName?: string | null;
+  lastPublishedAt?: string | null;
   createdAt?: string;
   updatedAt?: string;
 }


### PR DESCRIPTION
## Summary

- separate navigation into private and team workspaces on desktop and mobile
- keep team workspaces read-only while teammates browse published files and create private working copies
- add deliberate publish and sync flows with immutable version history, conflict review, and restoration
- enforce current team membership and publisher roles across listing, access, publish, sync, and restore operations
- preserve the privacy boundary by publishing visible workspace content without conversations, activity, schedules, credentials, or personal integrations
- document the product model and acceptance criteria

## Why

Users need a private place for unfinished work while giving teammates access only to versions they intentionally publish. This introduces a clear private-to-team publishing model without exposing the live private workspace.

## Impact

- new workspaces remain private by default
- existing shared workspaces migrate to read-only team workspaces
- publishing creates a separate team workspace and immutable version snapshot
- team updates can be synced into private copies without changing the team version
- overlapping edits require explicit per-file resolution
- publication metadata and historical versions remain available for audit and recovery

## Validation

- `cd backend && npx tsc --noEmit`
- `cd backend && npm test` — 107 tests, 94 passed, 13 environment-gated skips
- disposable-database publication lifecycle test — publish, private copy, conflict review, sync, concurrent publication, restore, membership revocation, and deleted-publisher history
- publisher foreign-key migration verification
- `cd frontend && npm run build`
- `cd frontend && npm run lint` — 0 errors; 3 pre-existing hook warnings
- `git diff --check`
- local frontend and backend health checks
