### PR TITLE
Fix slide runs and chat appearance

### DIFF
--- a/agent/helpudoc_agent/tools/workspace/builtins/skills.py
+++ b/agent/helpudoc_agent/tools/workspace/builtins/skills.py
@@ -34,6 +34,47 @@ MAX_SKILL_ASSET_MANIFEST_ITEMS = 40
 MAX_DATA_WORKSPACE_QUERIES_PER_TURN = 10
 
 
+def _skill_sandbox_error(
+    error_code: str,
+    message: str,
+    suggested_next_call: str,
+) -> str:
+    """Return a machine-readable, non-retryable sandbox failure.
+
+    The stream runtime only marks structured ``status=error`` tool results as
+    failures.  Plain-text failures look like successful tool completions and
+    invite the model to issue the same sandbox call again.
+    """
+    return json.dumps(
+        {
+            "status": "error",
+            "tool": "run_skill_python_script",
+            "message": str(message or "Skill sandbox execution failed.").strip(),
+            "errorCode": str(error_code or "SKILL_SANDBOX_EXECUTION_FAILED").strip(),
+            "retryable": False,
+            "suggestedNextCall": str(suggested_next_call).strip(),
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+
+
+def _sandbox_exception_error(exc: Exception, *, unavailable: bool = False) -> str:
+    message = str(exc).strip() or "Skill sandbox execution failed."
+    prefix = message.partition(":")[0].strip()
+    error_code = (
+        prefix
+        if prefix and prefix.replace("_", "").isalnum() and prefix.upper() == prefix
+        else "SKILL_SANDBOX_UNAVAILABLE" if unavailable
+        else "SKILL_SANDBOX_EXECUTION_BLOCKED"
+    )
+    return _skill_sandbox_error(
+        error_code,
+        message,
+        "Do not repeat the same sandbox call. Use outputs already produced, choose a different declared action, or report the blocker to the user.",
+    )
+
+
 def _data_workspace_action(args: List[str]) -> str:
     raw = ""
     if "--request-json" in args:
@@ -317,9 +358,9 @@ def build_run_skill_python_script_tool(settings: Settings, workspace_state: Work
                 timeout_seconds=timeout_seconds,
             )
         except SandboxUnavailableError as exc:
-            return str(exc)
+            return _sandbox_exception_error(exc, unavailable=True)
         except SandboxExecutionError as exc:
-            return f"Skill sandbox execution blocked: {exc}"
+            return _sandbox_exception_error(exc)
         lines = [
             "SKILL_SANDBOX_INLINE_RUN_COMPLETED",
             f"Run ID: {result.run_id}",
@@ -352,22 +393,32 @@ def build_run_skill_python_script_tool(settings: Settings, workspace_state: Work
         """Run a declared Python script, or inline Python, from the active skill in the sandbox."""
         blocked = tagged_files_mode_guard(workspace_state.context, "run_skill_python_script")
         if blocked:
-            return blocked
+            return _skill_sandbox_error(
+                "TAGGED_FILE_POLICY_BLOCKED",
+                blocked,
+                "Do not repeat the same sandbox call. Use only the tagged files allowed for this task or explain the policy blocker.",
+            )
         has_script = bool(str(script_name or "").strip())
         has_inline = bool(str(inline_code or "").strip())
         if has_script and has_inline:
-            return (
-                "SKILL_SANDBOX_REQUEST_INVALID\n"
-                "Provide exactly one of script_name or inline_code, not both."
+            return _skill_sandbox_error(
+                "SKILL_SANDBOX_REQUEST_INVALID",
+                "Provide exactly one of script_name or inline_code, not both.",
+                "Correct the arguments once; do not repeat this invalid call.",
             )
         if not has_script and not has_inline:
-            return (
-                "SKILL_SANDBOX_REQUEST_INVALID\n"
-                "Provide exactly one of script_name or inline_code."
+            return _skill_sandbox_error(
+                "SKILL_SANDBOX_REQUEST_INVALID",
+                "Provide exactly one of script_name or inline_code.",
+                "Provide one valid execution mode once; do not repeat this invalid call.",
             )
         if has_inline:
             if args:
-                return "SKILL_SANDBOX_REQUEST_INVALID\nargs is only valid with script_name."
+                return _skill_sandbox_error(
+                    "SKILL_SANDBOX_REQUEST_INVALID",
+                    "args is only valid with script_name.",
+                    "Remove args from the inline call; do not repeat this invalid call.",
+                )
             return _run_inline(
                 inline_code=str(inline_code),
                 input_paths=input_paths or [],
@@ -375,9 +426,10 @@ def build_run_skill_python_script_tool(settings: Settings, workspace_state: Work
                 timeout_seconds=timeout_seconds,
             )
         if output_paths or timeout_seconds is not None:
-            return (
-                "SKILL_SANDBOX_REQUEST_INVALID\n"
-                "output_paths and timeout_seconds are only valid with inline_code."
+            return _skill_sandbox_error(
+                "SKILL_SANDBOX_REQUEST_INVALID",
+                "output_paths and timeout_seconds are only valid with inline_code.",
+                "Remove inline-only arguments from the declared-script call; do not repeat this invalid call.",
             )
         script_name = _canonical_declared_script_name(workspace_state, str(script_name))
         effective_args = list(args or [])
@@ -392,10 +444,10 @@ def build_run_skill_python_script_tool(settings: Settings, workspace_state: Work
                 workspace_state.context.get("_native_dashboard_builder_executions") or 0
             )
             if execution_count >= 1:
-                return (
-                    "NATIVE_DASHBOARD_BUILDER_DUPLICATE_BLOCKED\n"
-                    "The native dashboard builder already executed once for this task. "
-                    "Do not call it again."
+                return _skill_sandbox_error(
+                    "NATIVE_DASHBOARD_BUILDER_DUPLICATE_BLOCKED",
+                    "The native dashboard builder already executed once for this task.",
+                    "Use the dashboard output already produced; do not call the builder again.",
                 )
             approved_output_path = str(
                 workspace_state.context.get("host_dashboard_output_path") or ""
@@ -474,11 +526,10 @@ def build_run_skill_python_script_tool(settings: Settings, workspace_state: Work
                 workspace_state.context.get("_data_workspace_query_executions") or 0
             )
             if query_count >= MAX_DATA_WORKSPACE_QUERIES_PER_TURN:
-                return (
-                    "DATA_WORKSPACE_QUERY_LIMIT_REACHED\n"
-                    f"This task already executed {MAX_DATA_WORKSPACE_QUERIES_PER_TURN} "
-                    "bounded data_workspace queries. Use the existing results or explain "
-                    "that the analysis limit was reached."
+                return _skill_sandbox_error(
+                    "DATA_WORKSPACE_QUERY_LIMIT_REACHED",
+                    f"This task already executed {MAX_DATA_WORKSPACE_QUERIES_PER_TURN} bounded data_workspace queries.",
+                    "Use the existing results or explain that the analysis limit was reached; do not query again.",
                 )
         try:
             result = run_declared_skill_python_script(
@@ -490,9 +541,9 @@ def build_run_skill_python_script_tool(settings: Settings, workspace_state: Work
                 args=effective_args,
             )
         except SandboxUnavailableError as exc:
-            return str(exc)
+            return _sandbox_exception_error(exc, unavailable=True)
         except SandboxExecutionError as exc:
-            return f"Skill sandbox execution blocked: {exc}"
+            return _sandbox_exception_error(exc)
         if data_workspace_action in {"query", "export"}:
             workspace_state.context["_data_workspace_query_executions"] = (
                 int(workspace_state.context.get("_data_workspace_query_executions") or 0) + 1

--- a/backend/src/services/agent-runs/lifecycle.ts
+++ b/backend/src/services/agent-runs/lifecycle.ts
@@ -3238,6 +3238,7 @@ async function runAgentRunWorker(
   let processingQueue: Promise<void> = Promise.resolve();
   let activeToolCalls = 0;
   let lastRealActivityAt = Date.now();
+  const skillSandboxFailureCounts = new Map<string, number>();
   let assistantText = '';
   let thinkingText = '';
   let conversationRunPolicy: ConversationRunPolicy | undefined;
@@ -3882,6 +3883,7 @@ async function runAgentRunWorker(
       }
     }
     if (parsed?.type === 'tool_start' || parsed?.type === 'tool_end' || parsed?.type === 'tool_error') {
+      let repeatedSkillSandboxFailure = '';
       if (parsed.type === 'tool_start') {
         activeToolCalls += 1;
         toolCallCount += 1;
@@ -3895,6 +3897,15 @@ async function runAgentRunWorker(
       if (parsed.type === 'tool_error') {
         activeToolCalls = Math.max(0, activeToolCalls - 1);
         toolErrorCount += 1;
+        if (parsed.name === 'run_skill_python_script') {
+          const signature = `${coerceText(parsed.name).trim()}\u0000${coerceText(parsed.content).trim()}`;
+          const failureCount = (skillSandboxFailureCounts.get(signature) || 0) + 1;
+          skillSandboxFailureCounts.set(signature, failureCount);
+          if (failureCount >= 2) {
+            repeatedSkillSandboxFailure =
+              'Agent stopped because the skill sandbox returned the same terminal error twice. Retrying the same request cannot succeed.';
+          }
+        }
       }
       if (parsed.type === 'tool_end') {
         activeToolCalls = Math.max(0, activeToolCalls - 1);
@@ -3928,6 +3939,18 @@ async function runAgentRunWorker(
             error: safeErrorForLog(telemetryError),
           });
         }
+      }
+      if (repeatedSkillSandboxFailure) {
+        loopErrorMessage = repeatedSkillSandboxFailure;
+        await appendStreamEvent(
+          runId,
+          JSON.stringify(normalizeInterruptPayloadRecord(parsed)),
+        );
+        await appendStreamEvent(runId, JSON.stringify({ type: 'error', message: loopErrorMessage }));
+        if (upstream && !upstream.destroyed) {
+          upstream.destroy();
+        }
+        return 'stop';
       }
     }
     if (parsed?.type === 'tool_end' && parsed.name === 'workflow_action') {

--- a/frontend/src/components/chat/AgentChatPane.tsx
+++ b/frontend/src/components/chat/AgentChatPane.tsx
@@ -293,11 +293,8 @@ export default function AgentChatPane({
           isAgentPaneVisible={isAgentPaneVisible}
           isAgentPaneFullScreen={isAgentPaneFullScreen}
           mode={sharedMode}
-          personas={personas}
-          selectedPersona={selectedPersona}
           onToggleVisibility={onToggleAgentPaneVisibility}
           onModeChange={handleSharedModeChange}
-          onPersonaChange={onModeChange}
           onToggleHistory={onToggleHistory}
           onNewChat={onNewChat}
           onOpenCollaboration={onOpenCollaboration || (() => undefined)}

--- a/frontend/src/components/chat/ChatInputArea.tsx
+++ b/frontend/src/components/chat/ChatInputArea.tsx
@@ -190,9 +190,9 @@ export default function ChatInputArea({
               </div>
             </ChatComposerDrawer>
           ) : undefined}
-          headerContext={isStreaming || isPreparingAttachments ? (
+          headerContext={isPreparingAttachments ? (
             <span className="lumo-composer-status" role="status" aria-live="polite">
-              {isStreaming ? 'Working' : 'Preparing context…'}
+              Preparing context…
             </span>
           ) : undefined}
           input={(

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -1869,7 +1869,11 @@ export default function ChatMessageBubble({
   const toolExpandedClassName = isDarkMode
     ? 'mt-3 space-y-3 text-xs text-slate-200'
     : 'mt-3 space-y-3 text-xs text-slate-600';
-  const userPathPillClassName = 'inline-flex max-w-full items-center gap-1.5 rounded-full border border-white/20 bg-white/10 px-2.5 py-1 text-xs font-medium text-white';
+  const userPathPillClassName = `inline-flex max-w-full items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium ${
+    isDarkMode
+      ? 'border-white/20 bg-white/10 text-white'
+      : 'border-sky-900/15 bg-white/45 text-sky-950'
+  }`;
   const userBubbleClassName = 'lumo-user-content';
   const messageActionBarClassName = 'lumo-message-actions';
   const messageActionButtonClassName = 'lumo-message-action-button';

--- a/frontend/src/components/chat/PublishedWorkspaceChatHeader.tsx
+++ b/frontend/src/components/chat/PublishedWorkspaceChatHeader.tsx
@@ -9,17 +9,12 @@ import {
   ChevronRight,
   Eye,
   History,
-  Lock,
   Maximize2,
   MessageSquareText,
   Minimize2,
   Plus,
   StickyNote,
 } from 'lucide-react';
-import type { ChangeEvent } from 'react';
-
-import type { AgentPersona } from '../../types';
-
 export type SharedChatMode = 'team' | 'private';
 
 export default function PublishedWorkspaceChatHeader({
@@ -27,11 +22,8 @@ export default function PublishedWorkspaceChatHeader({
   isAgentPaneVisible,
   isAgentPaneFullScreen,
   mode,
-  personas,
-  selectedPersona,
   onToggleVisibility,
   onModeChange,
-  onPersonaChange,
   onToggleHistory,
   onNewChat,
   onOpenCollaboration,
@@ -41,11 +33,8 @@ export default function PublishedWorkspaceChatHeader({
   isAgentPaneVisible: boolean;
   isAgentPaneFullScreen: boolean;
   mode: SharedChatMode;
-  personas: AgentPersona[];
-  selectedPersona: string;
   onToggleVisibility: () => void;
   onModeChange: (mode: SharedChatMode) => void;
-  onPersonaChange: (event: ChangeEvent<HTMLSelectElement>) => void;
   onToggleHistory: () => void;
   onNewChat: () => void;
   onOpenCollaboration: () => void;
@@ -135,36 +124,6 @@ export default function PublishedWorkspaceChatHeader({
           <span className="text-[11px] leading-snug">
             Visible to workspace members. Lumo reads the Shared Working version.
           </span>
-        </div>
-      ) : null}
-
-      {isAgentPaneVisible && mode === 'private' ? (
-        <div className={`mt-2 flex items-center justify-between gap-3 rounded-xl px-2.5 py-1.5 ${
-          isDarkMode ? 'bg-slate-900 text-slate-300' : 'bg-slate-50 text-slate-600'
-        }`}>
-          <div className="flex min-w-0 items-center gap-2">
-            <Lock size={13} className="shrink-0 text-violet-500" />
-            <span className="truncate text-[11px] leading-snug">
-              Visible only to you. Lumo edits My draft, not the Shared workspace.
-            </span>
-          </div>
-          <select
-            value={selectedPersona}
-            onChange={onPersonaChange}
-            className={`h-7 shrink-0 rounded-lg border px-2 text-[11px] font-semibold outline-none ${
-              isDarkMode
-                ? 'border-slate-700 bg-slate-950 text-slate-200'
-                : 'border-slate-200 bg-white text-slate-700'
-            }`}
-            aria-label="Select private Lumo mode"
-            disabled={!personas.length}
-          >
-            {personas.map((persona) => (
-              <option key={persona.name} value={persona.name}>
-                {persona.displayName || persona.name}
-              </option>
-            ))}
-          </select>
         </div>
       ) : null}
     </div>

--- a/tests/test_skill_sandbox.py
+++ b/tests/test_skill_sandbox.py
@@ -1353,8 +1353,15 @@ def test_inline_tool_rejects_both_and_neither_modes(
     both = tool_obj.func(script_name="run", inline_code="print('hi')\n")
     neither = tool_obj.func()
 
-    assert "SKILL_SANDBOX_REQUEST_INVALID" in both
-    assert "SKILL_SANDBOX_REQUEST_INVALID" in neither
+    from helpudoc_agent.api.routes.chat import _is_terminal_tool_failure
+
+    for response in (both, neither):
+        payload = json.loads(response)
+        assert payload["status"] == "error"
+        assert payload["errorCode"] == "SKILL_SANDBOX_REQUEST_INVALID"
+        assert payload["retryable"] is False
+        assert payload["suggestedNextCall"]
+        assert _is_terminal_tool_failure("run_skill_python_script", response) is True
 
 
 def test_tool_rejects_arguments_from_the_other_execution_mode(


### PR DESCRIPTION
## Summary
- return terminal structured errors from skill sandbox failures and stop repeated identical skill errors
- improve light-mode user message contrast and remove the redundant composer Working label
- simplify the published private chat header

## Verification
- Python skill/runtime tests: 57 passed
- backend tests: 239 passed, 15 skipped
- backend TypeScript check passed
- frontend tests: 64 passed
- frontend production build passed
- changed frontend files passed ESLint
- graphify graph updated