### PR TITLE
Add governed workspace audience sharing

### DIFF
--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -13,10 +13,28 @@ const renameWorkspaceSchema = z.object({
   name: z.string().trim().min(1).max(255),
 });
 
+const namedWorkspaceRoleSchema = z.enum(['publisher', 'contributor', 'viewer']);
+
 const publishWorkspaceSchema = z.object({
+  audience: z.enum(['team', 'selected_people']).optional(),
   teamId: z.string().uuid().optional(),
+  userIds: z.array(z.string().uuid()).min(1).max(100).optional(),
+  role: namedWorkspaceRoleSchema.optional(),
   name: z.string().trim().min(1).max(255).optional(),
   note: z.string().trim().max(1000).optional(),
+}).superRefine((data, ctx) => {
+  if (data.audience === 'team' && !data.teamId) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Choose a team', path: ['teamId'] });
+  }
+  if (data.audience === 'selected_people' && !data.userIds?.length) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Choose at least one person', path: ['userIds'] });
+  }
+});
+
+const shareWorkspaceSchema = z.object({
+  userIds: z.array(z.string().uuid()).min(1).max(100),
+  role: namedWorkspaceRoleSchema.optional(),
+  name: z.string().trim().min(1).max(255).optional(),
 });
 
 const syncWorkspaceSchema = z.object({
@@ -124,6 +142,24 @@ export default function workspaceRoutes(
         return res.status(400).json({ error: 'Invalid publish payload' });
       }
       handleError(res, error, 'Failed to publish workspace');
+    }
+  });
+
+  router.post('/:workspaceId/share', async (req, res) => {
+    try {
+      const user = requireUserContext(req);
+      const payload = shareWorkspaceSchema.parse(req.body || {});
+      const shared = await publicationService.shareWithSelectedPeople(
+        req.params.workspaceId,
+        user.userId,
+        payload,
+      );
+      res.status(201).json(shared);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: 'Invalid sharing payload' });
+      }
+      handleError(res, error, 'Failed to share workspace');
     }
   });
 

--- a/backend/src/services/workspaceAudiencePolicy.ts
+++ b/backend/src/services/workspaceAudiencePolicy.ts
@@ -1,0 +1,27 @@
+import type { WorkspaceRole } from './workspaceService';
+
+export type WorkspaceNamedGrantRole = 'publisher' | 'contributor' | 'viewer';
+
+export const normalizeSelectedWorkspaceUsers = (
+  ownerUserId: string,
+  userIds: string[] = [],
+): string[] => Array.from(new Set(
+  userIds
+    .map((userId) => String(userId || '').trim())
+    .filter((userId) => userId && userId !== ownerUserId),
+));
+
+export const namedGrantToLegacyWorkspaceRole = (
+  role: WorkspaceNamedGrantRole,
+): WorkspaceRole => {
+  if (role === 'publisher') return 'editor';
+  return role;
+};
+
+export const legacyWorkspaceRoleToNamedGrant = (
+  role: WorkspaceRole,
+): WorkspaceNamedGrantRole => {
+  if (role === 'editor') return 'publisher';
+  if (role === 'contributor') return 'contributor';
+  return 'viewer';
+};

--- a/backend/src/services/workspaceCollaborationService.ts
+++ b/backend/src/services/workspaceCollaborationService.ts
@@ -539,18 +539,9 @@ export class WorkspaceCollaborationService {
     if (workspace.visibility !== 'team') {
       throw new ConflictError('Collaboration items are attached to published workspaces');
     }
-    let currentPublishedVersionId = workspace.currentPublishedVersionId || null;
-    if (!currentPublishedVersionId) {
-      await this.publicationService.listHistory(workspaceId, userId);
-      const refreshed = await this.db('workspaces')
-        .select('currentPublishedVersionId')
-        .where({ id: workspaceId })
-        .first();
-      currentPublishedVersionId = refreshed?.currentPublishedVersionId || null;
-    }
     return {
       membership,
-      currentPublishedVersionId,
+      currentPublishedVersionId: workspace.currentPublishedVersionId || null,
     };
   }
 

