### PR TITLE
Fix for knowledge OKF large docs

### DIFF
--- a/agent/helpudoc_agent/api/routes/documents.py
+++ b/agent/helpudoc_agent/api/routes/documents.py
@@ -158,7 +158,7 @@ def register_document_routes(
             ]
             usage: list[dict[str, object]] = []
             reduced = await hierarchical_reduce_enrichments(
-                gemini_manager.get_ingestion_chat_model(),
+                gemini_manager.get_reduce_chat_model(),
                 results=results,
                 blocks=blocks,
                 fan_in=req.fanIn,

--- a/agent/helpudoc_agent/knowledge_ingestion/enrichment.py
+++ b/agent/helpudoc_agent/knowledge_ingestion/enrichment.py
@@ -378,6 +378,41 @@ async def reduce_enrichment_batch(
         if attempt < max_attempts:
             feedback = "\nValidation failed. Repair only these issues:\n- " + "\n- ".join(errors[:30])
             continue
+        # Final attempt failed. When the structured output never came back (parsed is None),
+        # the merged object most likely exceeded the model output budget and was truncated.
+        # Splitting the batch lets each reduce emit a smaller object; merging duplicates
+        # bottom-up shrinks the union so the parent call can fit within budget.
+        if parsed is None and len(children) > 2:
+            mid = len(children) // 2
+            left, right = await asyncio.gather(
+                reduce_enrichment_batch(
+                    model,
+                    children=children[:mid],
+                    blocks=blocks,
+                    level=level,
+                    batch_index=batch_index * 10 + 1,
+                    max_attempts=max_attempts,
+                    usage_records=usage_records,
+                ),
+                reduce_enrichment_batch(
+                    model,
+                    children=children[mid:],
+                    blocks=blocks,
+                    level=level,
+                    batch_index=batch_index * 10 + 2,
+                    max_attempts=max_attempts,
+                    usage_records=usage_records,
+                ),
+            )
+            return await reduce_enrichment_batch(
+                model,
+                children=[left, right],
+                blocks=blocks,
+                level=level,
+                batch_index=batch_index,
+                max_attempts=max_attempts,
+                usage_records=usage_records,
+            )
         raise ValueError("Invalid Knowledge reduction result: " + "; ".join(errors[:30]))
     raise RuntimeError("Knowledge reduction exhausted attempts")
 

--- a/agent/helpudoc_agent/tools/workspace/gemini_client.py
+++ b/agent/helpudoc_agent/tools/workspace/gemini_client.py
@@ -27,6 +27,7 @@ class GeminiClientManager:
         self._attachment_chat_model: ChatGoogleGenerativeAI | None = None
         self._lite_chat_model: ChatGoogleGenerativeAI | None = None
         self._ingestion_chat_model: ChatGoogleGenerativeAI | None = None
+        self._reduce_chat_model: ChatGoogleGenerativeAI | None = None
         self._api_key = (
             model_cfg.api_key
             or os.getenv("GOOGLE_CLOUD_API_KEY")
@@ -143,6 +144,30 @@ class GeminiClientManager:
                 timeout=float(DEFAULT_HTTP_TIMEOUT),
             )
         return self._ingestion_chat_model
+
+    def get_reduce_chat_model(self) -> ChatGoogleGenerativeAI:
+        """Model for hierarchical reduce merges, with a large structured-output budget.
+
+        Reduce merges many child graphs into one structured object, so its output can be
+        far larger than a single map window. Lite's ~8k output cap truncates the tool call
+        for large documents (yields no parseable result -> 422). Use the main model and a
+        high output cap so the deduplicated union fits in one response.
+        """
+        self._require_configured_client()
+        if self._reduce_chat_model is None:
+            from ...gemini_chat import create_chat_google_generative_ai
+
+            model_name = self._model_cfg.resolve_chat_model_name("pro")
+            configured = self._model_cfg.resolve_max_output_tokens("pro") or 32768
+            output_tokens = max(configured, int(os.environ.get("KNOWLEDGE_REDUCE_MAX_OUTPUT_TOKENS", "32768")))
+            self._reduce_chat_model = create_chat_google_generative_ai(
+                self._model_cfg,
+                model_name,
+                thinking_level=self._model_cfg.resolve_thinking_level(None),
+                max_output_tokens=output_tokens,
+                timeout=float(DEFAULT_HTTP_TIMEOUT),
+            )
+        return self._reduce_chat_model
 
     @property
     def lite_model_name(self) -> str:

--- a/backend/src/lib/jsonb.ts
+++ b/backend/src/lib/jsonb.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+/**
+ * Serialize a value for insertion into a Postgres `jsonb` column.
+ *
+ * The `pg` driver JSON-encodes plain objects automatically, but a raw JS
+ * **array** is coerced into a Postgres array literal (`{...}`) instead of JSON,
+ * which Postgres rejects with `invalid input syntax for type json`. Always route
+ * `jsonb` values through this helper (or `JSON.stringify` for a bare batchInsert
+ * value) so arrays are encoded correctly.
+ *
+ * Returns `null` for `null`/`undefined` so nullable `jsonb` columns stay null
+ * rather than becoming the JSON string "null".
+ */
+export const jsonbParam = (db: Knex, value: unknown): Knex.Raw | null => (
+  value === null || typeof value === 'undefined'
+    ? null
+    : db.raw('?::jsonb', [JSON.stringify(value)])
+);

--- a/backend/src/services/dailyReflectionService.ts
+++ b/backend/src/services/dailyReflectionService.ts
@@ -1,5 +1,6 @@
 import { Knex } from 'knex';
 import { DatabaseService } from './databaseService';
+import { jsonbParam } from '../lib/jsonb';
 import { runInternalAnalysis } from './agentService';
 import { signAgentContextToken } from './agentToken';
 import type {
@@ -49,8 +50,6 @@ const REFLECTION_ANALYSIS_SYSTEM_PROMPT = [
   'recommendations must be an array of up to 4 items with id, title, detail, priority.',
   'Focus on operational diagnosis and concrete improvement suggestions.',
 ].join('\n');
-
-const jsonbParam = (db: Knex, value: unknown) => db.raw('?::jsonb', [JSON.stringify(value)]);
 
 function resolveAnalyticsTimezone(): string {
   const timezone = String(process.env.ANALYTICS_TIMEZONE || 'UTC').trim();

--- a/backend/src/services/knowledgeIngestionService.ts
+++ b/backend/src/services/knowledgeIngestionService.ts
@@ -139,6 +139,9 @@ export class KnowledgeIngestionService {
   async transition(runId: string, patch: Record<string, unknown>): Promise<void> {
     const status = patch.status as KnowledgeJobStatus | undefined;
     const updates: Record<string, unknown> = { ...patch, updatedAt: this.db.fn.now() };
+    // `warnings` is the jsonb column on knowledge_ingestion_jobs; pg would coerce a
+    // raw JS array into a Postgres array literal (invalid json), so serialize it.
+    if (Array.isArray(updates.warnings)) updates.warnings = JSON.stringify(updates.warnings);
     if (status === 'extracting') updates.startedAt = this.db.fn.now();
     if (status && TERMINAL_STATUSES.has(status)) updates.finishedAt = this.db.fn.now();
     await this.db('knowledge_ingestion_jobs').where({ id: runId }).update(updates);

--- a/backend/src/services/knowledgeService.ts
+++ b/backend/src/services/knowledgeService.ts
@@ -1407,7 +1407,6 @@ export class KnowledgeService {
       uploadUrl: directUpload.uploadUrl,
       expiresAt: expiresAt.toISOString(),
       headers: {
-        'Content-Type': mimeType,
         ...directUpload.uploadHeaders,
       },
       fileName: directUpload.requestedFileName,
@@ -1737,7 +1736,7 @@ export class KnowledgeService {
         content: payload.content,
         fileId: payload.fileId ?? null,
         sourceUrl: payload.sourceUrl,
-        tags: payload.tags ?? null,
+        tags: payload.tags != null ? JSON.stringify(payload.tags) : null,
         metadata: initialMetadata,
         createdBy: userId,
         updatedBy: userId,
@@ -2703,7 +2702,13 @@ export class KnowledgeService {
         okfVersion: OKF_VERSION,
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      // Agent (FastAPI) failures surface as axios errors whose useful reason lives in
+      // response.data.detail; error.message alone is just "Request failed with status code NNN".
+      const baseMessage = error instanceof Error ? error.message : String(error);
+      const agentDetail = (error as any)?.response?.data?.detail;
+      const message = agentDetail
+        ? `${baseMessage}: ${typeof agentDetail === 'string' ? agentDetail : JSON.stringify(agentDetail)}`
+        : baseMessage;
       const failedSource = await this.db('knowledge_sources').select('metadata').where({ id, workspaceId }).first();
       const failedRunId = this.getIngestionMetadata(failedSource?.metadata)?.runId;
       if (failedRunId) {
@@ -3107,8 +3112,8 @@ export class KnowledgeService {
           externalId: String(node.id || `structure:${index}`),
           title: String(node.title || `Section ${index + 1}`),
           level: Number(node.level ?? 0),
-          blockIds: node.blockIds || [],
-          signals: node.signals || [],
+          blockIds: JSON.stringify(node.blockIds || []),
+          signals: JSON.stringify(node.signals || []),
           confidence: Number(node.confidence ?? 0),
           sourceRange: { start: node.sourceStart ?? null, end: node.sourceEnd ?? null },
         })), 250);
@@ -3120,9 +3125,9 @@ export class KnowledgeService {
           runId: input.runId,
           externalId: String(window.id || `window-${index + 1}`),
           structureNodeId: String(window.structureNodeId || 'structure:root'),
-          coreBlockIds: window.coreBlockIds || [],
-          contextBeforeBlockIds: window.contextBeforeBlockIds || [],
-          contextAfterBlockIds: window.contextAfterBlockIds || [],
+          coreBlockIds: JSON.stringify(window.coreBlockIds || []),
+          contextBeforeBlockIds: JSON.stringify(window.contextBeforeBlockIds || []),
+          contextAfterBlockIds: JSON.stringify(window.contextAfterBlockIds || []),
           tokenCount: Number(window.tokenCount ?? 0),
           contentHash: String(window.contentHash || ''),
           strategy: String(window.strategy || 'structural'),
@@ -3153,8 +3158,8 @@ export class KnowledgeService {
               kind: concept.kind,
               name: concept.name,
               description: concept.description,
-              aliases: concept.aliases,
-              tags: concept.tags,
+              aliases: JSON.stringify(concept.aliases),
+              tags: JSON.stringify(concept.tags),
               path: concept.path,
               confidence: concept.assertions.length
                 ? Math.min(...concept.assertions.map((assertion) => assertion.confidence))
@@ -3166,8 +3171,8 @@ export class KnowledgeService {
               kind: 'Knowledge Section',
               name: concept.title,
               description: concept.description,
-              aliases: [],
-              tags: [],
+              aliases: JSON.stringify([]),
+              tags: JSON.stringify([]),
               path: concept.path,
               confidence: 1,
             }));
@@ -3188,7 +3193,7 @@ export class KnowledgeService {
               id: evidenceId,
               snapshotId,
               sourceFileId: job.sourceFileId || null,
-              blockIds: normalized,
+              blockIds: JSON.stringify(normalized),
               locator: { kind: 'source_blocks', blockIds: normalized },
               contentHash: `sha256:${sha256(key)}`,
             });
@@ -3201,7 +3206,7 @@ export class KnowledgeService {
               conceptId: concept.id,
               text: assertion.text,
               confidence: assertion.confidence,
-              evidenceSpanIds: evidenceIds.get(key) ? [evidenceIds.get(key)] : [],
+              evidenceSpanIds: JSON.stringify(evidenceIds.get(key) ? [evidenceIds.get(key)] : []),
               contentHash: `sha256:${sha256(`${concept.id}\n${assertion.text}`)}`,
             };
           }));
@@ -3216,7 +3221,7 @@ export class KnowledgeService {
               type: relationship.type,
               confidenceClass: relationship.confidenceClass,
               confidence: relationship.confidence,
-              evidenceSpanIds: evidenceIds.get(key) ? [evidenceIds.get(key)] : [],
+              evidenceSpanIds: JSON.stringify(evidenceIds.get(key) ? [evidenceIds.get(key)] : []),
             };
           }));
           if (relationships.length) await trx.batchInsert('knowledge_relationships', relationships, 250);