--- a/backend/src/services/workspacePublicationService.ts
+++ b/backend/src/services/workspacePublicationService.ts
@@ -11,6 +11,11 @@ import { S3Service } from './s3Service';
 import { WorkspaceRecord, WorkspaceRole, WorkspaceService } from './workspaceService';
 import { getWorkspaceRoleCapabilities } from './workspaceCollaborationPolicy';
 import {
+  namedGrantToLegacyWorkspaceRole,
+  normalizeSelectedWorkspaceUsers,
+  type WorkspaceNamedGrantRole,
+} from './workspaceAudiencePolicy';
+import {
   findPublicationConflicts,
   hasFileChanged,
   mergePublicationFolders,
@@ -84,7 +89,14 @@ export class WorkspacePublicationService {
   async publish(
     privateWorkspaceId: string,
     userId: string,
-    input: { teamId?: string; note?: string; name?: string },
+    input: {
+      audience?: 'team' | 'selected_people';
+      teamId?: string;
+      userIds?: string[];
+      role?: WorkspaceNamedGrantRole;
+      note?: string;
+      name?: string;
+    },
   ) {
     const { workspace: privateWorkspace } = await this.workspaceService.ensureMembership(
       privateWorkspaceId,
@@ -100,6 +112,19 @@ export class WorkspacePublicationService {
       .first();
 
     if (!existingLink) {
+      if (input.audience === 'selected_people') {
+        const selectedUserIds = normalizeSelectedWorkspaceUsers(userId, input.userIds);
+        if (!selectedUserIds.length) {
+          throw new ConflictError('Choose at least one person before publishing');
+        }
+        await this.ensureRegisteredUsers(selectedUserIds);
+        return this.publishFirstVersion(privateWorkspace, userId, {
+          selectedUserIds,
+          selectedRole: input.role || 'viewer',
+          note: input.note,
+          name: input.name,
+        });
+      }
       if (!input.teamId) {
         throw new ConflictError('Choose a team before publishing');
       }
@@ -125,7 +150,8 @@ export class WorkspacePublicationService {
     }
 
     if (
-      !existingLink.hasUnpublishedChanges
+      teamWorkspace.currentPublishedVersionId
+      && !existingLink.hasUnpublishedChanges
       && Number(privateWorkspace.contentRevision || 0) === Number(existingLink.basePrivateContentRevision || 0)
     ) {
       throw new ConflictError('There are no private changes to publish');
@@ -138,6 +164,88 @@ export class WorkspacePublicationService {
       note: input.note,
       existingLink,
     });
+  }
+
+  async shareWithSelectedPeople(
+    privateWorkspaceId: string,
+    userId: string,
+    input: { userIds: string[]; role?: WorkspaceNamedGrantRole; name?: string },
+  ) {
+    const { workspace: privateWorkspace } = await this.workspaceService.ensureMembership(
+      privateWorkspaceId,
+      userId,
+      { requireEdit: true },
+    );
+    if (privateWorkspace.visibility !== 'private' || privateWorkspace.ownerId !== userId) {
+      throw new AccessDeniedError('Only the owner can share a private workspace');
+    }
+
+    const existingLink = await this.db<PublicationLinkRecord>('workspace_publication_links')
+      .where({ privateWorkspaceId })
+      .first();
+    if (existingLink) {
+      throw new ConflictError('This private workspace already has a shared Team Workspace');
+    }
+
+    const selectedUserIds = normalizeSelectedWorkspaceUsers(userId, input.userIds);
+    if (!selectedUserIds.length) {
+      throw new ConflictError('Choose at least one person before sharing');
+    }
+    await this.ensureRegisteredUsers(selectedUserIds);
+
+    const teamWorkspace = await this.createTeamWorkspace(privateWorkspace, userId, {
+      selectedUserIds,
+      selectedRole: input.role || 'viewer',
+      name: input.name,
+    });
+
+    try {
+      const content = await this.readWorkspaceContent(privateWorkspace.id);
+      await this.replaceWorkspaceContent(teamWorkspace.id, content, userId);
+      await this.db.transaction(async (tx) => {
+        const currentPrivate = await tx<WorkspaceRecord>('workspaces')
+          .select('contentRevision')
+          .where({ id: privateWorkspace.id })
+          .forUpdate()
+          .first();
+        if (Number(currentPrivate?.contentRevision || 0) !== Number(privateWorkspace.contentRevision || 0)) {
+          throw new ConflictError('The private workspace changed while it was being shared. Try again.');
+        }
+        await this.copyValidatedWorkspaceSkillPins(tx, privateWorkspace.id, teamWorkspace.id);
+        await tx('workspace_publication_links').insert({
+          privateWorkspaceId: privateWorkspace.id,
+          teamWorkspaceId: teamWorkspace.id,
+          userId,
+          basePublishedVersionId: null,
+          basePrivateContentRevision: Number(currentPrivate?.contentRevision || 0),
+          hasUnpublishedChanges: false,
+        });
+        await tx('audit_events').insert({
+          id: uuidv4(),
+          actorUserId: userId,
+          actorRole: 'workspace_owner',
+          action: 'workspace.promoted',
+          resourceType: 'workspace',
+          resourceId: teamWorkspace.id,
+          metadata: {
+            sourcePrivateWorkspaceId: privateWorkspace.id,
+            audience: 'selected_people',
+            selectedUserIds,
+            selectedRole: input.role || 'viewer',
+            editingPolicy: 'review',
+          },
+        });
+      });
+      return {
+        privateWorkspaceId: privateWorkspace.id,
+        teamWorkspaceId: teamWorkspace.id,
+        sharedWithUserIds: selectedUserIds,
+      };
+    } catch (error) {
+      await this.db('workspaces').where({ id: teamWorkspace.id }).del();
+      await fs.rm(path.join(WORKSPACE_DIR, teamWorkspace.id), { recursive: true, force: true });
+      throw error;
+    }
   }
 
   async createPrivateCopy(teamWorkspaceId: string, userId: string) {
@@ -164,8 +272,12 @@ export class WorkspacePublicationService {
       }
     }
 
-    const currentVersion = await this.ensureCurrentVersion(teamWorkspace, userId);
-    const content = await this.readPublishedVersionContent(currentVersion);
+    const currentVersion = teamWorkspace.currentPublishedVersionId
+      ? await this.getPublishedVersion(teamWorkspace.currentPublishedVersionId, teamWorkspace.id)
+      : null;
+    const content = currentVersion
+      ? await this.readPublishedVersionContent(currentVersion)
+      : await this.readWorkspaceContent(teamWorkspace.id);
     const privateWorkspaceId = uuidv4();
     const name = await this.resolveUniquePrivateCopyName(userId, teamWorkspace.name);
     const slug = await this.generateUniqueSlug(name);
@@ -188,12 +300,16 @@ export class WorkspacePublicationService {
         role: 'owner',
         canEdit: true,
       });
-      await this.copyPublishedSkillPinsToWorkspace(
-        tx,
-        currentVersion.id,
-        privateWorkspaceId,
-        userId,
-      );
+      if (currentVersion) {
+        await this.copyPublishedSkillPinsToWorkspace(
+          tx,
+          currentVersion.id,
+          privateWorkspaceId,
+          userId,
+        );
+      } else {
+        await this.copyValidatedWorkspaceSkillPins(tx, teamWorkspace.id, privateWorkspaceId);
+      }
     });
 
     try {
@@ -202,7 +318,7 @@ export class WorkspacePublicationService {
         privateWorkspaceId,
         teamWorkspaceId,
         userId,
-        basePublishedVersionId: currentVersion.id,
+        basePublishedVersionId: currentVersion?.id || null,
         basePrivateContentRevision: contentRevision,
       });
     } catch (error) {
@@ -240,7 +356,13 @@ export class WorkspacePublicationService {
     }
 
     const { workspace: teamWorkspace } = await this.workspaceService.ensureMembership(link.teamWorkspaceId, userId);
-    const latestVersion = await this.ensureCurrentVersion(teamWorkspace, userId);
+    if (!teamWorkspace.currentPublishedVersionId) {
+      throw new ConflictError('No published Team version is available to sync');
+    }
+    const latestVersion = await this.getPublishedVersion(
+      teamWorkspace.currentPublishedVersionId,
+      teamWorkspace.id,
+    );
     if (latestVersion.id === link.basePublishedVersionId) {
       return {
         workspaceId: privateWorkspaceId,
@@ -314,7 +436,6 @@ export class WorkspacePublicationService {
     if (workspace.visibility !== 'team') {
       throw new ConflictError('Publication history is only available for team workspaces');
     }
-    await this.ensureCurrentVersion(workspace, userId);
     return this.db('workspace_published_versions as version')
       .leftJoin('users as publisher', 'publisher.id', 'version.publisherUserId')
       .where('version.teamWorkspaceId', teamWorkspaceId)
@@ -407,11 +528,47 @@ export class WorkspacePublicationService {
   private async publishFirstVersion(
     privateWorkspace: WorkspaceRecord,
     userId: string,
-    input: { teamId: string; note?: string; name?: string },
+    input: {
+      teamId?: string;
+      selectedUserIds?: string[];
+      selectedRole?: WorkspaceNamedGrantRole;
+      note?: string;
+      name?: string;
+    },
   ) {
+    const teamWorkspace = await this.createTeamWorkspace(privateWorkspace, userId, input);
+
+    try {
+      return await this.createPublishedVersion({
+        privateWorkspace,
+        teamWorkspace,
+        userId,
+        note: input.note,
+        existingLink: null,
+      });
+    } catch (error) {
+      await this.db('workspaces').where({ id: teamWorkspace.id }).del();
+      await fs.rm(path.join(WORKSPACE_DIR, teamWorkspace.id), { recursive: true, force: true });
+      throw error;
+    }
+  }
+
+  private async createTeamWorkspace(
+    privateWorkspace: WorkspaceRecord,
+    userId: string,
+    input: {
+      teamId?: string;
+      selectedUserIds?: string[];
+      selectedRole?: WorkspaceNamedGrantRole;
+      name?: string;
+    },
+  ): Promise<WorkspaceRecord> {
     const teamWorkspaceId = uuidv4();
     const resolvedName = String(input.name || privateWorkspace.name).trim().slice(0, 255) || privateWorkspace.name;
     const slug = await this.generateUniqueSlug(resolvedName);
+    const selectedUserIds = normalizeSelectedWorkspaceUsers(userId, input.selectedUserIds);
+    const selectedRole = input.selectedRole || 'viewer';
+    const legacyRole = namedGrantToLegacyWorkspaceRole(selectedRole);
 
     await this.db.transaction(async (tx) => {
       await tx('workspaces').insert({
@@ -423,7 +580,7 @@ export class WorkspacePublicationService {
         visibility: 'team',
         workspaceType: 'team',
         editingPolicy: 'review',
-        teamId: input.teamId,
+        teamId: input.teamId || null,
         contentRevision: 0,
       });
       await tx('workspace_members').insert({
@@ -432,25 +589,41 @@ export class WorkspacePublicationService {
         role: 'owner',
         canEdit: false,
       });
+      if (selectedUserIds.length) {
+        await tx('workspace_members').insert(selectedUserIds.map((selectedUserId) => ({
+          workspaceId: teamWorkspaceId,
+          userId: selectedUserId,
+          role: legacyRole,
+          canEdit: false,
+        })));
+        await tx('workspace_user_grants').insert(selectedUserIds.map((selectedUserId) => ({
+          workspaceId: teamWorkspaceId,
+          userId: selectedUserId,
+          role: selectedRole,
+          grantedByUserId: userId,
+        })));
+      }
+      if (input.teamId) {
+        await tx('workspace_team_grants').insert({
+          workspaceId: teamWorkspaceId,
+          teamId: input.teamId,
+          role: 'viewer',
+          grantedByUserId: userId,
+        });
+      }
     });
 
     const teamWorkspace = await this.db<WorkspaceRecord>('workspaces').where({ id: teamWorkspaceId }).first();
     if (!teamWorkspace) {
       throw new NotFoundError('Team workspace was not created');
     }
+    return teamWorkspace;
+  }
 
-    try {
-      return await this.createPublishedVersion({
-        privateWorkspace,
-        teamWorkspace,
-        userId,
-        note: input.note,
-        existingLink: null,
-      });
-    } catch (error) {
-      await this.db('workspaces').where({ id: teamWorkspaceId }).del();
-      await fs.rm(path.join(WORKSPACE_DIR, teamWorkspaceId), { recursive: true, force: true });
-      throw error;
+  private async ensureRegisteredUsers(userIds: string[]): Promise<void> {
+    const rows = await this.db('users').select('id').whereIn('id', userIds);
+    if (rows.length !== userIds.length) {
+      throw new NotFoundError('One or more selected users were not found');
     }
   }
 
@@ -502,6 +675,7 @@ export class WorkspacePublicationService {
         }
         if (
           currentLink
+          && lockedTeam.currentPublishedVersionId
           && !currentLink.hasUnpublishedChanges
           && Number(currentPrivate?.contentRevision || 0) === Number(currentLink.basePrivateContentRevision || 0)
         ) {
@@ -539,6 +713,35 @@ export class WorkspacePublicationService {
               manifest,
             })
             .returning('*');
+          if (!input.existingLink) {
+            await tx('audit_events').insert({
+              id: uuidv4(),
+              actorUserId: input.userId,
+              actorRole: 'workspace_owner',
+              action: 'workspace.promoted',
+              resourceType: 'workspace',
+              resourceId: lockedTeam.id,
+              metadata: {
+                sourcePrivateWorkspaceId: input.privateWorkspace.id,
+                audience: lockedTeam.teamId ? 'team' : 'selected_people',
+                teamId: lockedTeam.teamId || null,
+                editingPolicy: lockedTeam.editingPolicy || 'review',
+              },
+            });
+          }
+          await tx('audit_events').insert({
+            id: uuidv4(),
+            actorUserId: input.userId,
+            actorRole: 'workspace_owner_or_publisher',
+            action: 'workspace.version_published',
+            resourceType: 'workspace',
+            resourceId: lockedTeam.id,
+            metadata: {
+              publishedVersionId: version.id,
+              versionNumber: Number(version.versionNumber),
+              sourcePrivateWorkspaceId: input.privateWorkspace.id,
+            },
+          });
           await this.freezeWorkspaceSkillPins(
             tx,
             input.privateWorkspace.id,
@@ -595,72 +798,29 @@ export class WorkspacePublicationService {
     }
   }
 
-  private async ensureCurrentVersion(
-    teamWorkspace: WorkspaceRecord,
-    userId: string,
-  ): Promise<PublishedVersionRecord> {
-    if (teamWorkspace.currentPublishedVersionId) {
-      return this.getPublishedVersion(teamWorkspace.currentPublishedVersionId, teamWorkspace.id);
-    }
-
-    // Legacy shared workspaces are frozen as team workspaces during migration.
-    // Their first immutable version is created lazily when publication features are used.
-    const content = await this.readWorkspaceContent(teamWorkspace.id);
-    const versionId = uuidv4();
-    const manifest = await this.writeVersionSnapshot(versionId, content);
-    const publisherUserId = teamWorkspace.ownerId || userId;
-    try {
-      const result = await this.db.transaction(async (tx) => {
-        const lockedTeam = await tx<WorkspaceRecord>('workspaces')
-          .where({ id: teamWorkspace.id })
-          .forUpdate()
-          .first();
-        if (!lockedTeam) {
-          throw new NotFoundError('Team workspace not found');
-        }
-        if (lockedTeam.currentPublishedVersionId) {
-          const current = await tx<PublishedVersionRecord>('workspace_published_versions')
-            .where({ id: lockedTeam.currentPublishedVersionId, teamWorkspaceId: lockedTeam.id })
-            .first();
-          if (!current) {
-            throw new NotFoundError('Current published version not found');
-          }
-          return { version: current, created: false };
-        }
-
-        const [version] = await tx<PublishedVersionRecord>('workspace_published_versions')
-          .insert({
-            id: versionId,
-            teamWorkspaceId: lockedTeam.id,
-            versionNumber: 1,
-            sourcePrivateWorkspaceId: null,
-            publisherUserId,
-            note: 'Initial published version',
-            manifest,
-          })
-          .returning('*');
-        await this.freezeWorkspaceSkillPins(tx, lockedTeam.id, lockedTeam.id, version.id);
-        await tx('workspaces')
-          .where({ id: lockedTeam.id })
-          .update({ currentPublishedVersionId: version.id });
-        return { version, created: true };
-      });
-      if (!result.created) {
-        await fs.rm(this.versionDirectory(versionId), { recursive: true, force: true });
-      }
-      return result.version;
-    } catch (error) {
-      await fs.rm(this.versionDirectory(versionId), { recursive: true, force: true });
-      throw error;
-    }
-  }
-
   private async freezeWorkspaceSkillPins(
     tx: Knex.Transaction,
     sourceWorkspaceId: string,
     teamWorkspaceId: string,
     publishedVersionId: string,
   ): Promise<void> {
+    const pins = await this.copyValidatedWorkspaceSkillPins(tx, sourceWorkspaceId, teamWorkspaceId);
+    if (pins.length) {
+      await tx('published_version_skill_pins').insert(pins.map((pin: any) => ({
+        publishedVersionId,
+        skillId: pin.skillId,
+        skillVersionId: pin.skillVersionId,
+        semanticVersion: pin.semanticVersion,
+        manifestHash: pin.manifestHash,
+      })));
+    }
+  }
+
+  private async copyValidatedWorkspaceSkillPins(
+    tx: Knex.Transaction,
+    sourceWorkspaceId: string,
+    teamWorkspaceId: string,
+  ): Promise<any[]> {
     const pins = await tx('workspace_skill_pins as pin')
       .join('skills as skill', 'skill.id', 'pin.skillId')
       .join('skill_versions as version', 'version.id', 'pin.skillVersionId')
@@ -705,15 +865,7 @@ export class WorkspacePublicationService {
         })));
       }
     }
-    if (pins.length) {
-      await tx('published_version_skill_pins').insert(pins.map((pin: any) => ({
-        publishedVersionId,
-        skillId: pin.skillId,
-        skillVersionId: pin.skillVersionId,
-        semanticVersion: pin.semanticVersion,
-        manifestHash: pin.manifestHash,
-      })));
-    }
+    return pins;
   }
 
   private async restorePublishedSkillPins(

--- a/backend/src/services/workspaceService.ts
+++ b/backend/src/services/workspaceService.ts
@@ -7,6 +7,7 @@ import { S3Service } from './s3Service';
 import { UserContext } from '../types/user';
 import { AccessDeniedError, ConflictError, NotFoundError } from '../errors';
 import { resolveWorkspaceRoot } from '../config/workspaceRoot';
+import { legacyWorkspaceRoleToNamedGrant } from './workspaceAudiencePolicy';
 
 const WORKSPACE_DIR = resolveWorkspaceRoot();
 
@@ -76,6 +77,7 @@ export class WorkspaceService {
     canEdit: boolean;
     canPublish: boolean;
     teamName?: string | null;
+    audienceType: 'private' | 'selected_people' | 'team';
     publicationStatus: 'private_draft' | 'up_to_date' | 'changes_to_publish' | 'team_updates_available' | 'review_needed';
     linkedTeamWorkspaceId?: string | null;
     privateCopyWorkspaceId?: string | null;
@@ -172,10 +174,15 @@ export class WorkspaceService {
         && row.linkedTeamWorkspaceId
         && linkedTeamAccessible
         && String(row.linkedTeamCurrentPublishedVersionId || '') !== String(row.basePublishedVersionId || '');
+      const needsInitialPublication = visibility === 'private'
+        && Boolean(row.linkedTeamWorkspaceId)
+        && !row.linkedTeamCurrentPublishedVersionId;
       const publicationStatus = visibility === 'team'
         ? 'up_to_date'
         : !row.linkedTeamWorkspaceId
           ? 'private_draft'
+          : needsInitialPublication
+            ? 'changes_to_publish'
           : privateChanged && teamChanged
             ? 'review_needed'
             : privateChanged
@@ -206,6 +213,7 @@ export class WorkspaceService {
             )
           : row.directRole === 'owner' || row.directRole === 'editor',
         teamName: row.teamName || null,
+        audienceType: visibility === 'private' ? 'private' : row.teamId ? 'team' : 'selected_people',
         publicationStatus,
         linkedTeamWorkspaceId: row.linkedTeamWorkspaceId || null,
         privateCopyWorkspaceId: row.privateCopyWorkspaceId || null,
@@ -457,23 +465,30 @@ export class WorkspaceService {
     }
 
     const canEdit = false;
-    const existing = await this.db('workspace_members').where({ workspaceId, userId: targetUserId }).first();
-    if (existing) {
-      await this.db('workspace_members')
-        .where({ workspaceId, userId: targetUserId })
-        .update({
-          role,
-          canEdit,
-          updatedAt: this.db.fn.now(),
-        });
-      return;
-    }
-
-    await this.db('workspace_members').insert({
-      workspaceId,
-      userId: targetUserId,
-      role,
-      canEdit,
+    const grantRole = legacyWorkspaceRoleToNamedGrant(role);
+    await this.db.transaction(async (tx) => {
+      await tx('workspace_members')
+        .insert({ workspaceId, userId: targetUserId, role, canEdit })
+        .onConflict(['workspaceId', 'userId'])
+        .merge({ role, canEdit, updatedAt: tx.fn.now() });
+      await tx('workspace_user_grants')
+        .insert({
+          workspaceId,
+          userId: targetUserId,
+          role: grantRole,
+          grantedByUserId: actingUserId,
+        })
+        .onConflict(['workspaceId', 'userId'])
+        .merge({ role: grantRole, grantedByUserId: actingUserId, updatedAt: tx.fn.now() });
+      await tx('audit_events').insert({
+        id: uuidv4(),
+        actorUserId: actingUserId,
+        actorRole: 'workspace_owner',
+        action: 'workspace.access_granted',
+        resourceType: 'workspace',
+        resourceId: workspaceId,
+        metadata: { targetUserId, role: grantRole },
+      });
     });
   }
 
@@ -493,7 +508,19 @@ export class WorkspaceService {
       throw new AccessDeniedError('Cannot remove workspace owner');
     }
 
-    await this.db('workspace_members').where({ workspaceId, userId: targetUserId }).del();
+    await this.db.transaction(async (tx) => {
+      await tx('workspace_members').where({ workspaceId, userId: targetUserId }).del();
+      await tx('workspace_user_grants').where({ workspaceId, userId: targetUserId }).del();
+      await tx('audit_events').insert({
+        id: uuidv4(),
+        actorUserId: actingUserId,
+        actorRole: 'workspace_owner',
+        action: 'workspace.access_revoked',
+        resourceType: 'workspace',
+        resourceId: workspaceId,
+        metadata: { targetUserId, previousRole: legacyWorkspaceRoleToNamedGrant(target.role) },
+      });
+    });
   }
 
   async listCollaborators(

--- a/backend/tests/workspaceAudiencePolicy.test.ts
+++ b/backend/tests/workspaceAudiencePolicy.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  legacyWorkspaceRoleToNamedGrant,
+  namedGrantToLegacyWorkspaceRole,
+  normalizeSelectedWorkspaceUsers,
+} from '../src/services/workspaceAudiencePolicy';
+
+test('selected-person sharing excludes the owner and removes duplicates', () => {
+  assert.deepEqual(
+    normalizeSelectedWorkspaceUsers('owner-1', ['user-1', 'owner-1', 'user-1', 'user-2']),
+    ['user-1', 'user-2'],
+  );
+});
+
+test('named Publisher remains a direct legacy publishing role', () => {
+  assert.equal(namedGrantToLegacyWorkspaceRole('publisher'), 'editor');
+  assert.equal(legacyWorkspaceRoleToNamedGrant('editor'), 'publisher');
+});
+
+test('legacy roles map to the least-privileged governance grant', () => {
+  assert.equal(legacyWorkspaceRoleToNamedGrant('contributor'), 'contributor');
+  assert.equal(legacyWorkspaceRoleToNamedGrant('commenter'), 'viewer');
+  assert.equal(legacyWorkspaceRoleToNamedGrant('viewer'), 'viewer');
+});

--- a/frontend/src/components/WorkspaceCollaborationDialog.tsx
+++ b/frontend/src/components/WorkspaceCollaborationDialog.tsx
@@ -208,7 +208,9 @@ const WorkspaceCollaborationDialog = ({
         <Box>
           <Typography variant="h6">Notes, annotations & proposals</Typography>
           <Typography variant="caption" color="text.secondary">
-            Published version {workspace?.currentPublishedVersionNumber || '—'} stays read-only
+            {workspace?.currentPublishedVersionNumber == null
+              ? 'Shared files stay read-only until an immutable version is published'
+              : `Published version ${workspace.currentPublishedVersionNumber} stays read-only`}
           </Typography>
         </Box>
         <IconButton aria-label="close collaboration" onClick={onClose} size="small">

--- a/frontend/src/components/WorkspaceHistoryDialog.tsx
+++ b/frontend/src/components/WorkspaceHistoryDialog.tsx
@@ -74,32 +74,38 @@ const WorkspaceHistoryDialog: React.FC<WorkspaceHistoryDialogProps> = ({
             <CircularProgress size={28} />
           </Box>
         ) : (
-          <List disablePadding>
-            {versions.map((version, index) => (
-              <ListItem
-                key={version.id}
-                divider
-                secondaryAction={
-                  workspace?.role === 'owner' && index > 0 ? (
-                    <Button
-                      size="small"
-                      disabled={Boolean(restoreId)}
-                      onClick={() => void handleRestore(version)}
-                    >
-                      {restoreId === version.id ? 'Restoring…' : 'Restore'}
-                    </Button>
-                  ) : undefined
-                }
-              >
-                <ListItemText
-                  primary={`Version ${version.versionNumber}${index === 0 ? ' · Current' : ''}`}
-                  secondary={`${version.publisherName} · ${new Date(version.createdAt).toLocaleString()}${
-                    version.note ? ` · ${version.note}` : ''
-                  }`}
-                />
-              </ListItem>
-            ))}
-          </List>
+          versions.length ? (
+            <List disablePadding>
+              {versions.map((version, index) => (
+                <ListItem
+                  key={version.id}
+                  divider
+                  secondaryAction={
+                    workspace?.role === 'owner' && index > 0 ? (
+                      <Button
+                        size="small"
+                        disabled={Boolean(restoreId)}
+                        onClick={() => void handleRestore(version)}
+                      >
+                        {restoreId === version.id ? 'Restoring…' : 'Restore'}
+                      </Button>
+                    ) : undefined
+                  }
+                >
+                  <ListItemText
+                    primary={`Version ${version.versionNumber}${index === 0 ? ' · Current' : ''}`}
+                    secondary={`${version.publisherName} · ${new Date(version.createdAt).toLocaleString()}${
+                      version.note ? ` · ${version.note}` : ''
+                    }`}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          ) : (
+            <Alert severity="info">
+              This workspace has been shared, but no immutable version has been published yet.
+            </Alert>
+          )
         )}
         {error ? <Alert severity="error" sx={{ mt: 2 }}>{error}</Alert> : null}
       </DialogContent>

--- a/frontend/src/components/WorkspaceList.tsx
+++ b/frontend/src/components/WorkspaceList.tsx
@@ -17,6 +17,7 @@ import {
   Lock,
   ManageAccounts,
   Publish,
+  Share,
   Sync,
 } from '@mui/icons-material';
 
@@ -69,8 +70,12 @@ const WorkspaceList: React.FC<WorkspaceListProps> = ({
 
     const actions = [
       canPublish && onPublishWorkspace ? {
-        label: status === 'private_draft' ? `Publish ${workspace.name} to team` : `Publish changes from ${workspace.name}`,
-        icon: <Publish fontSize="small" />,
+        label: status === 'private_draft'
+          ? `Share or publish ${workspace.name}`
+          : workspace.currentPublishedVersionNumber == null
+            ? `Publish the first version of ${workspace.name}`
+            : `Publish changes from ${workspace.name}`,
+        icon: status === 'private_draft' ? <Share fontSize="small" /> : <Publish fontSize="small" />,
         onClick: () => onPublishWorkspace(workspace),
       } : null,
       canSync && onSyncWorkspace ? {
@@ -149,7 +154,7 @@ const WorkspaceList: React.FC<WorkspaceListProps> = ({
             secondary={
               isPrivate
                 ? STATUS_LABELS[status]
-                : `${workspace.teamName || 'Team'}${workspace.latestPublisherName
+                : `${workspace.teamName || (workspace.audienceType === 'selected_people' ? 'Selected people' : 'Team')}${workspace.latestPublisherName
                   ? ` · ${workspace.latestPublisherName}`
                   : ''}`
             }

--- a/frontend/src/components/WorkspacePublishDialog.tsx
+++ b/frontend/src/components/WorkspacePublishDialog.tsx
@@ -1,16 +1,21 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   Alert,
+  Autocomplete,
   Box,
   Button,
+  Chip,
   CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   FormControl,
+  FormControlLabel,
   InputLabel,
   MenuItem,
+  Radio,
+  RadioGroup,
   Select,
   TextField,
   Typography,
@@ -18,8 +23,13 @@ import {
 
 import type { Workspace } from '../types';
 import {
+  fetchUserDirectory,
   listWorkspaceTeams,
   publishWorkspace,
+  shareWorkspaceWithSelectedPeople,
+  type DirectoryUser,
+  type WorkspaceAudienceAction,
+  type WorkspaceNamedGrantRole,
   type WorkspaceTeam,
 } from '../services/workspaceApi';
 
@@ -31,6 +41,21 @@ type WorkspacePublishDialogProps = {
   onPublished: () => void | Promise<void>;
 };
 
+const ACTION_COPY: Record<WorkspaceAudienceAction, { title: string; description: string }> = {
+  share_selected: {
+    title: 'Share privately',
+    description: 'Create a Team Workspace visible only to selected people. No immutable version is published yet.',
+  },
+  publish_selected: {
+    title: 'Publish to selected people',
+    description: 'Create a Team Workspace for named people and publish its first immutable version.',
+  },
+  publish_team: {
+    title: 'Publish to team',
+    description: 'Create a Team Workspace for everyone in the selected team and publish its first immutable version.',
+  },
+};
+
 const WorkspacePublishDialog: React.FC<WorkspacePublishDialogProps> = ({
   open,
   workspace,
@@ -38,22 +63,38 @@ const WorkspacePublishDialog: React.FC<WorkspacePublishDialogProps> = ({
   onBeforePublish,
   onPublished,
 }) => {
+  const [action, setAction] = useState<WorkspaceAudienceAction>('share_selected');
   const [teams, setTeams] = useState<WorkspaceTeam[]>([]);
   const [teamId, setTeamId] = useState('');
+  const [selectedPeople, setSelectedPeople] = useState<DirectoryUser[]>([]);
+  const [peopleOptions, setPeopleOptions] = useState<DirectoryUser[]>([]);
+  const [peopleQuery, setPeopleQuery] = useState('');
+  const [peopleLoading, setPeopleLoading] = useState(false);
+  const [namedRole, setNamedRole] = useState<WorkspaceNamedGrantRole>('viewer');
   const [note, setNote] = useState('');
   const [loadingTeams, setLoadingTeams] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
   const firstPublication = !workspace?.linkedTeamWorkspaceId;
+  const firstImmutableVersion = workspace?.currentPublishedVersionNumber == null;
+  const selectedPeopleAction = firstPublication && action !== 'publish_team';
+  const publishesVersion = !firstPublication || action !== 'share_selected';
 
   useEffect(() => {
     if (!open) {
+      setAction('share_selected');
       setTeamId('');
+      setSelectedPeople([]);
+      setPeopleOptions([]);
+      setPeopleQuery('');
+      setNamedRole('viewer');
       setNote('');
       setError('');
-      return;
     }
-    if (!firstPublication) return;
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !firstPublication || action !== 'publish_team') return;
     setLoadingTeams(true);
     void listWorkspaceTeams()
       .then((items) => {
@@ -62,27 +103,72 @@ const WorkspacePublishDialog: React.FC<WorkspacePublishDialogProps> = ({
       })
       .catch((reason) => setError(reason instanceof Error ? reason.message : 'Failed to list teams'))
       .finally(() => setLoadingTeams(false));
-  }, [firstPublication, open]);
+  }, [action, firstPublication, open]);
 
-  const canPublish = useMemo(
-    () => Boolean(workspace && (!firstPublication || teamId) && !busy && !loadingTeams),
-    [busy, firstPublication, loadingTeams, teamId, workspace],
-  );
+  useEffect(() => {
+    if (!open || !selectedPeopleAction || peopleQuery.trim().length < 2) {
+      setPeopleOptions([]);
+      setPeopleLoading(false);
+      return;
+    }
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      setPeopleLoading(true);
+      void fetchUserDirectory(peopleQuery.trim())
+        .then((users) => {
+          if (!cancelled) setPeopleOptions(users);
+        })
+        .catch(() => {
+          if (!cancelled) setPeopleOptions([]);
+        })
+        .finally(() => {
+          if (!cancelled) setPeopleLoading(false);
+        });
+    }, 300);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [open, peopleQuery, selectedPeopleAction]);
 
-  const handlePublish = async () => {
-    if (!workspace || !canPublish) return;
+  const canSubmit = useMemo(() => {
+    if (!workspace || busy) return false;
+    if (!firstPublication) return true;
+    if (action === 'publish_team') return Boolean(teamId) && !loadingTeams;
+    return selectedPeople.length > 0 && !peopleLoading;
+  }, [action, busy, firstPublication, loadingTeams, peopleLoading, selectedPeople.length, teamId, workspace]);
+
+  const handleSubmit = async () => {
+    if (!workspace || !canSubmit) return;
     setBusy(true);
     setError('');
     try {
       await onBeforePublish?.(workspace);
-      await publishWorkspace(workspace.id, {
-        ...(firstPublication ? { teamId } : {}),
-        note: note.trim() || undefined,
-      });
+      if (firstPublication && action === 'share_selected') {
+        await shareWorkspaceWithSelectedPeople(workspace.id, {
+          userIds: selectedPeople.map((person) => person.id),
+          role: namedRole,
+        });
+      } else if (firstPublication && action === 'publish_selected') {
+        await publishWorkspace(workspace.id, {
+          audience: 'selected_people',
+          userIds: selectedPeople.map((person) => person.id),
+          role: namedRole,
+          note: note.trim() || undefined,
+        });
+      } else if (firstPublication) {
+        await publishWorkspace(workspace.id, {
+          audience: 'team',
+          teamId,
+          note: note.trim() || undefined,
+        });
+      } else {
+        await publishWorkspace(workspace.id, { note: note.trim() || undefined });
+      }
       await onPublished();
       onClose();
     } catch (reason) {
-      setError(reason instanceof Error ? reason.message : 'Failed to publish workspace');
+      setError(reason instanceof Error ? reason.message : 'Failed to update workspace sharing');
     } finally {
       setBusy(false);
     }
@@ -90,14 +176,93 @@ const WorkspacePublishDialog: React.FC<WorkspacePublishDialogProps> = ({
 
   return (
     <Dialog open={open} onClose={busy ? undefined : onClose} fullWidth maxWidth="sm">
-      <DialogTitle>{firstPublication ? 'Publish to team' : 'Publish changes'}</DialogTitle>
+      <DialogTitle>
+        {firstPublication ? 'Share or publish workspace' : firstImmutableVersion ? 'Publish first version' : 'Publish changes'}
+      </DialogTitle>
       <DialogContent dividers>
         <Typography variant="body2" sx={{ mb: 2 }}>
-          Publish a stable version of <strong>{workspace?.name}</strong>. Your private workspace remains visible only
-          to you.
+          {firstPublication ? (
+            <>Choose who can access <strong>{workspace?.name}</strong> and whether to publish an immutable version.</>
+          ) : firstImmutableVersion ? (
+            <>Publish the first immutable version of <strong>{workspace?.name}</strong>.</>
+          ) : (
+            <>Publish the latest private changes from <strong>{workspace?.name}</strong>.</>
+          )}
         </Typography>
 
         {firstPublication ? (
+          <RadioGroup
+            value={action}
+            onChange={(event) => {
+              setAction(event.target.value as WorkspaceAudienceAction);
+              setError('');
+            }}
+            sx={{ gap: 1, mb: 2 }}
+          >
+            {(Object.keys(ACTION_COPY) as WorkspaceAudienceAction[]).map((value) => (
+              <Box key={value} sx={{ border: 1, borderColor: 'divider', borderRadius: 2, px: 1.5, py: 0.75 }}>
+                <FormControlLabel
+                  value={value}
+                  control={<Radio size="small" />}
+                  label={<Typography variant="subtitle2">{ACTION_COPY[value].title}</Typography>}
+                />
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', pl: 4 }}>
+                  {ACTION_COPY[value].description}
+                </Typography>
+              </Box>
+            ))}
+          </RadioGroup>
+        ) : null}
+
+        {selectedPeopleAction ? (
+          <>
+            <Autocomplete
+              multiple
+              options={peopleOptions}
+              value={selectedPeople}
+              inputValue={peopleQuery}
+              onInputChange={(_event, value) => setPeopleQuery(value)}
+              onChange={(_event, value) => setSelectedPeople(value)}
+              getOptionLabel={(person) => person.email
+                ? `${person.displayName} (${person.email})`
+                : person.displayName}
+              isOptionEqualToValue={(left, right) => left.id === right.id}
+              filterOptions={(options) => options}
+              filterSelectedOptions
+              loading={peopleLoading}
+              renderTags={(value, getTagProps) => value.map((person, index) => (
+                <Chip {...getTagProps({ index })} key={person.id} size="small" label={person.displayName} />
+              ))}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Selected people"
+                  placeholder="Search registered users"
+                  helperText="Type at least 2 characters. Workspace access does not change Team membership."
+                />
+              )}
+              sx={{ mb: 2 }}
+            />
+            <FormControl fullWidth size="small" sx={{ mb: 2 }}>
+              <InputLabel id="named-workspace-role-label">Access role</InputLabel>
+              <Select
+                labelId="named-workspace-role-label"
+                label="Access role"
+                value={namedRole}
+                onChange={(event) => setNamedRole(event.target.value as WorkspaceNamedGrantRole)}
+              >
+                <MenuItem value="viewer">Viewer</MenuItem>
+                <MenuItem value="contributor">Contributor</MenuItem>
+                <MenuItem value="publisher">Publisher</MenuItem>
+              </Select>
+            </FormControl>
+            <Alert severity="info" sx={{ mb: 2 }}>
+              New shared workspaces use Review mode. Contributors cannot publish; Publisher is a direct named-user role.
+            </Alert>
+          </>
+        ) : null}
+
+        {firstPublication && action === 'publish_team' ? (
           loadingTeams ? (
             <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
               <CircularProgress size={26} />
@@ -118,33 +283,35 @@ const WorkspacePublishDialog: React.FC<WorkspacePublishDialogProps> = ({
             </FormControl>
           ) : (
             <Alert severity="info" sx={{ mb: 2 }}>
-              You need to belong to a team before you can publish this workspace.
+              You need to belong to a team before publishing to that team. You can still share or publish to selected people.
             </Alert>
           )
         ) : null}
 
-        <TextField
-          label="Publication note (optional)"
-          placeholder="Describe what changed"
-          value={note}
-          onChange={(event) => setNote(event.target.value)}
-          multiline
-          minRows={2}
-          fullWidth
-          inputProps={{ maxLength: 1000 }}
-          sx={{ mb: 2 }}
-        />
+        {publishesVersion ? (
+          <TextField
+            label="Publication note (optional)"
+            placeholder="Describe what changed"
+            value={note}
+            onChange={(event) => setNote(event.target.value)}
+            multiline
+            minRows={2}
+            fullWidth
+            inputProps={{ maxLength: 1000 }}
+            sx={{ mb: 2 }}
+          />
+        ) : null}
 
         <Alert severity="info">
-          Files, folders, and visible workspace artifacts will be published. Conversations, agent activity,
-          schedules, connections, credentials, and personal settings stay private.
+          Your Private Workspace remains owner-only. Sharing creates a separate Team Workspace. Conversations, agent
+          activity, schedules, connections, credentials, and personal settings stay private.
         </Alert>
         {error ? <Alert severity="error" sx={{ mt: 2 }}>{error}</Alert> : null}
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} disabled={busy}>Cancel</Button>
-        <Button variant="contained" onClick={() => void handlePublish()} disabled={!canPublish}>
-          {busy ? <CircularProgress size={18} color="inherit" /> : 'Publish'}
+        <Button variant="contained" onClick={() => void handleSubmit()} disabled={!canSubmit}>
+          {busy ? <CircularProgress size={18} color="inherit" /> : publishesVersion ? 'Publish' : 'Share'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/frontend/src/components/chat/AgentChatPane.tsx
+++ b/frontend/src/components/chat/AgentChatPane.tsx
@@ -317,7 +317,7 @@ export default function AgentChatPane({
                   ? 'border-violet-900/60 bg-violet-950/30 text-violet-200'
                   : 'border-violet-100 bg-violet-50 text-violet-700'
               }`}>
-                Private with Lumo is visible only to you. Lumo may analyze published files, but cannot edit them.
+                Private with Lumo is visible only to you. Lumo may analyze shared files, but cannot edit them.
               </div>
             ) : null}
             <ChatLayout
@@ -329,7 +329,7 @@ export default function AgentChatPane({
                   chatMessage={chatMessage}
                   chatAttachments={chatAttachments}
                   placeholder={isPublishedWorkspace
-                    ? 'Ask Lumo about this published workspace…'
+                    ? 'Ask Lumo about this shared workspace…'
                     : undefined}
                   chatInputRef={chatInputRef}
                   attachmentInputRef={attachmentInputRef}
@@ -373,7 +373,7 @@ export default function AgentChatPane({
                 isStreaming={isStreaming}
                 personaDisplayName={personaDisplayName}
                 emptyStateDescription={isPublishedWorkspace
-                  ? 'Ask Lumo to explain, summarize, or analyze the published workspace without changing it.'
+                  ? 'Ask Lumo to explain, summarize, or analyze the shared workspace without changing it.'
                   : undefined}
                 messageBubbleMaxWidth={messageBubbleMaxWidth}
                 markdownComponents={markdownComponents}

--- a/frontend/src/components/chat/PublishedWorkspaceChatHeader.tsx
+++ b/frontend/src/components/chat/PublishedWorkspaceChatHeader.tsx
@@ -75,7 +75,7 @@ export default function PublishedWorkspaceChatHeader({
               onChange={(value) => {
                 if (value === 'team' || value === 'private') onModeChange(value);
               }}
-              label="Published workspace conversation mode"
+              label="Shared workspace conversation mode"
               size="sm"
             >
               <ToggleButton
@@ -92,7 +92,7 @@ export default function PublishedWorkspaceChatHeader({
           ) : null}
         </div>
         {isAgentPaneVisible ? (
-          <ButtonGroup label="Published workspace chat actions" size="sm">
+          <ButtonGroup label="Shared workspace chat actions" size="sm">
             <IconButton
               label="Collaboration board"
               icon={<StickyNote size={15} />}

--- a/frontend/src/components/chat/WorkspaceTeamChatPanel.tsx
+++ b/frontend/src/components/chat/WorkspaceTeamChatPanel.tsx
@@ -277,7 +277,7 @@ export default function WorkspaceTeamChatPanel({
     const isActionsOpen = actionMessageId === message.id;
     const publishedVersion = message.originVersionNumber
       ? `Published v${message.originVersionNumber}`
-      : 'Published version';
+      : 'Shared workspace';
     return (
       <article
         key={message.id}
@@ -474,7 +474,7 @@ export default function WorkspaceTeamChatPanel({
               }`}>
                 <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-violet-500">
                   <Bot size={16} />
-                  Lumo is checking the published workspace
+                  Lumo is checking the shared workspace
                 </div>
                 <ChatToolCalls
                   calls={[{
@@ -483,7 +483,7 @@ export default function WorkspaceTeamChatPanel({
                     status: 'running',
                     target: workspace.currentPublishedVersionNumber
                       ? `Published v${workspace.currentPublishedVersionNumber}`
-                      : 'Published version',
+                      : 'Shared workspace',
                     node: 'read-only',
                   }]}
                 />

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -7207,7 +7207,11 @@ export default function WorkspacePage() {
                     : 'bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
                 }`}
               >
-                {selectedWorkspace.publicationStatus === 'private_draft' ? 'Publish to team' : 'Publish changes'}
+                {selectedWorkspace.publicationStatus === 'private_draft'
+                  ? 'Share or publish'
+                  : selectedWorkspace.currentPublishedVersionNumber == null
+                    ? 'Publish first version'
+                    : 'Publish changes'}
               </button>
             ) : null}
       </header>
@@ -7220,7 +7224,9 @@ export default function WorkspacePage() {
                 ? 'border-sky-900/60 bg-sky-950/40 text-sky-200'
                 : 'border-blue-100 bg-blue-50 text-blue-700'
             }`}>
-              Published files are read-only. Chat can analyze them; propose changes from a private copy.
+              {selectedWorkspace.currentPublishedVersionNumber == null
+                ? 'Shared files are read-only. Chat can analyze them; propose changes from a private copy.'
+                : 'Published files are read-only. Chat can analyze them; propose changes from a private copy.'}
             </div>
           ) : null}
           <ChatMessageList
@@ -7400,7 +7406,8 @@ export default function WorkspacePage() {
                       <span className={`block truncate text-[10px] ${
                         isDarkMode ? 'text-slate-500' : 'text-slate-500'
                       }`}>
-                        {workspace.teamName || 'Team workspace'}
+                        {workspace.teamName
+                          || (workspace.audienceType === 'selected_people' ? 'Selected people' : 'Team workspace')}
                       </span>
                     </span>
                     {selectedWorkspace?.id === workspace.id ? <Check size={15} className="shrink-0" /> : null}

--- a/frontend/src/services/workspaceApi.ts
+++ b/frontend/src/services/workspaceApi.ts
@@ -139,6 +139,9 @@ export type WorkspaceTeam = {
   name: string;
 };
 
+export type WorkspaceAudienceAction = 'share_selected' | 'publish_selected' | 'publish_team';
+export type WorkspaceNamedGrantRole = 'publisher' | 'contributor' | 'viewer';
+
 export type PublicationConflict = {
   path: string;
   privateChange: 'added' | 'changed' | 'deleted';
@@ -167,7 +170,14 @@ export const listWorkspaceTeams = async (): Promise<WorkspaceTeam[]> => {
 
 export const publishWorkspace = async (
   workspaceId: string,
-  payload: { teamId?: string; name?: string; note?: string },
+  payload: {
+    audience?: 'team' | 'selected_people';
+    teamId?: string;
+    userIds?: string[];
+    role?: WorkspaceNamedGrantRole;
+    name?: string;
+    note?: string;
+  },
 ) => {
   const response = await apiFetch(`${API_URL}/workspaces/${workspaceId}/publish`, {
     method: 'POST',
@@ -183,6 +193,25 @@ export const publishWorkspace = async (
     publishedVersionId: string;
     publishedVersionNumber: number;
     publishedAt: string;
+  }>;
+};
+
+export const shareWorkspaceWithSelectedPeople = async (
+  workspaceId: string,
+  payload: { userIds: string[]; role?: WorkspaceNamedGrantRole; name?: string },
+) => {
+  const response = await apiFetch(`${API_URL}/workspaces/${workspaceId}/share`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    return throwWorkspaceApiError(response, 'Failed to share workspace');
+  }
+  return response.json() as Promise<{
+    teamWorkspaceId: string;
+    privateWorkspaceId: string;
+    sharedWithUserIds: string[];
   }>;
 };
 

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -7,6 +7,7 @@ export interface Workspace {
   canEdit?: boolean;
   canPublish?: boolean;
   visibility?: 'private' | 'team';
+  audienceType?: 'private' | 'selected_people' | 'team';
   teamId?: string | null;
   teamName?: string | null;
   publicationStatus?:


### PR DESCRIPTION
## Summary

- add private sharing to selected people without implicit publication
- add publication to selected people or a whole team
- preserve owner-only private workspaces, direct grants, review mode, and audit events
- keep immutable publication explicit across chat, history, and private-copy flows

## Validation

- backend TypeScript check
- backend test suite: 145 tests, 131 passed, 14 skipped
- frontend production build
- targeted frontend ESLint: no errors