@@ -3256,7 +3261,7 @@ export class KnowledgeService {
                   algorithm: String(input.graphAnalysis?.algorithm || 'networkx-louvain'),
                   algorithmVersion: String(input.graphAnalysis?.algorithmVersion || 'networkx/unknown'),
                   label: String(community.label || `Community ${index + 1}`),
-                  conceptIds: community.conceptIds || [],
+                  conceptIds: JSON.stringify(community.conceptIds || []),
                   metadata: { size: Number(community.size || community.conceptIds?.length || 0) },
                 }))
               : communities.map((conceptIds, index) => ({
@@ -3265,7 +3270,7 @@ export class KnowledgeService {
               algorithm: 'weakly_connected_components',
               algorithmVersion: 'helpudoc-graph/1',
               label: `Community ${index + 1}`,
-              conceptIds,
+              conceptIds: JSON.stringify(conceptIds),
               metadata: { size: conceptIds.length },
               }));
             await trx.batchInsert('knowledge_communities', rows, 250);
@@ -3323,7 +3328,7 @@ export class KnowledgeService {
           modality: 'text',
           indexVersion: 'knowledge-vector/1',
           contentHash: `sha256:${sha256(stableJson(embedding.values))}`,
-          embedding: usesPgvector ? trx.raw('?::vector', [vectorValue]) : embedding.values,
+          embedding: usesPgvector ? trx.raw('?::vector', [vectorValue]) : JSON.stringify(embedding.values),
         });
       }
       const totalTokens = response.embeddings.reduce((sum, embedding) => sum + Number(embedding.tokenCount || 0), 0);
@@ -3378,7 +3383,7 @@ export class KnowledgeService {
             contentHash: embedding.contentHash || `sha256:${sha256(stableJson(embedding.values))}`,
             embedding: usesPgvector
               ? trx.raw('?::vector', [`[${embedding.values.join(',')}]`])
-              : embedding.values,
+              : JSON.stringify(embedding.values),
           });
         }
         const totalTokens = mediaResponse.embeddings.reduce((sum, embedding) => sum + Number(embedding.tokenCount || 0), 0);

--- a/backend/src/services/knowledgeService.ts
+++ b/backend/src/services/knowledgeService.ts
@@ -1401,14 +1401,20 @@ export class KnowledgeService {
     void this.cleanupExpiredUploadSessions().catch((error) => {
       console.error('Failed to clean up expired knowledge uploads', error);
     });
+    // The object store's signed upload already carries a lowercase `content-type`
+    // header. Guarantee exactly one, in the canonical lowercase form, so the session
+    // is self-sufficient even if a store omits it — without reintroducing the
+    // duplicate-casing header that broke finalize.
+    const uploadHeaders: Record<string, string> = { ...directUpload.uploadHeaders };
+    if (!Object.keys(uploadHeaders).some((key) => key.toLowerCase() === 'content-type')) {
+      uploadHeaders['content-type'] = mimeType;
+    }
     return {
       id,
       status: 'pending',
       uploadUrl: directUpload.uploadUrl,
       expiresAt: expiresAt.toISOString(),
-      headers: {
-        ...directUpload.uploadHeaders,
-      },
+      headers: uploadHeaders,
       fileName: directUpload.requestedFileName,
       sizeBytes: input.sizeBytes,
     };

--- a/backend/src/services/runTelemetryService.ts
+++ b/backend/src/services/runTelemetryService.ts
@@ -1,5 +1,6 @@
 import { Knex } from 'knex';
 import { DatabaseService } from './databaseService';
+import { jsonbParam } from '../lib/jsonb';
 
 export type AgentRunTelemetryStatus =
   | 'queued'
@@ -113,11 +114,6 @@ const normalizeOutputFiles = (value: unknown): Array<Record<string, unknown>> | 
   return files.length ? files : null;
 };
 
-const jsonbParam = (db: Knex, value: unknown) => (
-  value === null || typeof value === 'undefined'
-    ? null
-    : db.raw('?::jsonb', [JSON.stringify(value)])
-);
 
 export const normalizeToolEventJson = (input: Pick<AgentRunToolEventInput, 'outputFiles' | 'payload'>) => ({
   outputFiles: normalizeOutputFiles(input.outputFiles),

--- a/backend/tests/knowledgeService.test.ts
+++ b/backend/tests/knowledgeService.test.ts
@@ -130,7 +130,7 @@ test('direct knowledge uploads reserve object storage without buffering file byt
 
   assert.equal(session.status, 'pending');
   assert.equal(session.sizeBytes, 135_098_025);
-  assert.equal(session.headers['Content-Type'], 'application/pdf');
+  assert.equal(session.headers['content-type'], 'application/pdf');
   assert.match(session.uploadUrl, /^https:\/\/uploads\.example\.test\//);
   assert.equal(inserted.length, 1);
   assert.equal(inserted[0].sizeBytes, 135_098_025);


### PR DESCRIPTION
- Fix JSONB errors when encoding results back into Postgres.
- Fix model output token limit (default lite model) when extracting knowledge from large documents (>80 pages).